### PR TITLE
feat: self-healing Gmail OAuth — detect invalid_grant + one-click reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,36 @@ Hosted UI setup notes:
   - invitation creation/activation
   - Stripe subscription webhook seat sync
 
+## Gmail OAuth: avoid the 7-day refresh-token expiry
+
+Discra uses the Gmail `gmail.modify` scope, which Google classifies as a
+**sensitive scope**. Refresh tokens issued for sensitive scopes expire after
+**7 days** while the OAuth app is in **Testing** status in Google Cloud
+Console. The visible symptom is exactly what you'd expect: the integration
+works perfectly for ~7 days, then dies with `invalid_grant: Token has been
+expired or revoked.` and stops processing email until the user reconnects.
+
+**Fix (one-time, no code change required):**
+
+1. Open Google Cloud Console → APIs & Services → OAuth consent screen.
+2. Click **PUBLISH APP** to move the app from *Testing* to *In production*.
+3. You can publish without going through full Google verification — refresh
+   tokens issued after publishing will then last until the user (or Google)
+   explicitly revokes them.
+
+Full verification (a multi-week external Google review) is required only to
+remove the unverified-app warning shown to users during OAuth consent. It is
+**not** required to fix the 7-day token expiry.
+
+Reference: <https://developers.google.com/identity/protocols/oauth2#expiration>
+
+If a refresh token *does* expire (or the user revokes access from their
+Google account), the app self-heals: the poller detects `invalid_grant`,
+stops hammering Gmail with the dead token, broadcasts a WebSocket event so
+any connected admin sees a red banner, and one click on **Reconnect Gmail**
+runs the OAuth flow again. The reconnect preserves all `email_rules` and
+other org-level config.
+
 ## Migration roadmap (incremental PRs)
 1. Python backend skeleton + SAM wiring + health/version parity
 2. Cognito JWT auth + RBAC + Users/Organizations model

--- a/backend/email_poller.py
+++ b/backend/email_poller.py
@@ -15,7 +15,7 @@ try:
     from backend.email_classifier import classify_email, SkipReason
     from backend.email_parser import get_parser
     from backend.email_store import get_email_config_store, get_skipped_email_store
-    from backend.gmail_client import GmailClient
+    from backend.gmail_client import GmailClient, GmailAuthError
     from backend.order_store import get_order_store
     from backend.schemas import Order, OrderStatus, SkippedEmail
     from backend.ws_notifier import broadcast as ws_broadcast
@@ -23,7 +23,7 @@ except ModuleNotFoundError:  # local run from backend/ directory
     from email_classifier import classify_email, SkipReason
     from email_parser import get_parser
     from email_store import get_email_config_store, get_skipped_email_store
-    from gmail_client import GmailClient
+    from gmail_client import GmailClient, GmailAuthError
     from order_store import get_order_store
     from schemas import Order, OrderStatus, SkippedEmail
     from ws_notifier import broadcast as ws_broadcast
@@ -36,6 +36,18 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _notify_reauth_required(org_id: str, code: str):
+    """Best-effort live notification that a Gmail reconnect is required."""
+    try:
+        ws_broadcast(org_id, {
+            "type": "gmail_auth_required",
+            "code": code,
+            "message": "Gmail authorization expired. Please reconnect to resume order processing.",
+        })
+    except Exception as ws_err:
+        logger.warning("Org %s: ws broadcast for gmail_auth_required failed: %s", org_id, ws_err)
+
+
 def _process_org(org_config):
     """Process a single org's email inbox. Returns (orders_created, errors)."""
     org_id = org_config.org_id
@@ -45,6 +57,11 @@ def _process_org(org_config):
     config_store = get_email_config_store()
     skipped_store = get_skipped_email_store()
     order_store = get_order_store()
+
+    # Short-circuit if the connection is already known to need reauth.
+    if getattr(org_config, "needs_reauth", False):
+        logger.info("Org %s: skipping poll — Gmail needs reauth", org_id)
+        return 0, []
 
     client_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "")
     client_secret = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET", "")
@@ -202,6 +219,20 @@ def _process_org(org_config):
         error_summary = "; ".join(errors) if errors else None
         config_store.update_poll_status(org_id, new_history_id, error=error_summary)
 
+    except GmailAuthError as e:
+        logger.warning("Org %s: Gmail auth failed (%s) — marking needs_reauth", org_id, e.code)
+        try:
+            config_store.update_poll_status(
+                org_id,
+                org_config.gmail_history_id or "",
+                error=f"Gmail authorization expired ({e.code}). Please reconnect.",
+                error_code=e.code,
+                needs_reauth=True,
+            )
+        except Exception:
+            pass
+        _notify_reauth_required(org_id, e.code)
+        errors.append(f"auth:{e.code}")
     except Exception as e:
         logger.exception("Org %s: poll failed: %s", org_id, e)
         try:

