### PR TITLE
feat: condense nav to 3 tabs with Orders sub-nav (In Flight, History, + modal)

### DIFF
--- a/backend/frontend/admin.html
+++ b/backend/frontend/admin.html
@@ -41,9 +41,7 @@
     <nav class="topbar-workspace-nav" role="tablist" aria-label="Console workspaces">
       <button class="topbar-ws-tab is-active" type="button" data-workspace-target="operations">Dispatch</button>
       <button class="topbar-ws-tab" type="button" data-workspace-target="orders">Orders</button>
-      <button class="topbar-ws-tab" type="button" data-workspace-target="planning">Planning</button>
-      <button class="topbar-ws-tab" type="button" data-workspace-target="insights">In Flight</button>
-      <button class="topbar-ws-tab" type="button" data-workspace-target="admin">Admin</button>
+      <button id="admin-nav-tab" class="topbar-ws-tab" type="button" data-workspace-target="admin">Admin</button>
     </nav>
     <div class="topbar-slim-right">
       <span id="auth-state" class="status-pill status-idle">Not Signed In</span>
@@ -126,109 +124,186 @@
       </div>
     </section>
 
-    <!-- ===== ORDERS VIEW (existing, wrapped) ===== -->
+    <!-- ===== ORDERS VIEW ===== -->
     <section class="workspace-panel" data-workspace-panel="orders">
-      <div class="workspace-contained">
-        <section class="panel">
-          <div class="panel-title-row">
-            <h2>Orders View</h2>
-            <button id="refresh-orders-table" class="btn btn-ghost" type="button">Refresh Orders</button>
-          </div>
-          <p class="panel-help">Spreadsheet-style order management with sorting, filtering, and fast assignment actions.</p>
 
-          <div class="row">
-            <input id="bulk-driver-id" class="compact-input" list="driver-options" placeholder="driver id">
-            <button id="bulk-assign-selected" class="btn btn-primary" type="button">Assign Selected</button>
-            <button id="bulk-unassign-selected" class="btn btn-ghost" type="button">Unassign</button>
-            <button id="clear-selection" class="btn btn-ghost" type="button">Clear</button>
-            <span id="selection-count" class="status-pill status-idle">0 selected</span>
-          </div>
-
-          <datalist id="driver-options"></datalist>
-
-          <form id="orders-filter-form" class="row orders-filters">
-            <label class="field">
-              <span>Status</span>
-              <select id="orders-status-filter" name="status">
-                <option value="">Any status</option>
-                <option value="Created">Created</option>
-                <option value="Assigned">Assigned</option>
-                <option value="PickedUp">PickedUp</option>
-                <option value="EnRoute">EnRoute</option>
-                <option value="Delivered">Delivered</option>
-                <option value="Failed">Failed</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>Assigned Driver</span>
-              <input id="orders-assigned-filter" name="assigned_to" placeholder="driver id">
-            </label>
-            <label class="field">
-              <span>Assignment</span>
-              <select id="orders-assignment-filter" name="assignment">
-                <option value="">All</option>
-                <option value="assigned">Assigned only</option>
-                <option value="unassigned">Unassigned only</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>Due Date</span>
-              <select id="orders-due-filter" name="due">
-                <option value="">Any</option>
-                <option value="upcoming">Upcoming (next 2h)</option>
-                <option value="overdue">Overdue</option>
-                <option value="none">No deadline</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>Search</span>
-              <input id="orders-search-filter" name="search" placeholder="customer / reference / order id">
-            </label>
-            <label class="field">
-              <span>Sort By</span>
-              <select id="orders-sort-field" name="sort_field">
-                <option value="dropoff_deadline">Dropoff Deadline</option>
-                <option value="pickup_deadline">Pickup Deadline</option>
-                <option value="created_at">Created At</option>
-                <option value="customer_name">Customer</option>
-                <option value="reference_id">Reference ID</option>
-                <option value="status">Status</option>
-                <option value="assigned_to">Assigned Driver</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>Direction</span>
-              <select id="orders-sort-direction" name="sort_direction">
-                <option value="asc">Ascending</option>
-                <option value="desc">Descending</option>
-              </select>
-            </label>
-            <div class="filter-actions">
-              <button class="btn btn-primary" type="submit">Apply</button>
-              <button id="orders-clear-filters" class="btn btn-ghost" type="button">Clear</button>
-            </div>
-          </form>
-
-          <div class="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th><input id="select-all-orders" type="checkbox" aria-label="Select all orders"></th>
-                  <th><button class="table-sort" type="button" data-order-sort-field="customer_name">Order</button></th>
-                  <th><button class="table-sort" type="button" data-order-sort-field="pick_up_street">Stops</button></th>
-                  <th><button class="table-sort" type="button" data-order-sort-field="pickup_deadline">Deadlines</button></th>
-                  <th><button class="table-sort" type="button" data-order-sort-field="status">Status</button></th>
-                  <th><button class="table-sort" type="button" data-order-sort-field="assigned_to">Assignment</button></th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody id="orders-tbody"></tbody>
-            </table>
-          </div>
-          <div id="orders-mobile" class="orders-mobile"></div>
-          <p id="orders-message" class="message"></p>
-        </section>
+      <!-- Sub-nav bar -->
+      <div class="orders-subnav-bar">
+        <nav class="orders-subnav" role="tablist" aria-label="Orders sections">
+          <button class="orders-subnav-tab is-active" type="button" data-orders-tab="list">Orders</button>
+          <button class="orders-subnav-tab" type="button" data-orders-tab="inflight">In Flight</button>
+          <button class="orders-subnav-tab" type="button" data-orders-tab="history">Order History</button>
+        </nav>
+        <button id="add-order-btn" class="btn btn-primary orders-add-btn" type="button" title="Create new order">+</button>
       </div>
