### PR TITLE
fix: fetch VAPID private key from SSM at runtime (keep as SecureString)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -175,7 +175,6 @@ jobs:
             "OrdersWebhookAllowedOrgId=$ORDERS_WEBHOOK_ALLOWED_ORG_ID"
             "DevAuthSecret=/discra/dev-auth-secret"
             "VapidPublicKey=/discra/vapid-public-key"
-            "VapidPrivateKey=/discra/vapid-private-key"
             "VapidClaimEmail=/discra/vapid-claim-email"
           )
 

--- a/backend/push_service.py
+++ b/backend/push_service.py
@@ -15,6 +15,40 @@ except ModuleNotFoundError:  # local run from backend/ directory
 
 logger = logging.getLogger(__name__)
 
+_vapid_private_key_cache: str = ""
+
+
+def _get_vapid_private_key() -> str:
+    """Fetch the VAPID private key from SSM SecureString at runtime.
+
+    The env var VAPID_PRIVATE_KEY_PARAM holds the SSM parameter path.
+    Falls back to VAPID_PRIVATE_KEY env var for local development.
+    Result is cached for the lifetime of the Lambda container.
+    """
+    global _vapid_private_key_cache
+    if _vapid_private_key_cache:
+        return _vapid_private_key_cache
+
+    # Local dev fallback
+    direct = os.environ.get("VAPID_PRIVATE_KEY", "")
+    if direct:
+        _vapid_private_key_cache = direct
+        return _vapid_private_key_cache
+
+    param_path = os.environ.get("VAPID_PRIVATE_KEY_PARAM", "")
+    if not param_path:
+        return ""
+
+    try:
+        import boto3
+        ssm = boto3.client("ssm")
+        resp = ssm.get_parameter(Name=param_path, WithDecryption=True)
+        _vapid_private_key_cache = resp["Parameter"]["Value"]
+    except Exception as e:
+        logger.error("Failed to fetch VAPID private key from SSM: %s", e)
+
+    return _vapid_private_key_cache
+
 
 def send_push_notification(org_id: str, driver_id: str, payload: dict) -> bool:
     """Send a Web Push notification to a driver. Returns True if sent successfully.
@@ -26,7 +60,7 @@ def send_push_notification(org_id: str, driver_id: str, payload: dict) -> bool:
         logger.debug("pywebpush not installed, skipping push notification")
         return False
 
-    vapid_private_key = os.environ.get("VAPID_PRIVATE_KEY", "")
+    vapid_private_key = _get_vapid_private_key()
     vapid_claim_email = os.environ.get("VAPID_CLAIM_EMAIL", "")
     if not vapid_private_key or not vapid_claim_email:
         logger.debug("VAPID keys not configured, skipping push notification")

--- a/template.yaml
+++ b/template.yaml
@@ -153,10 +153,7 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /discra/vapid-public-key
     Description: VAPID public key (URL-safe base64) for Web Push notifications
-  VapidPrivateKey:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /discra/vapid-private-key
-    Description: VAPID private key for signing Web Push messages (SSM parameter must be String type, not SecureString)
+  # VapidPrivateKey is a SecureString in SSM — fetched at runtime by push_service.py via boto3, not injected as env var
   AnthropicApiKey:
     Type: String
     Default: ""
@@ -631,7 +628,7 @@ Resources:
           AUDIT_LOGS_TABLE: !Ref AuditLogsTable
           PUSH_SUBSCRIPTIONS_TABLE: !Ref PushSubscriptionsTable
           VAPID_PUBLIC_KEY: !Ref VapidPublicKey
-          VAPID_PRIVATE_KEY: !Ref VapidPrivateKey
+          VAPID_PRIVATE_KEY_PARAM: /discra/vapid-private-key
           ANTHROPIC_API_KEY: !Ref AnthropicApiKey
           VAPID_CLAIM_EMAIL: !Ref VapidClaimEmail
           COGNITO_HOSTED_UI_DOMAIN: !Ref CognitoHostedUiDomain
@@ -720,6 +717,16 @@ Resources:
             Action:
               - execute-api:ManageConnections
             Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DiscraWebSocketApi}/*"
+        - Statement:
+            Effect: Allow
+            Action:
+              - ssm:GetParameter
+            Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/discra/vapid-private-key"
+        - Statement:
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/ssm"
       Events:
         BackendHealthGet:
           Type: HttpApi


### PR DESCRIPTION
## Summary

Fixes the deploy failure caused by CloudFormation's inability to resolve a SecureString SSM parameter via `AWS::SSM::Parameter::Value<String>`.

Instead of injecting the key through CloudFormation, `push_service.py` now fetches it directly from SSM at Lambda cold start using `boto3` with `WithDecryption=True`. The value is cached for the container lifetime so subsequent calls are free.

- `VAPID_PRIVATE_KEY_PARAM=/discra/vapid-private-key` is set as a plain env var (just the path, not the secret)
- `BackendApiFunction` role gets `ssm:GetParameter` on the specific parameter ARN + `kms:Decrypt` on `alias/aws/ssm`
- `VapidPrivateKey` removed from CloudFormation Parameters and deploy workflow overrides
- Local dev fallback: `VAPID_PRIVATE_KEY` env var still works if set directly

## Test plan

- [ ] Deploy succeeds (SAM validate passes, no SSM type errors)
- [ ] Push notifications still delivered to drivers after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)