--- a/backend/email_store.py
+++ b/backend/email_store.py
@@ -49,7 +49,14 @@ class EmailConfigStore(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def update_poll_status(self, org_id: str, history_id: str, error: Optional[str] = None) -> None:
+    def update_poll_status(
+        self,
+        org_id: str,
+        history_id: str,
+        error: Optional[str] = None,
+        error_code: Optional[str] = None,
+        needs_reauth: bool = False,
+    ) -> None:
         raise NotImplementedError
 
 
@@ -70,12 +77,27 @@ class InMemoryEmailConfigStore(EmailConfigStore):
     def list_connected_orgs(self) -> List[EmailConfig]:
         return [c for c in self.items.values() if c.email_connected]
 
-    def update_poll_status(self, org_id: str, history_id: str, error: Optional[str] = None) -> None:
+    def update_poll_status(
+        self,
+        org_id: str,
+        history_id: str,
+        error: Optional[str] = None,
+        error_code: Optional[str] = None,
+        needs_reauth: bool = False,
+    ) -> None:
         config = self.items.get(org_id)
         if config:
             config.gmail_history_id = history_id
             config.last_poll_at = utc_now()
             config.last_error = error
+            if needs_reauth:
+                config.needs_reauth = True
+                config.last_error_code = error_code
+                config.last_error_at = utc_now()
+            elif error is None:
+                config.needs_reauth = False
+                config.last_error_code = None
+                config.last_error_at = None
 
 
 class DynamoEmailConfigStore(EmailConfigStore):
@@ -113,17 +135,42 @@ class DynamoEmailConfigStore(EmailConfigStore):
             items.extend(resp.get("Items", []))
         return [EmailConfig.model_validate(item) for item in items]
 
-    def update_poll_status(self, org_id: str, history_id: str, error: Optional[str] = None) -> None:
-        update_expr = "SET gmail_history_id = :hid, last_poll_at = :now"
+    def update_poll_status(
+        self,
+        org_id: str,
+        history_id: str,
+        error: Optional[str] = None,
+        error_code: Optional[str] = None,
+        needs_reauth: bool = False,
+    ) -> None:
+        set_parts = ["gmail_history_id = :hid", "last_poll_at = :now"]
+        remove_parts: list = []
         expr_values: dict = {
             ":hid": history_id,
             ":now": utc_now().isoformat(),
         }
         if error:
-            update_expr += ", last_error = :err"
+            set_parts.append("last_error = :err")
             expr_values[":err"] = error
         else:
-            update_expr += " REMOVE last_error"
+            remove_parts.append("last_error")
+
+        if needs_reauth:
+            set_parts.append("needs_reauth = :nr")
+            set_parts.append("last_error_code = :ec")
+            set_parts.append("last_error_at = :now")
+            expr_values[":nr"] = True
+            expr_values[":ec"] = error_code or "refresh_failed"
+        elif error is None:
+            # Clean recovery — clear all reauth state.
+            set_parts.append("needs_reauth = :nr")
+            expr_values[":nr"] = False
+            remove_parts.append("last_error_code")
+            remove_parts.append("last_error_at")
+
+        update_expr = "SET " + ", ".join(set_parts)
+        if remove_parts:
+            update_expr += " REMOVE " + ", ".join(remove_parts)
 
         self._table.update_item(
             Key={"org_id": org_id},

--- a/backend/frontend/admin.html
+++ b/backend/frontend/admin.html
@@ -26,6 +26,12 @@
     </div>
   </div>
 
+  <!-- ========== GMAIL REAUTH BANNER ========== -->
+  <div id="gmail-reauth-banner" class="reauth-banner" hidden>
+    <span class="reauth-banner-text">Gmail connection expired — order processing is paused until you reconnect.</span>
+    <button id="gmail-reauth-reconnect" type="button" class="btn btn-primary reauth-banner-btn">Reconnect Gmail</button>
+  </div>
+
   <!-- ========== SLIM TOPBAR ========== -->
   <header class="topbar-slim">
     <div class="topbar-slim-left">

--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -105,6 +105,8 @@
     emailLastPoll: document.getElementById("email-last-poll"),
     emailPollStatus: document.getElementById("email-poll-status"),
     connectGmailBtn: document.getElementById("connect-gmail-btn"),
+    gmailReauthBanner: document.getElementById("gmail-reauth-banner"),
+    gmailReauthReconnect: document.getElementById("gmail-reauth-reconnect"),
     disconnectEmailBtn: document.getElementById("disconnect-email-btn"),
     refreshEmailStatus: document.getElementById("refresh-email-status"),
     refreshSkippedEmails: document.getElementById("refresh-skipped-emails"),
@@ -3554,6 +3556,9 @@
   async function refreshEmailStatus() {
     try {
       var status = await C.requestJson(apiBase, "/email/status", { token: token });
+      var needsReauth = !!(status && status.needs_reauth);
+      if (el.gmailReauthBanner) el.gmailReauthBanner.hidden = !needsReauth;
+
       if (status && status.connected) {
         if (el.emailNotConnected) el.emailNotConnected.hidden = true;
         if (el.emailConnected) el.emailConnected.hidden = false;
@@ -3565,7 +3570,7 @@
         }
         if (el.emailPollStatus) {
           el.emailPollStatus.textContent = status.last_error || "OK";
-          el.emailPollStatus.style.color = status.last_error ? "#ef4444" : "#22c55e";
+          el.emailPollStatus.style.color = (status.last_error || needsReauth) ? "#ef4444" : "#22c55e";
         }
       } else {
         if (el.emailNotConnected) el.emailNotConnected.hidden = false;
@@ -3785,37 +3790,42 @@
     }
   }
 
+  function startGmailOAuth() {
+    if (!googleOAuthClientId) return;
+    var redirectUri = window.location.origin + window.location.pathname;
+    var scope = "https://www.googleapis.com/auth/gmail.modify";
+    var authUrl = "https://accounts.google.com/o/oauth2/v2/auth" +
+      "?client_id=" + encodeURIComponent(googleOAuthClientId) +
+      "&redirect_uri=" + encodeURIComponent(redirectUri) +
+      "&response_type=code" +
+      "&scope=" + encodeURIComponent(scope) +
+      "&access_type=offline" +
+      "&prompt=consent" +
+      "&state=gmail_connect";
+    var popup = window.open(authUrl, "gmail_connect", "width=500,height=600");
+    function onGmailMessage(event) {
+      if (event.origin !== window.location.origin) return;
+      if (!event.data || event.data.type !== "gmail_oauth_callback") return;
+      window.removeEventListener("message", onGmailMessage);
+      if (popup && !popup.closed) popup.close();
+      if (event.data.code) {
+        connectGmailWithCode(event.data.code, redirectUri);
+      }
+    }
+    window.addEventListener("message", onGmailMessage);
+  }
+
   function initConnectGmail() {
     if (!googleOAuthClientId) {
       if (el.connectGmailBtn) el.connectGmailBtn.disabled = true;
+      if (el.gmailReauthReconnect) el.gmailReauthReconnect.disabled = true;
       return;
     }
     if (el.connectGmailBtn) {
-      el.connectGmailBtn.addEventListener("click", function () {
-        // Open Google OAuth consent in a popup
-        var redirectUri = window.location.origin + window.location.pathname;
-        var scope = "https://www.googleapis.com/auth/gmail.modify";
-        var authUrl = "https://accounts.google.com/o/oauth2/v2/auth" +
-          "?client_id=" + encodeURIComponent(googleOAuthClientId) +
-          "&redirect_uri=" + encodeURIComponent(redirectUri) +
-          "&response_type=code" +
-          "&scope=" + encodeURIComponent(scope) +
-          "&access_type=offline" +
-          "&prompt=consent" +
-          "&state=gmail_connect";
-        var popup = window.open(authUrl, "gmail_connect", "width=500,height=600");
-        // Listen for the OAuth code posted back by the popup callback
-        function onGmailMessage(event) {
-          if (event.origin !== window.location.origin) return;
-          if (!event.data || event.data.type !== "gmail_oauth_callback") return;
-          window.removeEventListener("message", onGmailMessage);
-          if (popup && !popup.closed) popup.close();
-          if (event.data.code) {
-            connectGmailWithCode(event.data.code, redirectUri);
-          }
-        }
-        window.addEventListener("message", onGmailMessage);
-      });
+      el.connectGmailBtn.addEventListener("click", startGmailOAuth);
+    }
+    if (el.gmailReauthReconnect) {
+      el.gmailReauthReconnect.addEventListener("click", startGmailOAuth);
     }
   }
 
@@ -4027,6 +4037,13 @@
         var msg = JSON.parse(event.data);
         if (msg.type === "new_order") {
           handleNewOrderNotification(msg.order || {});
+        } else if (msg.type === "gmail_auth_required") {
+          // Show the banner immediately, then refresh the status card.
+          if (el.gmailReauthBanner) el.gmailReauthBanner.hidden = false;
+          refreshEmailStatus().catch(function () {});
+        } else if (msg.type === "gmail_auth_restored") {
+          if (el.gmailReauthBanner) el.gmailReauthBanner.hidden = true;
+          refreshEmailStatus().catch(function () {});
         }
       } catch (e) { /* ignore malformed messages */ }
     };