+
+      <!-- Orders List sub-panel -->
+      <div class="orders-subpanel is-active" data-orders-panel="list">
+        <div class="workspace-contained">
+          <section class="panel">
+            <div class="panel-title-row">
+              <h2>Orders</h2>
+              <button id="refresh-orders-table" class="btn btn-ghost" type="button">Refresh Orders</button>
+            </div>
+            <p class="panel-help">Spreadsheet-style order management with sorting, filtering, and fast assignment actions.</p>
+
+            <div class="row">
+              <input id="bulk-driver-id" class="compact-input" list="driver-options" placeholder="driver id">
+              <button id="bulk-assign-selected" class="btn btn-primary" type="button">Assign Selected</button>
+              <button id="bulk-unassign-selected" class="btn btn-ghost" type="button">Unassign</button>
+              <button id="clear-selection" class="btn btn-ghost" type="button">Clear</button>
+              <span id="selection-count" class="status-pill status-idle">0 selected</span>
+            </div>
+
+            <datalist id="driver-options"></datalist>
+
+            <form id="orders-filter-form" class="row orders-filters">
+              <label class="field">
+                <span>Status</span>
+                <select id="orders-status-filter" name="status">
+                  <option value="">Any status</option>
+                  <option value="Created">Created</option>
+                  <option value="Assigned">Assigned</option>
+                  <option value="PickedUp">PickedUp</option>
+                  <option value="EnRoute">EnRoute</option>
+                  <option value="Delivered">Delivered</option>
+                  <option value="Failed">Failed</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Assigned Driver</span>
+                <input id="orders-assigned-filter" name="assigned_to" placeholder="driver id">
+              </label>
+              <label class="field">
+                <span>Assignment</span>
+                <select id="orders-assignment-filter" name="assignment">
+                  <option value="">All</option>
+                  <option value="assigned">Assigned only</option>
+                  <option value="unassigned">Unassigned only</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Due Date</span>
+                <select id="orders-due-filter" name="due">
+                  <option value="">Any</option>
+                  <option value="upcoming">Upcoming (next 2h)</option>
+                  <option value="overdue">Overdue</option>
+                  <option value="none">No deadline</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Search</span>
+                <input id="orders-search-filter" name="search" placeholder="customer / reference / order id">
+              </label>
+              <label class="field">
+                <span>Sort By</span>
+                <select id="orders-sort-field" name="sort_field">
+                  <option value="dropoff_deadline">Dropoff Deadline</option>
+                  <option value="pickup_deadline">Pickup Deadline</option>
+                  <option value="created_at">Created At</option>
+                  <option value="customer_name">Customer</option>
+                  <option value="reference_id">Reference ID</option>
+                  <option value="status">Status</option>
+                  <option value="assigned_to">Assigned Driver</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Direction</span>
+                <select id="orders-sort-direction" name="sort_direction">
+                  <option value="asc">Ascending</option>
+                  <option value="desc">Descending</option>
+                </select>
+              </label>
+              <div class="filter-actions">
+                <button class="btn btn-primary" type="submit">Apply</button>
+                <button id="orders-clear-filters" class="btn btn-ghost" type="button">Clear</button>
+              </div>
+            </form>
+
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th><input id="select-all-orders" type="checkbox" aria-label="Select all orders"></th>
+                    <th><button class="table-sort" type="button" data-order-sort-field="customer_name">Order</button></th>
+                    <th><button class="table-sort" type="button" data-order-sort-field="pick_up_street">Stops</button></th>
+                    <th><button class="table-sort" type="button" data-order-sort-field="pickup_deadline">Deadlines</button></th>
+                    <th><button class="table-sort" type="button" data-order-sort-field="status">Status</button></th>
+                    <th><button class="table-sort" type="button" data-order-sort-field="assigned_to">Assignment</button></th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="orders-tbody"></tbody>
+              </table>
+            </div>
+            <div id="orders-mobile" class="orders-mobile"></div>
+            <p id="orders-message" class="message"></p>
+          </section>
+        </div>
+      </div>
+
+      <!-- In Flight sub-panel -->
+      <div class="orders-subpanel" data-orders-panel="inflight">
+        <div class="workspace-contained" style="max-width:none;">
+          <section class="panel">
+            <div class="panel-title-row">
+              <h2>In Flight</h2>
+              <div style="display:flex;gap:8px;align-items:center;">
+                <span id="inflight-count" class="stat-badge" style="background:var(--accent);color:#fff;padding:3px 10px;border-radius:12px;font-size:.75rem;font-weight:700;">0</span>
+                <button id="refresh-inflight" class="btn btn-ghost" type="button">Refresh</button>
+              </div>
+            </div>
+            <div id="inflight-list" class="inflight-list">
+              <div class="inflight-empty">No active shipments.</div>
+            </div>
+            <p id="inflight-message" class="message"></p>
+          </section>
+
+          <section class="panel">
+            <div class="panel-title-row">
+              <h2>Audit Logs</h2>
+              <button id="refresh-audit-logs" class="btn btn-ghost" type="button">Refresh</button>
+            </div>
+            <form id="audit-filter-form" class="form-grid">
+              <label class="field"><span>Action (optional)</span><input id="audit-action-filter" name="action" placeholder="order.assigned"></label>
+              <label class="field"><span>Target Type (optional)</span><input id="audit-target-filter" name="target_type" placeholder="order"></label>
+              <label class="field"><span>Actor ID (optional)</span><input id="audit-actor-filter" name="actor_id" placeholder="admin-123"></label>
+              <label class="field"><span>Limit</span><input id="audit-limit-filter" name="limit" type="number" min="1" max="200" value="50"></label>
+            </form>
+            <div id="audit-logs-view" class="data-surface">No audit logs loaded.</div>
+            <p id="audit-message" class="message"></p>
+          </section>
+        </div>
+      </div>
+
+      <!-- Order History sub-panel -->
+      <div class="orders-subpanel" data-orders-panel="history">
+        <div class="workspace-contained">
+          <section class="panel">
+            <div class="panel-title-row">
+              <h2>Order History</h2>
+              <button id="refresh-order-history" class="btn btn-ghost" type="button">Refresh</button>
+            </div>
+            <p class="panel-help">Review completed deliveries — driver, timestamps, and proof of delivery.</p>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Order</th>
+                    <th>Stops</th>
+                    <th>Driver</th>
+                    <th>Created</th>
+                    <th>POD</th>
+                  </tr>
+                </thead>
+                <tbody id="order-history-tbody"></tbody>
+              </table>
+            </div>
+            <p id="order-history-message" class="message"></p>
+          </section>
+        </div>
+      </div>
+
     </section>
 
     <!-- ===== EDIT ORDER MODAL ===== -->
