### PR TITLE
feat: auto-load email data on page load + 60s background polling + 24hr skipped TTL

### DIFF
--- a/backend/email_store.py
+++ b/backend/email_store.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:  # local run from backend/ directory
 
 logger = logging.getLogger(__name__)
 
-SKIPPED_EMAIL_TTL_DAYS = 30
+SKIPPED_EMAIL_TTL_DAYS = 1
 
 
 def utc_now() -> datetime:

--- a/backend/frontend/admin.html
+++ b/backend/frontend/admin.html
@@ -572,7 +572,7 @@
           <input type="hidden" id="email-rule-id" value="">
           <label class="field field-span-2">
             <span>Rule name</span>
-            <input id="email-rule-name" type="text" maxlength="120" placeholder="e.g. Vel Logistix, Marken Chicago" required>
+            <input id="email-rule-name" type="text" maxlength="120" placeholder="e.g. Acme Logistics, Chicago Pickup" required>
           </label>
           <label class="field field-span-2">
             <span>Emails from…</span>
@@ -645,6 +645,6 @@
 
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
   <script src="assets/common.js?v=20260326b"></script>
-  <script src="assets/admin.js?v=20260408b"></script>
+  <script src="assets/admin.js?v=20260409a"></script>
 </body>
 </html>

--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -158,6 +158,7 @@
   let activeRouteLayerId = "route-line-layer";
   let driverRefreshTimer = null;
   let orderRefreshTimer = null;
+  let emailAutoRefreshTimer = null;
   let allOrders = [];
   let lastOrders = [];
   let lastDriverLocations = [];
@@ -1122,6 +1123,24 @@
     orderRefreshTimer = null;
   }
 
+  function startEmailAutoRefresh() {
+    if (emailAutoRefreshTimer || !isAuthorizedRole) {
+      return;
+    }
+    emailAutoRefreshTimer = window.setInterval(function () {
+      refreshEmailStatus().catch(function () {});
+      refreshSkippedEmails().catch(function () {});
+    }, 60000);
+  }
+
+  function stopEmailAutoRefresh() {
+    if (!emailAutoRefreshTimer) {
+      return;
+    }
+    window.clearInterval(emailAutoRefreshTimer);
+    emailAutoRefreshTimer = null;
+  }
+
   function showLoginScreen(show) {
     if (el.loginScreen) {
       el.loginScreen.classList.toggle("hidden", !show);
@@ -1185,6 +1204,7 @@
     }
     startDriverAutoRefresh();
     startOrderAutoRefresh();
+    startEmailAutoRefresh();
     if (!isAdminRole) {
       C.showMessage(el.billingMessage, "Billing controls require Admin role.", "error");
     }
@@ -3244,6 +3264,8 @@
     initAudioAlerts();
     if (isAuthorizedRole) {
       refreshEmailStatus().catch(function () {});
+      refreshSkippedEmails().catch(function () {});
+      refreshEmailRules().catch(function () {});
       if (wsEndpoint) connectWebSocket();
     }
   }

--- a/email_poller_fn/email_store.py
+++ b/email_poller_fn/email_store.py
@@ -17,7 +17,7 @@ from schemas import EmailConfig, SkippedEmail
 
 logger = logging.getLogger(__name__)
 
-SKIPPED_EMAIL_TTL_DAYS = 30
+SKIPPED_EMAIL_TTL_DAYS = 1
 
 
 def utc_now() -> datetime:


### PR DESCRIPTION
## Summary

- **Auto-load on page load**: Skipped emails and classification rules now load automatically — no manual Refresh click needed
- **Background polling**: Email status and skipped emails refresh every 60 seconds automatically (aligns with the 1-minute poller cadence)
- **24hr skipped email TTL**: Reduced from 30 days to 1 day in both Lambda and backend store — cuts DynamoDB storage cost for ephemeral skip records
- **Placeholder fix**: Removed real company name from rule name input placeholder

## Test plan

- [ ] Page load → skipped emails and rules appear without clicking Refresh
- [ ] Wait 60s → email status "Last Poll" time updates automatically
- [ ] New skipped emails appear in the panel within ~60s of the poller running

🤖 Generated with [Claude Code](https://claude.com/claude-code)