--- a/backend/frontend/assets/styles.css
+++ b/backend/frontend/assets/styles.css
@@ -3273,6 +3273,24 @@ body.theme-admin .billing-seat-cards .stat-card small {
   font-size: 0.72rem;
 }
 
+/* ── Gmail reauth banner ── */
+.reauth-banner {
+  position: sticky;
+  top: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 10px 16px;
+  background: #b91c1c;
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+.reauth-banner-text { flex: 0 1 auto; }
+.reauth-banner-btn { flex: 0 0 auto; }
+
 /* ── Toast notifications ── */
 .toast-container {
   position: fixed;

--- a/backend/gmail_client.py
+++ b/backend/gmail_client.py
@@ -14,15 +14,49 @@ logger = logging.getLogger(__name__)
 
 try:
     from google.auth.transport.requests import Request as GoogleAuthRequest
+    from google.auth.exceptions import RefreshError as _GoogleRefreshError
     from google.oauth2.credentials import Credentials
     from googleapiclient.discovery import build
 except ImportError:  # pragma: no cover
     GoogleAuthRequest = None
+    _GoogleRefreshError = Exception
     Credentials = None
     build = None
 
 GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
 TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+# Substrings Google returns inside RefreshError messages for hard auth failures
+# that mean "the refresh token is no longer usable". We translate any of these
+# into a structured GmailAuthError so callers can surface a friendly reauth
+# prompt instead of treating it as a transient error.
+_HARD_AUTH_ERROR_CODES = (
+    "invalid_grant",
+    "invalid_client",
+    "unauthorized_client",
+    "invalid_token",
+)
+
+
+class GmailAuthError(Exception):
+    """The user's Gmail OAuth credentials can no longer be refreshed.
+
+    Caller should mark the connection as needing reauth and stop polling
+    until the user re-consents via the OAuth flow.
+    """
+
+    def __init__(self, code: str, message: str = ""):
+        super().__init__(message or code)
+        self.code = code
+
+
+def _classify_refresh_error(err: Exception) -> Optional[str]:
+    """Return the matched hard-auth code if `err` is a hard refresh failure, else None."""
+    text = str(err).lower()
+    for code in _HARD_AUTH_ERROR_CODES:
+        if code in text:
+            return code
+    return None
 
 
 @dataclass
@@ -68,7 +102,11 @@ class GmailClient:
             client_secret=self._client_secret,
             scopes=GMAIL_SCOPES,
         )
-        creds.refresh(GoogleAuthRequest())
+        try:
+            creds.refresh(GoogleAuthRequest())
+        except _GoogleRefreshError as e:
+            code = _classify_refresh_error(e) or "refresh_failed"
+            raise GmailAuthError(code=code, message=str(e)) from e
         self._service = build("gmail", "v1", credentials=creds, cache_discovery=False)
         return self._service
 
@@ -272,7 +310,16 @@ def exchange_auth_code(code: str, redirect_uri: str, client_id: str = "", client
         scopes=GMAIL_SCOPES,
         redirect_uri=redirect_uri,
     )
-    flow.fetch_token(code=code)
+    try:
+        flow.fetch_token(code=code)
+    except Exception as e:
+        # Stale/already-used auth codes and revoked clients all surface as
+        # OAuth errors here. Translate hard-auth failures so callers can
+        # render a clear "please re-authorize" message.
+        hard_code = _classify_refresh_error(e)
+        if hard_code:
+            raise GmailAuthError(code=hard_code, message=str(e)) from e
+        raise
     creds = flow.credentials
 
     service = build("gmail", "v1", credentials=creds, cache_discovery=False)

--- a/backend/routers/email.py
+++ b/backend/routers/email.py
@@ -14,14 +14,16 @@ try:
     from backend.auth import ROLE_ADMIN, ROLE_DISPATCHER, get_current_user, require_roles
     from backend.email_store import get_email_config_store, get_skipped_email_store
     from backend.email_parser import PARSERS
-    from backend.gmail_client import exchange_auth_code
+    from backend.gmail_client import GmailAuthError, exchange_auth_code
     from backend.schemas import EmailConfig, EmailRule
+    from backend.ws_notifier import broadcast as ws_broadcast
 except ModuleNotFoundError:  # local run from backend/ directory
     from auth import ROLE_ADMIN, ROLE_DISPATCHER, get_current_user, require_roles
     from email_store import get_email_config_store, get_skipped_email_store
     from email_parser import PARSERS
-    from gmail_client import exchange_auth_code
+    from gmail_client import GmailAuthError, exchange_auth_code
     from schemas import EmailConfig, EmailRule
+    from ws_notifier import broadcast as ws_broadcast
 
 router = APIRouter(prefix="/email", tags=["email"])
 
@@ -41,6 +43,8 @@ class EmailStatusResponse(BaseModel):
     email: str = ""
     last_poll_at: str = ""
     last_error: str = ""
+    last_error_code: str = ""
+    needs_reauth: bool = False
 
 
 class SkippedEmailItem(BaseModel):
@@ -74,6 +78,13 @@ async def connect_email(
             client_id=client_id,
             client_secret=client_secret,
         )
+    except GmailAuthError as e:
+        # Stale auth code or revoked client — surface as a friendly 400 so
+        # the UI can prompt the user to start the OAuth flow again.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Gmail authorization failed ({e.code}). Please try connecting again.",
+        )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -88,15 +99,43 @@ async def connect_email(
         )
 
     email_address = tokens.get("email", "")