@@ -278,77 +353,54 @@
       </div>
     </div>
 
-    <!-- ===== PLANNING (existing, wrapped) ===== -->
-    <section class="workspace-panel" data-workspace-panel="planning">
-      <div class="workspace-contained">
-        <div class="planning-centered">
-          <section class="panel">
-            <div class="panel-title-row">
-              <h2>Create Order</h2>
-            </div>
-            <p class="panel-help">Capture complete order details, then move to optimization and assignment.</p>
-            <form id="create-order-form" class="form-grid">
-              <label class="field"><span>Customer Name</span><input name="customer_name" required></label>
-              <label class="field"><span>Reference ID</span><input name="reference_id" type="text" required></label>
-              <label class="field field-span-2"><span>Pick Up Street</span><input name="pick_up_street" required></label>
-              <label class="field"><span>Pick Up City</span><input name="pick_up_city" required></label>
-              <label class="field"><span>Pick Up State</span><input name="pick_up_state" required></label>
-              <label class="field"><span>Pick Up Zip</span><input name="pick_up_zip" required></label>
-              <label class="field field-span-2"><span>Delivery Street</span><input name="delivery_street" required></label>
-              <label class="field"><span>Delivery City</span><input name="delivery_city" required></label>
-              <label class="field"><span>Delivery State</span><input name="delivery_state" required></label>
-              <label class="field"><span>Delivery Zip</span><input name="delivery_zip" required></label>
-              <label class="field"><span>Dimensions <small>(optional)</small></span><input name="dimensions" placeholder="e.g. 12x8x5 in"></label>
-              <label class="field"><span>Weight <small>(optional)</small></span><input name="weight" type="number" step="any" min="0.01" placeholder="lbs"></label>
-              <label class="field"><span>Pick Up Deadline</span><input name="pickup_deadline" type="datetime-local"></label>
-              <label class="field"><span>Drop Off Deadline</span><input name="dropoff_deadline" type="datetime-local"></label>
-              <label class="field"><span>Phone</span><input name="phone"></label>
-              <label class="field"><span>Email</span><input name="email" type="email"></label>
-              <label class="field"><span>Packages</span><input name="num_packages" type="number" min="1" value="1"></label>
-              <label class="field field-span-2"><span>Notes</span><textarea name="notes" rows="2"></textarea></label>
-              <button class="btn btn-primary field-span-2" type="submit">Create Order</button>
-            </form>
-            <p id="create-order-message" class="message"></p>
-          </section>
+    <!-- ===== CREATE ORDER MODAL ===== -->
+    <div id="create-order-modal" class="modal-overlay" style="display:none;">
+      <div class="modal-dialog modal-lg">
+        <div class="modal-header">
+          <h3>Create Order</h3>
+          <button id="create-order-modal-close" class="modal-close-btn" type="button">&times;</button>
+        </div>
+        <div class="modal-body">
+          <form id="create-order-form" class="form-grid">
+            <label class="field"><span>Customer Name</span><input name="customer_name" required></label>
+            <label class="field"><span>Reference ID</span><input name="reference_id" type="text" required></label>
+            <label class="field field-span-2"><span>Pick Up Street</span><input name="pick_up_street" required></label>
+            <label class="field"><span>Pick Up City</span><input name="pick_up_city" required></label>
+            <label class="field"><span>Pick Up State</span><input name="pick_up_state" required></label>
+            <label class="field"><span>Pick Up Zip</span><input name="pick_up_zip" required></label>
+            <label class="field field-span-2"><span>Delivery Street</span><input name="delivery_street" required></label>
+            <label class="field"><span>Delivery City</span><input name="delivery_city" required></label>
+            <label class="field"><span>Delivery State</span><input name="delivery_state" required></label>
+            <label class="field"><span>Delivery Zip</span><input name="delivery_zip" required></label>
+            <label class="field"><span>Dimensions <small>(optional)</small></span><input name="dimensions" placeholder="e.g. 12x8x5 in"></label>
+            <label class="field"><span>Weight <small>(optional)</small></span><input name="weight" type="number" step="any" min="0.01" placeholder="lbs"></label>
+            <label class="field"><span>Pick Up Deadline</span><input name="pickup_deadline" type="datetime-local"></label>
+            <label class="field"><span>Drop Off Deadline</span><input name="dropoff_deadline" type="datetime-local"></label>
+            <label class="field"><span>Phone</span><input name="phone"></label>
+            <label class="field"><span>Email</span><input name="email" type="email"></label>
+            <label class="field"><span>Packages</span><input name="num_packages" type="number" min="1" value="1"></label>
+            <label class="field field-span-2"><span>Notes</span><textarea name="notes" rows="2"></textarea></label>
+            <button class="btn btn-primary field-span-2" type="submit">Create Order</button>
+          </form>
+          <p id="create-order-message" class="message"></p>
         </div>
       </div>
