### PR TITLE
ci: remove stale Java handler verification from deploy-dev workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -110,28 +110,6 @@ jobs:
         run: |
           echo "=== .aws-sam/build tree ==="
           find .aws-sam/build -maxdepth 4 -type d -print || true
-          echo "=== Handler classes found ==="
-          find .aws-sam/build -type f -path '*/com/discra/api/*Handler.class' -print || true
-
-      - name: Verify handlers exist in SAM build
-        shell: bash
-        run: |
-          set -euo pipefail
-          have_class () {
-            local classpath="$1"
-            if find .aws-sam/build -type f -path "*/${classpath}" | grep -q . ; then return 0; fi
-            local jars; jars=$(find .aws-sam/build -type f -name '*.jar' || true)
-            if [ -n "$jars" ]; then
-              for j in $jars; do
-                if jar tf "$j" | grep -q "^${classpath}$" ; then return 0; fi
-              done
-            fi
-            return 1
-          }
-          for C in HealthHandler VersionHandler AdminPingHandler; do
-            CP="com/discra/api/${C}.class"
-            if have_class "$CP"; then echo "✅ Found $CP"; else echo "❌ Missing $CP"; exit 1; fi
-          done
 
       # Avoid CFN stack lock
       - name: Wait if stack update is in progress


### PR DESCRIPTION
## Summary

The Deploy Dev workflow was checking for compiled Java `.class` files for `HealthHandler`, `VersionHandler`, and `AdminPingHandler` — three stub functions that were removed from `template.yaml` in #137. This caused the post-merge deploy on `main` to fail immediately at the "Verify handlers exist in SAM build" step.

Removes the entire verification step (and the related handler-class search in "Show SAM build outputs") since there are no longer any Java Lambda functions in the template.

## Test plan
- [ ] Deploy Dev workflow passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)