+    now = datetime.now(timezone.utc)
 
-    config = EmailConfig(
-        org_id=org_id,
-        gmail_email=email_address,
-        gmail_refresh_token=refresh_token,
-        email_connected=True,
-        connected_at=datetime.now(timezone.utc),
-    )
-    config_store.put_config(config)
+    # Reconnect path: merge tokens into the existing config so we don't
+    # destroy email_rules or other org-level settings. After reauth we
+    # also reset gmail_history_id so the next poll re-initializes to
+    # "now" rather than trying to replay a possibly-expired history.
+    existing = config_store.get_config(org_id)
+    if existing:
+        existing.gmail_email = email_address
+        existing.gmail_refresh_token = refresh_token
+        existing.email_connected = True
+        existing.connected_at = now
+        existing.gmail_history_id = None
+        existing.last_error = None
+        existing.last_error_code = None
+        existing.last_error_at = None
+        existing.needs_reauth = False
+        config_store.put_config(existing)
+    else:
+        config = EmailConfig(
+            org_id=org_id,
+            gmail_email=email_address,
+            gmail_refresh_token=refresh_token,
+            email_connected=True,
+            connected_at=now,
+        )
+        config_store.put_config(config)
+
+    # Notify any open admin sessions that the connection is healthy again
+    # so banners/state can clear without a manual page refresh.
+    try:
+        ws_broadcast(org_id, {
+            "type": "gmail_auth_restored",
+            "email": email_address,
+        })
+    except Exception:
+        pass
 
     return EmailConnectResponse(ok=True, email=email_address)
 