-    </section>
+    </div>
 
-    <!-- ===== INSIGHTS (existing, wrapped) ===== -->
-    <section class="workspace-panel" data-workspace-panel="insights">
-      <div class="workspace-contained" style="max-width:none;">
-        <section class="panel">
-          <div class="panel-title-row">
-            <h2>In Flight</h2>
-            <div style="display:flex;gap:8px;align-items:center;">
-              <span id="inflight-count" class="stat-badge" style="background:var(--accent);color:#fff;padding:3px 10px;border-radius:12px;font-size:.75rem;font-weight:700;">0</span>
-              <button id="refresh-inflight" class="btn btn-ghost" type="button">Refresh</button>
-            </div>
-          </div>
-          <div id="inflight-list" class="inflight-list">
-            <div class="inflight-empty">No active shipments.</div>
-          </div>
-          <p id="inflight-message" class="message"></p>
-        </section>
-
-        <section class="panel">
-          <div class="panel-title-row">
-            <h2>Audit Logs</h2>
-            <button id="refresh-audit-logs" class="btn btn-ghost" type="button">Refresh</button>
-          </div>
-          <form id="audit-filter-form" class="form-grid">
-            <label class="field"><span>Action (optional)</span><input id="audit-action-filter" name="action" placeholder="order.assigned"></label>
-            <label class="field"><span>Target Type (optional)</span><input id="audit-target-filter" name="target_type" placeholder="order"></label>
-            <label class="field"><span>Actor ID (optional)</span><input id="audit-actor-filter" name="actor_id" placeholder="admin-123"></label>
-            <label class="field"><span>Limit</span><input id="audit-limit-filter" name="limit" type="number" min="1" max="200" value="50"></label>
-          </form>
-          <div id="audit-logs-view" class="data-surface">No audit logs loaded.</div>
-          <p id="audit-message" class="message"></p>
-        </section>
+    <!-- ===== POD VIEW MODAL ===== -->
+    <div id="pod-view-modal" class="modal-overlay" style="display:none;">
+      <div class="modal-dialog modal-lg">
+        <div class="modal-header">
+          <h3>Proof of Delivery</h3>
+          <button id="pod-view-modal-close" class="modal-close-btn" type="button">&times;</button>
+        </div>
+        <div class="modal-body" id="pod-view-content">
+          <p style="color:var(--text-muted);text-align:center;padding:32px">Loading…</p>
+        </div>
       </div>
-    </section>
+    </div>
 
-    <!-- ===== ADMIN (existing + session/auth config moved here, wrapped) ===== -->
+    <!-- ===== ADMIN ===== -->
     <section class="workspace-panel" data-workspace-panel="admin">
       <div class="workspace-contained">
 

