### PR TITLE
fix: custom classification rules ignored, causing valid orders to be skipped

### DIFF
--- a/backend/email_classifier.py
+++ b/backend/email_classifier.py
@@ -28,7 +28,9 @@ class SkipReason(str, Enum):
 @dataclass
 class ClassificationResult:
     is_order: bool
-    source: Optional[EmailSource] = None
+    # Parser key as a plain string. For built-in rules it equals an
+    # EmailSource value; for custom rules it is the rule's parser_type.
+    source: Optional[str] = None
     skip_reason: Optional[SkipReason] = None
     original_sender: str = ""
     original_subject: str = ""
@@ -148,27 +150,28 @@ def classify_email(
     if fwd_subject.lower().startswith("fwd:"):
         fwd_subject = fwd_subject[4:].strip()
 
-    # Check org-level custom rules first (highest priority)
+    # Check org-level custom rules first (highest priority). Rules with a
+    # specific subject_pattern are tried before empty-subject catch-alls so a
+    # catch-all can't shadow more specific parsers regardless of saved order.
     if custom_rules:
-        for rule in custom_rules:
+        ordered_rules = sorted(
+            custom_rules,
+            key=lambda r: not r.get("subject_pattern", "").strip(),
+        )
+        sender_matched = False
+        for rule in ordered_rules:
             if not rule.get("enabled", True):
                 continue
             sp = rule.get("sender_pattern", "").lower()
-            if sp and sp in original_sender.lower():
-                subj_pat = rule.get("subject_pattern", "").lower()
-                if subj_pat:
-                    if subj_pat not in original_subject.lower() and subj_pat not in fwd_subject.lower():
-                        logger.info(
-                            "Custom rule '%s' sender matched but subject did not: %s",
-                            rule.get("name", ""),
-                            original_subject,
-                        )
-                        return ClassificationResult(
-                            is_order=False,
-                            skip_reason=SkipReason.NO_SUBJECT_MATCH,
-                            original_sender=original_sender,
-                            original_subject=original_subject,
-                        )
+            if not sp or sp not in original_sender.lower():
+                continue
+            sender_matched = True
+            subj_pat = rule.get("subject_pattern", "").lower()
+            if (
+                not subj_pat
+                or subj_pat in original_subject.lower()
+                or subj_pat in fwd_subject.lower()
+            ):
                 logger.info(
                     "Custom rule '%s' matched sender %s",
                     rule.get("name", ""),
@@ -180,6 +183,18 @@ def classify_email(
                     original_sender=original_sender,
                     original_subject=original_subject,
                 )
+        if sender_matched:
+            logger.info(
+                "Custom rules matched sender %s but no subject_pattern accepted %r",
+                original_sender,
+                original_subject,
+            )
+            return ClassificationResult(
+                is_order=False,
+                skip_reason=SkipReason.NO_SUBJECT_MATCH,
+                original_sender=original_sender,
+                original_subject=original_subject,
+            )
 
     # Fall back to built-in sender rules
     for rule in _SENDER_RULES:
@@ -192,7 +207,7 @@ def classify_email(
             if subject_match:
                 return ClassificationResult(
                     is_order=True,
-                    source=rule["source"],
+                    source=rule["source"].value,
                     original_sender=original_sender,
                     original_subject=original_subject,
                 )

--- a/backend/email_poller.py
+++ b/backend/email_poller.py
@@ -97,12 +97,17 @@ def _process_org(org_config):
 
                 message = gmail.get_message(msg_id)
 
-                # Classify the email
+                # Classify the email against the org's custom rules first,
+                # then built-in rules (inside classify_email).
+                custom_rules = [
+                    rule.model_dump() for rule in (org_config.email_rules or [])
+                ]
                 result = classify_email(
                     subject=message.subject,
                     sender=message.sender,
                     html_body=message.html_body,
                     text_body=message.text_body,
+                    custom_rules=custom_rules,
                 )
 
                 if not result.is_order:
@@ -125,7 +130,7 @@ def _process_org(org_config):
                     continue
 
                 # Parse the order
-                parser = get_parser(result.source.value)
+                parser = get_parser(result.source)
                 if not parser:
                     logger.warning("Org %s: no parser for source %s", org_id, result.source)
                     continue
@@ -148,7 +153,7 @@ def _process_org(org_config):
 
                 # Use the email message ID as external_order_id for dedup
                 external_id = parsed.external_order_id or msg_id
-                source = parsed.source or result.source.value
+                source = parsed.source or result.source
 
                 # Check for duplicates
                 existing = order_store.find_order_by_external_id(org_id, source, external_id)

--- a/backend/tests/test_email_classifier.py
+++ b/backend/tests/test_email_classifier.py
@@ -260,3 +260,90 @@ def test_custom_rule_subject_checked_against_fwd_subject():
         custom_rules=[rule],
     )
     assert result.is_order is True
+
+
+# --- Multi-rule iteration ---
+
+def _rule(name, sender, subject_pattern, parser_type="email-airspace", enabled=True):
+    return {
+        "rule_id": f"rule-{name}",
+        "name": name,
+        "sender_pattern": sender,
+        "subject_pattern": subject_pattern,
+        "parser_type": parser_type,
+        "enabled": enabled,
+    }
+
+
+def test_multiple_rules_same_sender_first_fails_second_matches():
+    """When rule A (subject 'PICKUP ALERT') fails, rule B (subject 'Agent Alert') should still be evaluated."""
+    rules = [
+        _rule("vel ai", "vellogistix.com", "PICKUP ALERT", parser_type="email-airspace"),
+        _rule("vel table", "vellogistix.com", "Agent Alert", parser_type="email-cap"),
+    ]
+    result = classify_email(
+        subject="Agent Alert 2604A5414",
+        sender="dispatch@vellogistix.com",
+        custom_rules=rules,
+    )
+    assert result.is_order is True
+    assert result.source == "email-cap"
+
+
+def test_catchall_rule_after_specific_rules():
+    """With an empty-subject catch-all at the end, any sender-matching email should classify as an order."""
+    rules = [
+        _rule("vel ai", "vellogistix.com", "PICKUP ALERT", parser_type="email-airspace"),
+        _rule("vel table", "vellogistix.com", "Agent Alert", parser_type="email-cap"),
+        _rule("Marken", "vellogistix.com", "Marken", parser_type="email-marken"),
+        _rule("Ai No Subject", "vellogistix.com", "", parser_type="email-airspace"),
+    ]
+    result = classify_email(
+        subject="Tracking ID: AT4YC6GGW9, Order #: 3607991 - Delivery Dispatch",
+        sender="dispatch@vellogistix.com",
+        custom_rules=rules,
+    )
+    assert result.is_order is True
+    assert result.source == "email-airspace"
+
+
+def test_catchall_rule_sorted_last_even_if_saved_first():
+    """A catch-all placed first in saved order must not shadow a more specific rule below it."""
+    rules = [
+        _rule("Ai No Subject", "vellogistix.com", "", parser_type="email-airspace"),
+        _rule("vel table", "vellogistix.com", "Agent Alert", parser_type="email-cap"),
+    ]
+    result = classify_email(
+        subject="Agent Alert 2604A5414",
+        sender="dispatch@vellogistix.com",
+        custom_rules=rules,
+    )
+    assert result.is_order is True
+    assert result.source == "email-cap"
+
+
+def test_all_matching_sender_rules_fail_subject():
+    """If every sender-matching rule has a subject filter that fails, return NO_SUBJECT_MATCH."""
+    rules = [
+        _rule("vel ai", "vellogistix.com", "PICKUP ALERT"),
+        _rule("vel table", "vellogistix.com", "Agent Alert"),
+    ]
+    result = classify_email(
+        subject="Weekly Summary",
+        sender="dispatch@vellogistix.com",
+        custom_rules=rules,
+    )
+    assert result.is_order is False
+    assert result.skip_reason == SkipReason.NO_SUBJECT_MATCH
+
+
+def test_no_custom_rule_sender_match_falls_through_to_builtin():
+    """If no custom rule's sender matches, built-in rules should still run."""
+    unrelated_rule = _rule("other", "otherdomain.com", "anything", parser_type="email-cap")
+    result = classify_email(
+        subject="PICKUP ALERT #55555",
+        sender="no-reply@marken.com",
+        custom_rules=[unrelated_rule],
+    )
+    assert result.is_order is True
+    assert result.source == EmailSource.MARKEN

--- a/backend/tests/test_email_poller.py
+++ b/backend/tests/test_email_poller.py
@@ -1,0 +1,147 @@
+"""Tests for the email poller's orchestration of classification + parsing.
+
+Focuses on the wiring between `_process_org`, the classifier, and the Gmail
+client — specifically that the org's custom classification rules are forwarded
+to `classify_email`.
+"""
+
+import os
+import sys
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from backend import email_poller
+from backend.email_classifier import ClassificationResult, SkipReason
+from backend.email_store import (
+    get_email_config_store,
+    get_skipped_email_store,
+    reset_in_memory_email_config_store,
+)
+from backend.schemas import EmailConfig, EmailRule
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("USE_IN_MEMORY_EMAIL_STORE", "true")
+    reset_in_memory_email_config_store()
+    # Clear any skipped rows from prior tests.
+    store = get_skipped_email_store()
+    if hasattr(store, "items"):
+        store.items.clear()
+
+
+def _seed_with_rule(**rule_overrides) -> EmailConfig:
+    now = datetime.now(timezone.utc)
+    rule_fields = dict(
+        rule_id="rule-1",
+        name="Vel Logistix AI",
+        sender_pattern="vellogistix.com",
+        subject_pattern="",
+        parser_type="email-airspace",
+        enabled=True,
+        created_at=now,
+        updated_at=now,
+    )
+    rule_fields.update(rule_overrides)
+    rule = EmailRule(**rule_fields)
+    cfg = EmailConfig(
+        org_id="org-poll",
+        gmail_email="dispatcher@example.com",
+        gmail_refresh_token="tok",
+        email_connected=True,
+        connected_at=now,
+        gmail_history_id="100",
+        email_rules=[rule],
+    )
+    get_email_config_store().put_config(cfg)
+    return cfg
+
+
+def _fake_message(sender: str, subject: str):
+    msg = MagicMock()
+    msg.sender = sender
+    msg.subject = subject
+    msg.html_body = ""
+    msg.text_body = ""
+    return msg
+
+
+def test_process_org_passes_custom_rules_to_classifier():
+    """The poller must forward org_config.email_rules to classify_email."""
+    cfg = _seed_with_rule(subject_pattern="Agent Alert", parser_type="email-cap")
+
+    fake_gmail = MagicMock()
+    fake_gmail.list_new_message_ids.return_value = (["msg-1"], "200")
+    fake_gmail.has_label.return_value = False
+    fake_gmail.get_message.return_value = _fake_message(
+        sender="dispatch@vellogistix.com",
+        subject="Agent Alert 2604A5414",
+    )
+
+    captured = {}
+
+    def fake_classify(**kwargs):
+        captured.update(kwargs)
+        # Simulate a skip so the poller doesn't try to parse.
+        return ClassificationResult(
+            is_order=False,
+            skip_reason=SkipReason.NO_SUBJECT_MATCH,
+            original_sender=kwargs["sender"],
+            original_subject=kwargs["subject"],
+        )
+
+    with patch("backend.email_poller.GmailClient", return_value=fake_gmail), \
+         patch("backend.email_poller.classify_email", side_effect=fake_classify):
+        email_poller._process_org(cfg)
+
+    assert "custom_rules" in captured
+    rules = captured["custom_rules"]
+    assert len(rules) == 1
+    assert rules[0]["sender_pattern"] == "vellogistix.com"
+    assert rules[0]["subject_pattern"] == "Agent Alert"
+    assert rules[0]["parser_type"] == "email-cap"
+    assert rules[0]["enabled"] is True
+
+
+def test_process_org_passes_empty_list_when_no_rules():
+    """Orgs with no rules should still poll — classify_email receives []."""
+    now = datetime.now(timezone.utc)
+    cfg = EmailConfig(
+        org_id="org-poll",
+        gmail_email="dispatcher@example.com",
+        gmail_refresh_token="tok",
+        email_connected=True,
+        connected_at=now,
+        gmail_history_id="100",
+        email_rules=[],
+    )
+    get_email_config_store().put_config(cfg)
+
+    fake_gmail = MagicMock()
+    fake_gmail.list_new_message_ids.return_value = (["msg-1"], "200")
+    fake_gmail.has_label.return_value = False
+    fake_gmail.get_message.return_value = _fake_message(
+        sender="unknown@example.com",
+        subject="anything",
+    )
+
+    captured = {}
+
+    def fake_classify(**kwargs):
+        captured.update(kwargs)
+        return ClassificationResult(
+            is_order=False,
+            skip_reason=SkipReason.NO_SENDER_MATCH,
+            original_sender=kwargs["sender"],
+            original_subject=kwargs["subject"],
+        )
+
+    with patch("backend.email_poller.GmailClient", return_value=fake_gmail), \
+         patch("backend.email_poller.classify_email", side_effect=fake_classify):
+        email_poller._process_org(cfg)
+
+    assert captured.get("custom_rules") == []


### PR DESCRIPTION
## Summary

- **Custom rules were never passed to the classifier.** `email_poller.py` called `classify_email()` without the `custom_rules` parameter, so all user-defined rules were silently ignored. Emails from `dispatch@vellogistix.com` fell through to the hard-coded Airspace built-in rule, which requires a strict `Tracking ID: … Dispatch` subject pattern — rejecting everything else with `no_subject_match`.
- **First sender-match short-circuited the loop.** The classifier returned `NO_SUBJECT_MATCH` on the very first rule whose sender matched but subject didn't, meaning fallback rules (including the "Ai No Subject" catch-all) were never evaluated.
- **`result.source` type mismatch.** Built-in rules set `source` to an `EmailSource` enum; custom rules set it to a plain string. The poller called `.value` on it unconditionally, which would have crashed at runtime as soon as custom rules were actually used.

## Changes

### `backend/email_poller.py`
- Serialize `org_config.email_rules` via `model_dump()` and forward them as `custom_rules` to `classify_email`.
- Remove `.value` calls on `result.source` — now always a plain string.

### `backend/email_classifier.py`
- **Evaluate all enabled rules** whose sender matches before reporting `NO_SUBJECT_MATCH`.
- **Auto-sort empty-subject (catch-all) rules last** (stable sort, preserving relative order within each group) so a catch-all can't shadow more specific rules regardless of the order saved in the admin table.
- Normalize `ClassificationResult.source` to `Optional[str]`; built-in rule path now stores `.value` explicitly.

### Tests
- **`test_email_classifier.py`** — 5 new tests: multi-rule same-sender iteration, catch-all fallback, catch-all auto-sorted last even when saved first, all-subjects-fail returns `NO_SUBJECT_MATCH`, and no-custom-sender-match falls through to built-ins.
- **`tests/test_email_poller.py`** (new file) — 2 tests asserting `_process_org` forwards `custom_rules` with the correct shape, and passes `[]` when the org has no rules.

## Test plan

- [ ] `python -m pytest backend/tests/test_email_classifier.py backend/tests/test_email_poller.py backend/tests/test_gmail_reauth.py backend/tests/test_email_rules.py -v` — all pass (68 tests)
- [ ] Deploy to dev, configure the four vellogistix rules shown in the bug report, send emails with subjects "Agent Alert …", "Marken - PICKUP ALERT …", and "Tracking ID: …" — confirm they appear as orders, not in Skipped Emails
- [ ] Confirm an unrelated sender's email still skips with `no_sender_match`

🤖 Generated with [Claude Code](https://claude.com/claude-code)