@@ -113,11 +152,21 @@ async def email_status(
     if not config or not config.email_connected:
         return EmailStatusResponse(connected=False)
 
+    # When the connection needs reauth, surface a friendly message instead
+    # of the raw Google tuple. The full diagnostic stays in last_error_code.
+    needs_reauth = bool(getattr(config, "needs_reauth", False))
+    if needs_reauth:
+        friendly = "Gmail disconnected — please reconnect to resume order processing."
+    else:
+        friendly = config.last_error or ""
+
     return EmailStatusResponse(
         connected=True,
         email=config.gmail_email,
         last_poll_at=config.last_poll_at.isoformat() if config.last_poll_at else "",
-        last_error=config.last_error or "",
+        last_error=friendly,
+        last_error_code=getattr(config, "last_error_code", None) or "",
+        needs_reauth=needs_reauth,
     )
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -611,6 +611,9 @@ class EmailConfig(BaseModel):
     connected_at: Optional[datetime] = None
     last_poll_at: Optional[datetime] = None
     last_error: Optional[str] = None
+    last_error_code: Optional[str] = None
+    last_error_at: Optional[datetime] = None
+    needs_reauth: bool = False
     email_rules: List[EmailRule] = Field(default_factory=list)
 
 

--- a/backend/tests/test_gmail_reauth.py
+++ b/backend/tests/test_gmail_reauth.py
@@ -1,0 +1,218 @@
+"""Tests for Gmail self-healing OAuth (invalid_grant detection + recovery).
+
+Covers:
+- GmailAuthError is raised when the refresh-token exchange returns invalid_grant.
+- The poller short-circuits when org_config.needs_reauth is True.
+- The poller marks needs_reauth + last_error_code on GmailAuthError.
+- /email/connect merges tokens into the existing config and preserves email_rules.
+"""
+
+import base64
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from backend.app import app
+from backend import email_poller
+from backend.email_store import (
+    get_email_config_store,
+    reset_in_memory_email_config_store,
+)
+from backend.gmail_client import (
+    GmailAuthError,
+    GmailClient,
+    _classify_refresh_error,
+)
+from backend.schemas import EmailConfig, EmailRule
+
+
+client = TestClient(app)
+
+
+def _make_token(sub: str, org_id: str, groups):
+    payload = {"sub": sub, "custom:org_id": org_id, "cognito:groups": groups}
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).rstrip(b"=")
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=")
+    return f"{header.decode()}.{body.decode()}."
+
+
+ADMIN_TOKEN = _make_token("admin-r", "org-r", ["Admin"])
+AUTH = {"Authorization": f"Bearer {ADMIN_TOKEN}"}
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("JWT_VERIFY_SIGNATURE", "false")
+    monkeypatch.setenv("USE_IN_MEMORY_EMAIL_STORE", "true")
+    reset_in_memory_email_config_store()
+
+
+# ---------------------------------------------------------------------------
+# 1. GmailAuthError translation
+# ---------------------------------------------------------------------------
+
+def test_classify_refresh_error_detects_invalid_grant():
+    err = Exception("('invalid_grant: Token has been expired or revoked.', {})")
+    assert _classify_refresh_error(err) == "invalid_grant"
+
+
+def test_classify_refresh_error_returns_none_for_unrelated():
+    assert _classify_refresh_error(Exception("connection reset by peer")) is None
+
+
+def test_get_service_raises_gmail_auth_error_on_refresh_failure(monkeypatch):
+    """When Credentials.refresh raises a RefreshError-like exception with
+    invalid_grant in the message, GmailClient should translate it to
+    GmailAuthError(code='invalid_grant')."""
+
+    # The gmail_client module aliases google.auth.exceptions.RefreshError to
+    # _GoogleRefreshError on import, falling back to plain Exception when the
+    # google libs are not installed. We raise whatever it currently aliases to
+    # so the test runs in either environment.
+    from backend.gmail_client import _GoogleRefreshError as RefreshErrorAlias
+
+    class _FakeCreds:
+        def __init__(self, *a, **kw):
+            pass
+
+        def refresh(self, _request):
+            raise RefreshErrorAlias("invalid_grant: Token has been expired or revoked.")
+
+    monkeypatch.setattr("backend.gmail_client.Credentials", _FakeCreds)
+    monkeypatch.setattr("backend.gmail_client.GoogleAuthRequest", lambda: object())
+
+    gc = GmailClient(refresh_token="bad", client_id="cid", client_secret="csecret")
+    with pytest.raises(GmailAuthError) as exc_info:
+        gc._get_service()
+    assert exc_info.value.code == "invalid_grant"
+
+
+# ---------------------------------------------------------------------------
+# 2. Poller behavior
+# ---------------------------------------------------------------------------
+
+def _seed(org_id="org-r", **overrides) -> EmailConfig:
+    cfg = EmailConfig(
+        org_id=org_id,
+        gmail_email="test@example.com",
+        gmail_refresh_token="tok",
+        email_connected=True,
+        connected_at=datetime.now(timezone.utc),
+        gmail_history_id="100",
+    )
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    get_email_config_store().put_config(cfg)
+    return cfg
+
+
+def test_process_org_short_circuits_when_needs_reauth():
+    cfg = _seed(needs_reauth=True)
+    with patch("backend.email_poller.GmailClient") as mock_cls:
+        created, errors = email_poller._process_org(cfg)
+    assert created == 0
+    assert errors == []
+    # The Gmail client must not even be instantiated when reauth is required.
+    mock_cls.assert_not_called()
+
+
+def test_process_org_marks_needs_reauth_on_gmail_auth_error():
+    cfg = _seed()
+    fake_gmail = MagicMock()
+    fake_gmail.list_new_message_ids.side_effect = GmailAuthError(
+        code="invalid_grant", message="Token has been expired or revoked."
+    )
+    with patch("backend.email_poller.GmailClient", return_value=fake_gmail), \
+         patch("backend.email_poller._notify_reauth_required") as notify:
+        created, errors = email_poller._process_org(cfg)
+
+    assert created == 0
+    assert errors == ["auth:invalid_grant"]
+    notify.assert_called_once()
+
+    stored = get_email_config_store().get_config("org-r")
+    assert stored.needs_reauth is True
+    assert stored.last_error_code == "invalid_grant"
+    assert stored.last_error and "invalid_grant" in stored.last_error
+
+
+# ---------------------------------------------------------------------------
+# 3. /email/connect preserves email_rules and clears reauth state
+# ---------------------------------------------------------------------------
+
+def test_connect_preserves_email_rules_and_clears_reauth(monkeypatch):
+    # Seed a connection that already has rules + is in needs_reauth state.
+    now = datetime.now(timezone.utc)
+    rule = EmailRule(
+        rule_id="rule-1",
+        name="Vel Logistix",
+        sender_pattern="vellogistix.com",
+        subject_pattern="",
+        parser_type="email-airspace",
+        enabled=True,
+        created_at=now,
+        updated_at=now,
+    )
+    _seed(
+        last_error="('invalid_grant: ...')",
+        last_error_code="invalid_grant",
+        last_error_at=now,
+        needs_reauth=True,
+    )
+    cfg = get_email_config_store().get_config("org-r")
+    cfg.email_rules = [rule]
+    get_email_config_store().put_config(cfg)
+
+    # Mock the OAuth code exchange to return a fresh token.
+    monkeypatch.setattr(
+        "backend.routers.email.exchange_auth_code",
+        lambda **kw: {
+            "refresh_token": "new-token",
+            "access_token": "x",
+            "email": "test@example.com",
+        },
+    )
+
+    resp = client.post(
+        "/email/connect",
+        headers=AUTH,
+        json={"code": "fake-auth-code", "redirect_uri": "https://example/cb"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    after = get_email_config_store().get_config("org-r")
+    assert after.gmail_refresh_token == "new-token"
+    assert after.needs_reauth is False
+    assert after.last_error is None
+    assert after.last_error_code is None
+    # History reset so the next poll re-initializes.
+    assert after.gmail_history_id is None
+    # Rules survived the reconnect.
+    assert len(after.email_rules) == 1
+    assert after.email_rules[0].rule_id == "rule-1"
+
+
+def test_status_response_surfaces_needs_reauth():
+    _seed(
+        last_error="('invalid_grant: Token has been expired or revoked.')",
+        last_error_code="invalid_grant",
+        last_error_at=datetime.now(timezone.utc),
+        needs_reauth=True,
+    )
+    resp = client.get("/email/status", headers=AUTH)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is True
+    assert body["needs_reauth"] is True
+    assert body["last_error_code"] == "invalid_grant"
+    # The friendly message should NOT contain the raw Google tuple.
+    assert "invalid_grant" not in body["last_error"]
+    assert "reconnect" in body["last_error"].lower()

--- a/email_poller_fn/email_poller.py
+++ b/email_poller_fn/email_poller.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 from email_classifier import classify_email, SkipReason
 from email_parser import get_parser
 from email_store import get_email_config_store, get_skipped_email_store
-from gmail_client import GmailClient
+from gmail_client import GmailClient, GmailAuthError
 from order_store import get_order_store
 from schemas import Order, OrderStatus, SkippedEmail
 from ws_notifier import broadcast as ws_broadcast
@@ -27,6 +27,18 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _notify_reauth_required(org_id: str, code: str):
+    """Best-effort live notification that a Gmail reconnect is required."""
+    try:
+        ws_broadcast(org_id, {
+            "type": "gmail_auth_required",
+            "code": code,
+            "message": "Gmail authorization expired. Please reconnect to resume order processing.",
+        })
+    except Exception as ws_err:
+        logger.warning("Org %s: ws broadcast for gmail_auth_required failed: %s", org_id, ws_err)
+
+
 def _process_org(org_config):
     """Process a single org's email inbox. Returns (orders_created, errors)."""
     org_id = org_config.org_id
@@ -36,6 +48,13 @@ def _process_org(org_config):
     config_store = get_email_config_store()
     skipped_store = get_skipped_email_store()
     order_store = get_order_store()
+
+    # Short-circuit if the connection is already known to need reauth.
+    # The poller stops touching Gmail until the user reconnects via OAuth,
+    # which clears needs_reauth. This avoids burning quota on a dead token.
+    if getattr(org_config, "needs_reauth", False):
+        logger.info("Org %s: skipping poll — Gmail needs reauth", org_id)
+        return 0, []
 
     client_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "")
     client_secret = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET", "")
@@ -196,6 +215,24 @@ def _process_org(org_config):
         error_summary = "; ".join(errors) if errors else None
         config_store.update_poll_status(org_id, new_history_id, error=error_summary)
 
+    except GmailAuthError as e:
+        # Hard auth failure — the refresh token is dead. Mark the org as
+        # needing reauth so the poller stops hammering Google with a bad
+        # token, and notify any connected admins so the UI can surface a
+        # reconnect banner without a page refresh.
+        logger.warning("Org %s: Gmail auth failed (%s) — marking needs_reauth", org_id, e.code)
+        try:
+            config_store.update_poll_status(
+                org_id,
+                org_config.gmail_history_id or "",
+                error=f"Gmail authorization expired ({e.code}). Please reconnect.",
+                error_code=e.code,
+                needs_reauth=True,
+            )
+        except Exception:
+            pass
+        _notify_reauth_required(org_id, e.code)
+        errors.append(f"auth:{e.code}")
     except Exception as e:
         logger.exception("Org %s: poll failed: %s", org_id, e)
         try:

--- a/email_poller_fn/email_store.py
+++ b/email_poller_fn/email_store.py
@@ -46,7 +46,14 @@ class EmailConfigStore(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def update_poll_status(self, org_id: str, history_id: str, error: Optional[str] = None) -> None:
+    def update_poll_status(
+        self,
+        org_id: str,
+        history_id: str,
+        error: Optional[str] = None,
+        error_code: Optional[str] = None,
+        needs_reauth: bool = False,
+    ) -> None:
         raise NotImplementedError
 
 
@@ -67,12 +74,27 @@ class InMemoryEmailConfigStore(EmailConfigStore):
     def list_connected_orgs(self) -> List[EmailConfig]:
         return [c for c in self.items.values() if c.email_connected]
 
-    def update_poll_status(self, org_id: str, history_id: str, error: Optional[str] = None) -> None:
+    def update_poll_status(
+        self,
+        org_id: str,
+        history_id: str,
+        error: Optional[str] = None,
+        error_code: Optional[str] = None,
+        needs_reauth: bool = False,
+    ) -> None:
         config = self.items.get(org_id)
         if config:
             config.gmail_history_id = history_id
             config.last_poll_at = utc_now()
             config.last_error = error
+            if needs_reauth:
+                config.needs_reauth = True
+                config.last_error_code = error_code
+                config.last_error_at = utc_now()
+            elif error is None:
+                config.needs_reauth = False
+                config.last_error_code = None
+                config.last_error_at = None
 
 
 class DynamoEmailConfigStore(EmailConfigStore):
@@ -110,17 +132,41 @@ class DynamoEmailConfigStore(EmailConfigStore):
             items.extend(resp.get("Items", []))
         return [EmailConfig.model_validate(item) for item in items]
 
-    def update_poll_status(self, org_id: str, history_id: str, error: Optional[str] = None) -> None:
-        update_expr = "SET gmail_history_id = :hid, last_poll_at = :now"
+    def update_poll_status(
+        self,
+        org_id: str,
+        history_id: str,
+        error: Optional[str] = None,
+        error_code: Optional[str] = None,
+        needs_reauth: bool = False,
+    ) -> None:
+        set_parts = ["gmail_history_id = :hid", "last_poll_at = :now"]
+        remove_parts: list = []
         expr_values: dict = {
             ":hid": history_id,
             ":now": utc_now().isoformat(),
         }
         if error:
-            update_expr += ", last_error = :err"
+            set_parts.append("last_error = :err")
             expr_values[":err"] = error
         else:
-            update_expr += " REMOVE last_error"
+            remove_parts.append("last_error")
+
+        if needs_reauth:
+            set_parts.append("needs_reauth = :nr")
+            set_parts.append("last_error_code = :ec")
+            set_parts.append("last_error_at = :now")
+            expr_values[":nr"] = True
+            expr_values[":ec"] = error_code or "refresh_failed"
+        elif error is None:
+            set_parts.append("needs_reauth = :nr")
+            expr_values[":nr"] = False
+            remove_parts.append("last_error_code")
+            remove_parts.append("last_error_at")
+
+        update_expr = "SET " + ", ".join(set_parts)
+        if remove_parts:
+            update_expr += " REMOVE " + ", ".join(remove_parts)
 
         self._table.update_item(
             Key={"org_id": org_id},

--- a/email_poller_fn/gmail_client.py
+++ b/email_poller_fn/gmail_client.py
@@ -14,15 +14,49 @@ logger = logging.getLogger(__name__)
 
 try:
     from google.auth.transport.requests import Request as GoogleAuthRequest
+    from google.auth.exceptions import RefreshError as _GoogleRefreshError
     from google.oauth2.credentials import Credentials
     from googleapiclient.discovery import build
 except ImportError:  # pragma: no cover
     GoogleAuthRequest = None
+    _GoogleRefreshError = Exception
     Credentials = None
     build = None
 
 GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
 TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+# Substrings Google returns inside RefreshError messages for hard auth failures
+# that mean "the refresh token is no longer usable". We translate any of these
+# into a structured GmailAuthError so callers can surface a friendly reauth
+# prompt instead of treating it as a transient error.
+_HARD_AUTH_ERROR_CODES = (
+    "invalid_grant",
+    "invalid_client",
+    "unauthorized_client",
+    "invalid_token",
+)
+
+
+class GmailAuthError(Exception):
+    """The user's Gmail OAuth credentials can no longer be refreshed.
+
+    Caller should mark the connection as needing reauth and stop polling
+    until the user re-consents via the OAuth flow.
+    """
+
+    def __init__(self, code: str, message: str = ""):
+        super().__init__(message or code)
+        self.code = code
+
+
+def _classify_refresh_error(err: Exception) -> Optional[str]:
+    """Return the matched hard-auth code if `err` is a hard refresh failure, else None."""
+    text = str(err).lower()
+    for code in _HARD_AUTH_ERROR_CODES:
+        if code in text:
+            return code
+    return None
 
 
 @dataclass
@@ -68,7 +102,11 @@ class GmailClient:
             client_secret=self._client_secret,
             scopes=GMAIL_SCOPES,
         )
-        creds.refresh(GoogleAuthRequest())
+        try:
+            creds.refresh(GoogleAuthRequest())
+        except _GoogleRefreshError as e:
+            code = _classify_refresh_error(e) or "refresh_failed"
+            raise GmailAuthError(code=code, message=str(e)) from e
         self._service = build("gmail", "v1", credentials=creds, cache_discovery=False)
         return self._service
 
@@ -272,7 +310,16 @@ def exchange_auth_code(code: str, redirect_uri: str, client_id: str = "", client
         scopes=GMAIL_SCOPES,
         redirect_uri=redirect_uri,
     )
-    flow.fetch_token(code=code)
+    try:
+        flow.fetch_token(code=code)
+    except Exception as e:
+        # Stale/already-used auth codes and revoked clients all surface as
+        # OAuth errors here. Translate hard-auth failures so callers can
+        # render a clear "please re-authorize" message.
+        hard_code = _classify_refresh_error(e)
+        if hard_code:
+            raise GmailAuthError(code=hard_code, message=str(e)) from e
+        raise
     creds = flow.credentials
 
     service = build("gmail", "v1", credentials=creds, cache_discovery=False)

--- a/email_poller_fn/schemas.py
+++ b/email_poller_fn/schemas.py
@@ -611,6 +611,9 @@ class EmailConfig(BaseModel):
     connected_at: Optional[datetime] = None
     last_poll_at: Optional[datetime] = None
     last_error: Optional[str] = None
+    last_error_code: Optional[str] = None
+    last_error_at: Optional[datetime] = None
+    needs_reauth: bool = False
     email_rules: List[EmailRule] = Field(default_factory=list)
 
 


### PR DESCRIPTION
## Summary
- Gmail integration now self-heals when the OAuth refresh token expires (the `invalid_grant` failure that paused order processing this morning). The poller stops hammering Google with a dead token, marks the org `needs_reauth`, and broadcasts a WebSocket event so a red banner appears live in the admin UI on every tab.
- One click on **Reconnect Gmail** runs the OAuth flow again. The reconnect now **merges** tokens into the existing config — `email_rules` and other org settings are preserved (previously they were destroyed).
- README documents the underlying operational fix: publishing the OAuth app to **In production** in Google Cloud Console removes the 7-day refresh-token expiry that's specific to apps in *Testing* status with sensitive scopes (`gmail.modify`). No full Google verification required to take this step.

## What changed (per industry standard pattern — Slack/Notion/Zapier)
1. **`gmail_client`** classifies `RefreshError` (`invalid_grant`, `unauthorized_client`, …) into a structured `GmailAuthError(code=…)`. Mirrored to `email_poller_fn/gmail_client.py`.
2. **`EmailConfig`** gains `needs_reauth`, `last_error_code`, `last_error_at` (default-safe for existing Dynamo rows). `update_poll_status` writes them on auth failure and clears them on clean recovery — both InMemory and Dynamo, both copies.
3. **Poller** short-circuits any org with `needs_reauth=True` (no more 60 s polling on a dead token). On `GmailAuthError`, it marks the org and emits a `gmail_auth_required` WS event.
4. **`/email/connect`** merges tokens into the existing `EmailConfig`, resets `gmail_history_id` so the next poll re-initializes, and emits `gmail_auth_restored` so banners clear live.
5. **`/email/status`** surfaces `needs_reauth` + `last_error_code`, with a friendly "please reconnect" message (raw Google tuple no longer reaches the UI).
6. **Admin UI** adds a sticky red banner above the workspace tabs with a Reconnect button (factored to share the same OAuth popup logic as the original Connect button), plus WS handlers for both `gmail_auth_required` and `gmail_auth_restored`.

## Test plan
- [x] `pytest backend/tests/test_gmail_reauth.py backend/tests/test_email_rules.py` — 26/26 pass (7 new tests).
- [x] Full backend pytest suite — same 4 unrelated pre-existing failures in `test_billing.py` and `test_order_store.py`; all email tests green.
- [ ] Manual end-to-end on dev: revoke the dev Gmail token via Google Account → Security → Third-party access. Within 60 s the admin UI should display the red banner (live, via WebSocket) and the email settings card should show the friendly "Gmail disconnected" message instead of the raw error tuple.
- [ ] Click **Reconnect Gmail** in the banner → OAuth popup → consent → banner disappears, status returns to OK, previously-created `email_rules` are still listed.
- [ ] Forward a test order email — within 60 s an order is created (proving polling resumed cleanly).
- [ ] In Google Cloud Console, confirm the OAuth app is published to "In production" so future refresh tokens last beyond 7 days.

## Out of scope
- Email/SMS notifications to admin (no transactional email infra wired up yet — WebSocket + persistent banner cover the realistic use cases).
- Full Google OAuth app verification (multi-week external Google process; only required to remove the unverified-app warning, not to fix token expiry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)