--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -149,6 +149,18 @@
     dispatchOrderList: document.getElementById("dispatch-order-list"),
     dispatchOrderSearch: document.getElementById("dispatch-order-search"),
     dispatchFilterBtns: Array.from(document.querySelectorAll("[data-dispatch-filter]")),
+    adminNavTab: document.getElementById("admin-nav-tab"),
+    addOrderBtn: document.getElementById("add-order-btn"),
+    createOrderModal: document.getElementById("create-order-modal"),
+    createOrderModalClose: document.getElementById("create-order-modal-close"),
+    ordersSubnavTabs: Array.from(document.querySelectorAll("[data-orders-tab]")),
+    ordersSubpanels: Array.from(document.querySelectorAll("[data-orders-panel]")),
+    refreshOrderHistory: document.getElementById("refresh-order-history"),
+    orderHistoryBody: document.getElementById("order-history-tbody"),
+    orderHistoryMessage: document.getElementById("order-history-message"),
+    podViewModal: document.getElementById("pod-view-modal"),
+    podViewModalClose: document.getElementById("pod-view-modal-close"),
+    podViewContent: document.getElementById("pod-view-content"),
   };
 
   let token = "";
@@ -528,7 +540,7 @@
       return;
     }
     const hashPanel = (window.location.hash || "").replace("#", "").trim();
-    const knownPanels = new Set(["operations", "orders", "planning", "insights", "admin"]);
+    const knownPanels = new Set(["operations", "orders", "admin"]);
     renderWorkspace(knownPanels.has(hashPanel) ? hashPanel : "operations");
     el.workspaceTabs.forEach(function (tab) {
       tab.addEventListener("click", function () {
@@ -537,6 +549,122 @@
         history.replaceState(null, "", "#" + target);
       });
     });
+  }
+
+  function renderOrdersSubnav(target) {
+    el.ordersSubnavTabs.forEach(function (tab) {
+      tab.classList.toggle("is-active", tab.getAttribute("data-orders-tab") === target);
+    });
+    el.ordersSubpanels.forEach(function (panel) {
+      panel.classList.toggle("is-active", panel.getAttribute("data-orders-panel") === target);
+    });
+  }
+
+  function initOrdersSubnav() {
+    el.ordersSubnavTabs.forEach(function (tab) {
+      tab.addEventListener("click", function () {
+        var target = tab.getAttribute("data-orders-tab");
+        renderOrdersSubnav(target);
+        if (target === "history") {
+          refreshOrderHistory().catch(function (error) {
+            if (el.orderHistoryMessage) C.showMessage(el.orderHistoryMessage, error.message, "error");
+          });
+        }
+        if (target === "inflight") {
+          refreshInflight().catch(function (error) {
+            if (el.inflightMessage) C.showMessage(el.inflightMessage, error.message, "error");
+          });
+        }
+      });
+    });
+  }
+
+  function openCreateOrderModal() {
+    if (el.createOrderModal) el.createOrderModal.style.display = "flex";
+  }
+
+  function closeCreateOrderModal() {
+    if (el.createOrderModal) el.createOrderModal.style.display = "none";
+  }
+
+  function openPodViewModal() {
+    if (el.podViewModal) el.podViewModal.style.display = "flex";
+  }
+
+  function closePodViewModal() {
+    if (el.podViewModal) el.podViewModal.style.display = "none";
+  }
+
+  async function refreshOrderHistory() {
+    if (!requireAuthorized(el.orderHistoryMessage)) return;
+    if (el.orderHistoryBody) {
+      el.orderHistoryBody.innerHTML = "<tr><td colspan=\"5\" style=\"text-align:center;color:var(--text-muted)\">Loading…</td></tr>";
+    }
+    try {
+      var orders = await C.requestJson(apiBase, "/orders?status=Delivered&sort_field=created_at&sort_direction=desc", { token });
+      renderOrderHistory(Array.isArray(orders) ? orders : []);
+    } catch (error) {
+      if (el.orderHistoryMessage) C.showMessage(el.orderHistoryMessage, error.message, "error");
+    }
+  }
+
+  function renderOrderHistory(orders) {
+    if (!el.orderHistoryBody) return;
+    if (!orders.length) {
+      el.orderHistoryBody.innerHTML = "<tr><td colspan=\"5\" style=\"text-align:center;color:var(--text-muted);padding:24px\">No delivered orders yet.</td></tr>";
+      return;
+    }
+    el.orderHistoryBody.innerHTML = orders.map(function (order) {
+      var driver = order.assigned_to
+        ? "<span class=\"driver-pill\">" + C.escapeHtml(order.assigned_to) + "</span>"
+        : "<span style=\"color:var(--text-muted)\">—</span>";
+      var pickup = C.escapeHtml((order.pick_up_street || "") + ", " + (order.pick_up_city || ""));
+      var delivery = C.escapeHtml((order.delivery_street || "") + ", " + (order.delivery_city || ""));
+      return "<tr>" +
+        "<td><strong>" + C.escapeHtml(order.customer_name || "") + "</strong><br><small style=\"color:var(--text-muted)\">Ref " + C.escapeHtml(order.reference_id || "") + "</small></td>" +
+        "<td><small>" + pickup + "</small><br><small style=\"color:var(--text-muted)\">→ " + delivery + "</small></td>" +
+        "<td>" + driver + "</td>" +
+        "<td><small>" + C.escapeHtml(C.formatTimestamp(order.created_at)) + "</small></td>" +
+        "<td><button class=\"btn btn-ghost\" style=\"font-size:.75rem;padding:3px 8px\" type=\"button\" data-pod-order-id=\"" + C.escapeHtml(order.id) + "\">View POD</button></td>" +
+        "</tr>";
+    }).join("");
+  }
+
+  async function fetchAndShowPod(orderId) {
+    if (!requireAuthorized(el.orderHistoryMessage)) return;
+    if (el.podViewContent) el.podViewContent.innerHTML = "<p style=\"color:var(--text-muted);text-align:center;padding:32px\">Loading…</p>";
+    openPodViewModal();
+    try {
+      var records = await C.requestJson(apiBase, "/pod/order/" + orderId, { token });
+      renderPodModal(Array.isArray(records) ? records : []);
+    } catch (error) {
+      if (el.podViewContent) el.podViewContent.innerHTML = "<p class=\"message message-error\" style=\"margin:24px\">" + C.escapeHtml(error.message) + "</p>";
+    }
+  }
+
+  function renderPodModal(records) {
+    if (!el.podViewContent) return;
+    if (!records.length) {
+      el.podViewContent.innerHTML = "<p style=\"color:var(--text-muted);text-align:center;padding:32px\">No proof of delivery recorded for this order.</p>";
+      return;
+    }
+    el.podViewContent.innerHTML = records.map(function (record, i) {
+      var photos = (record.photo_urls || []).map(function (url) {
+        return "<a href=\"" + C.escapeHtml(url) + "\" target=\"_blank\" rel=\"noopener\"><img src=\"" + C.escapeHtml(url) + "\" class=\"pod-photo\" alt=\"Delivery photo\"></a>";
+      }).join("");
+      var sigs = (record.signature_urls || []).map(function (url) {
+        return "<a href=\"" + C.escapeHtml(url) + "\" target=\"_blank\" rel=\"noopener\"><img src=\"" + C.escapeHtml(url) + "\" class=\"pod-signature\" alt=\"Signature\"></a>";
+      }).join("");
+      return (i > 0 ? "<hr style=\"border-color:var(--border);margin:16px 0\">" : "") +
+        "<div class=\"pod-record\">" +
+        "<div class=\"pod-meta\">Driver: <strong>" + C.escapeHtml(record.driver_id || "—") + "</strong>" +
+        " &bull; Captured: <strong>" + C.escapeHtml(C.formatTimestamp(record.captured_at)) + "</strong>" +
+        (record.notes ? " &bull; Notes: <em>" + C.escapeHtml(record.notes) + "</em>" : "") +
+        "</div>" +
+        (photos ? "<div class=\"pod-photos\"><h4 style=\"margin:12px 0 6px\">Photos</h4>" + photos + "</div>" : "") +
+        (sigs ? "<div class=\"pod-signatures\"><h4 style=\"margin:12px 0 6px\">Signature</h4>" + sigs + "</div>" : "") +
+        "</div>";
+    }).join("");
   }
 
   function updateOrderStats(orders) {
@@ -1193,6 +1321,9 @@
     } else {
       showLoginScreen(false);
     }
+    if (el.adminNavTab) {
+      el.adminNavTab.hidden = !isAdminRole;
+    }
     setInteractiveState(isAuthorizedRole);
     setBillingInteractiveState(isAuthorizedRole && isAdminRole);
     if (!isAuthorizedRole) {
@@ -1578,6 +1709,7 @@
       });
       C.showMessage(el.createMessage, "Created order " + created.id, "success");
       el.createForm.reset();
+      closeCreateOrderModal();
       await refreshOrders();
     } catch (error) {
       C.showMessage(el.createMessage, error.message, "error");
@@ -3197,6 +3329,7 @@
     setInteractiveState(false);
     setBillingInteractiveState(false);
     initWorkspaceTabs();
+    initOrdersSubnav();
     if (el.authDebug) {
       el.authDebug.hidden = !debugAuth;
     }
@@ -3438,6 +3571,41 @@
       el.purchaseModal.hidden = true;
     }
   });
+  if (el.addOrderBtn) {
+    el.addOrderBtn.addEventListener("click", openCreateOrderModal);
+  }
+  if (el.createOrderModalClose) {
+    el.createOrderModalClose.addEventListener("click", closeCreateOrderModal);
+  }
+  if (el.createOrderModal) {
+    el.createOrderModal.addEventListener("click", function (event) {
+      if (event.target === el.createOrderModal) closeCreateOrderModal();
+    });
+  }
+  if (el.podViewModalClose) {
+    el.podViewModalClose.addEventListener("click", closePodViewModal);
+  }
+  if (el.podViewModal) {
+    el.podViewModal.addEventListener("click", function (event) {
+      if (event.target === el.podViewModal) closePodViewModal();
+    });
+  }
+  if (el.orderHistoryBody) {
+    el.orderHistoryBody.addEventListener("click", function (event) {
+      var btn = event.target.closest("[data-pod-order-id]");
+      if (!btn) return;
+      fetchAndShowPod(btn.getAttribute("data-pod-order-id")).catch(function (error) {
+        if (el.orderHistoryMessage) C.showMessage(el.orderHistoryMessage, error.message, "error");
+      });
+    });
+  }
+  if (el.refreshOrderHistory) {
+    el.refreshOrderHistory.addEventListener("click", function () {
+      refreshOrderHistory().catch(function (error) {
+        if (el.orderHistoryMessage) C.showMessage(el.orderHistoryMessage, error.message, "error");
+      });
+    });
+  }
   if (el.devAuthActions) {
     el.devAuthActions.addEventListener("click", function (event) {
       onDevAuthActionClick(event).catch(function (error) {

--- a/backend/frontend/assets/styles.css
+++ b/backend/frontend/assets/styles.css
@@ -2833,6 +2833,58 @@ body.theme-admin .billing-seat-cards .stat-card small {
 
 .login-message { margin-top: 1rem; }
 
+/* ===== ORDERS SUB-NAV ===== */
+.orders-subnav-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  min-height: 44px;
+  flex-shrink: 0;
+}
+.orders-subnav {
+  display: flex;
+  gap: 2px;
+}
+.orders-subnav-tab {
+  padding: 10px 16px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  font-size: .82rem;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 140ms ease, border-color 140ms ease;
+  margin-bottom: -1px;
+}
+.orders-subnav-tab:hover { color: var(--text-heading); }
+.orders-subnav-tab.is-active {
+  color: var(--gold-bright);
+  border-bottom-color: var(--gold-primary);
+}
+.orders-add-btn {
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 4px 14px;
+}
+.orders-subpanel { display: none; flex: 1; overflow-y: auto; }
+.orders-subpanel.is-active { display: block; }
+.workspace-panel[data-workspace-panel="orders"] { display: none; flex-direction: column; }
+.workspace-panel[data-workspace-panel="orders"].is-active { display: flex; }
+
+/* ===== POD VIEW ===== */
+.pod-record { padding: 8px 0; }
+.pod-meta { font-size: .82rem; color: var(--text-muted); margin-bottom: 10px; }
+.pod-meta strong { color: var(--text); }
+.pod-photos, .pod-signatures { display: flex; flex-wrap: wrap; gap: 10px; }
+.pod-photo { max-width: 240px; max-height: 200px; border-radius: var(--radius-sm); border: 1px solid var(--border); object-fit: cover; }
+.pod-signature { max-width: 300px; max-height: 120px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: #fff; object-fit: contain; }
+
 /* ===== IN FLIGHT ===== */
 .inflight-list { display: flex; flex-direction: column; gap: 2px; }
 .inflight-empty { color: var(--text-muted); font-size: .85rem; padding: 24px 0; text-align: center; }

--- a/backend/pod_service.py
+++ b/backend/pod_service.py
@@ -102,6 +102,14 @@ class PodDataStore(ABC):
     def put_metadata(self, metadata: PodMetadataRecord) -> PodMetadataRecord:
         raise NotImplementedError
 
+    @abstractmethod
+    def list_by_order_id(self, org_id: str, order_id: str) -> List[PodMetadataRecord]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def generate_presigned_get_url(self, key: str, expires_in: int) -> str:
+        raise NotImplementedError
+
 
 class InMemoryPodDataStore(PodDataStore):
     def __init__(self):
@@ -126,6 +134,12 @@ class InMemoryPodDataStore(PodDataStore):
     def put_metadata(self, metadata: PodMetadataRecord) -> PodMetadataRecord:
         self.items[metadata.pod_id] = metadata
         return metadata
+
+    def list_by_order_id(self, org_id: str, order_id: str) -> List[PodMetadataRecord]:
+        return [r for r in self.items.values() if r.org_id == org_id and r.order_id == order_id]
+
+    def generate_presigned_get_url(self, key: str, expires_in: int) -> str:
+        return f"https://example.invalid/pod-view?key={key}"
 
 
 class DynamoS3PodDataStore(PodDataStore):
@@ -158,6 +172,26 @@ class DynamoS3PodDataStore(PodDataStore):
     def put_metadata(self, metadata: PodMetadataRecord) -> PodMetadataRecord:
         self.table.put_item(Item=metadata.model_dump(mode="json"))
         return metadata
+
+    def list_by_order_id(self, org_id: str, order_id: str) -> List[PodMetadataRecord]:
+        from boto3.dynamodb.conditions import Attr
+        response = self.table.scan(
+            FilterExpression=Attr("org_id").eq(org_id) & Attr("order_id").eq(order_id)
+        )
+        result = []
+        for item in response.get("Items", []):
+            try:
+                result.append(PodMetadataRecord(**item))
+            except Exception:
+                pass
+        return result
+
+    def generate_presigned_get_url(self, key: str, expires_in: int) -> str:
+        return self.s3.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket_name, "Key": key},
+            ExpiresIn=expires_in,
+        )
 
 
 _IN_MEMORY_POD_STORE = InMemoryPodDataStore()

--- a/backend/routers/pod.py
+++ b/backend/routers/pod.py
@@ -20,6 +20,7 @@ try:
         PodPresignRequest,
         PodPresignResponse,
         PodPresignedUpload,
+        PodViewRecord,
     )
 except ModuleNotFoundError:  # local run from backend/ directory
     from auth import ROLE_ADMIN, ROLE_DISPATCHER, ROLE_DRIVER, require_roles
@@ -39,6 +40,7 @@ except ModuleNotFoundError:  # local run from backend/ directory
         PodPresignRequest,
         PodPresignResponse,
         PodPresignedUpload,
+        PodViewRecord,
     )
 
 router = APIRouter(prefix="/pod", tags=["pod"])
@@ -135,3 +137,30 @@ async def create_pod_metadata(
         location=payload.location,
     )
     return pod_store.put_metadata(metadata)
+
+
+POD_VIEW_EXPIRES_SECONDS = 600
+
+
+@router.get("/order/{order_id}", response_model=List[PodViewRecord])
+async def list_pod_for_order(
+    order_id: str,
+    user=Depends(require_roles([ROLE_ADMIN, ROLE_DISPATCHER])),
+    pod_store=Depends(get_pod_data_store),
+):
+    _require_tenant_order(order_id, user["org_id"])
+    records = pod_store.list_by_order_id(user["org_id"], order_id)
+    result = []
+    for record in records:
+        photo_urls = [pod_store.generate_presigned_get_url(k, POD_VIEW_EXPIRES_SECONDS) for k in record.photo_keys]
+        sig_urls = [pod_store.generate_presigned_get_url(k, POD_VIEW_EXPIRES_SECONDS) for k in record.signature_keys]
+        result.append(PodViewRecord(
+            pod_id=record.pod_id,
+            order_id=record.order_id,
+            driver_id=record.driver_id,
+            captured_at=record.captured_at,
+            notes=record.notes,
+            photo_urls=photo_urls,
+            signature_urls=sig_urls,
+        ))
+    return result

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -417,6 +417,16 @@ class PodMetadataRecord(BaseModel):
     location: Optional[PodLocation] = None
 
 
+class PodViewRecord(BaseModel):
+    pod_id: str
+    order_id: str
+    driver_id: str
+    captured_at: datetime
+    notes: Optional[str] = None
+    photo_urls: List[str] = Field(default_factory=list)
+    signature_urls: List[str] = Field(default_factory=list)
+
+
 class DriverLocationRecord(BaseModel):
     org_id: str
     driver_id: str


### PR DESCRIPTION
## Summary

- **Top nav condensed from 5 → 3 items**: Dispatch, Orders, Admin. The Admin tab is hidden at runtime for Dispatcher-role users (only Admins see it).
- **Orders tab gets a sub-nav** with three sections: Orders (existing table), In Flight (moved from old top-level tab), and Order History (new).
- **Planning tab removed** — the Create Order form is now a modal opened by the `+` button in the sub-nav bar.
- **In Flight tab removed** — content (shipments list + audit logs) moved into Orders > In Flight sub-panel.
- **New Order History sub-panel** lists Delivered orders with customer, driver, pickup → delivery, created date, and a "View POD" button.
- **POD viewer modal** — clicking "View POD" calls the new `GET /pod/order/{order_id}` endpoint and renders delivery photos and signatures inline with presigned download URLs.

## Backend changes

- `PodDataStore` abstract class gains two new methods: `list_by_order_id` and `generate_presigned_get_url`, implemented in both `InMemoryPodDataStore` and `DynamoS3PodDataStore`.
- New route `GET /pod/order/{order_id}` in `routers/pod.py` — Admin/Dispatcher only — returns presigned view URLs for all POD records on an order.
- `PodViewRecord` schema added to `schemas.py`.

## Test plan

- [ ] Sign in as Admin — all 3 top nav tabs visible (Dispatch, Orders, Admin)
- [ ] Sign in as Dispatcher — Admin tab is hidden
- [ ] Click Orders tab → default "Orders" sub-panel shows the existing table/filters
- [ ] Click "In Flight" sub-tab → inflight shipments list and audit logs load
- [ ] Click "Order History" sub-tab → delivered orders load; empty state shown if none
- [ ] Click "+" button → Create Order modal opens; submit a test order → modal closes, orders list refreshes
- [ ] Click "View POD" on a delivered order → POD modal opens (shows "No proof of delivery" if no POD recorded)
- [ ] Existing Dispatch tab (map + driver list) unchanged
- [ ] Existing Admin tab content unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)