### PR TITLE
Dispatch redesign + server-side driver simulator

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -59,6 +59,7 @@ try:
         push_router,
         reports_router,
         routes_router,
+        simulator_router,
     )
 except ModuleNotFoundError:  # local run from backend/ directory
     from auth import (  # type: ignore
@@ -88,6 +89,7 @@ except ModuleNotFoundError:  # local run from backend/ directory
         push_router,
         reports_router,
         routes_router,
+        simulator_router,
     )
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
@@ -745,6 +747,7 @@ def create_app() -> FastAPI:
     app.include_router(onboarding_router)
     app.include_router(push_router)
     app.include_router(email_router)
+    app.include_router(simulator_router)
     app.include_router(identity_router, prefix="/backend")
     app.include_router(orders_router, prefix="/backend")
     app.include_router(drivers_router, prefix="/backend")
@@ -755,6 +758,7 @@ def create_app() -> FastAPI:
     app.include_router(onboarding_router, prefix="/backend")
     app.include_router(push_router, prefix="/backend")
     app.include_router(email_router, prefix="/backend")
+    app.include_router(simulator_router, prefix="/backend")
     app.include_router(identity_router, prefix="/dev/backend")
     app.include_router(orders_router, prefix="/dev/backend")
     app.include_router(drivers_router, prefix="/dev/backend")
@@ -765,6 +769,7 @@ def create_app() -> FastAPI:
     app.include_router(onboarding_router, prefix="/dev/backend")
     app.include_router(push_router, prefix="/dev/backend")
     app.include_router(email_router, prefix="/dev/backend")
+    app.include_router(simulator_router, prefix="/dev/backend")
 
     return app
 

--- a/backend/frontend/simulator.html
+++ b/backend/frontend/simulator.html
@@ -95,6 +95,10 @@
         <div class="sim-label">Update interval (seconds)</div>
         <input id="update-interval" class="sim-input" type="number" value="5" min="2" max="60">
       </div>
+      <div style="margin-bottom:8px;">
+        <div class="sim-label">Speed (mph)</div>
+        <input id="speed-mph" class="sim-input" type="number" value="30" min="1" max="120">
+      </div>
       <div class="sim-row">
         <button id="btn-spawn" class="sim-btn sim-btn-accent">Spawn Drivers</button>
         <button id="btn-stop" class="sim-btn sim-btn-red" disabled>Stop All</button>
@@ -150,10 +154,19 @@
   var updateCount = 0;
   var devAuthCookie = null;
 
+  // Dispatch behaviour constants
+  var ARRIVAL_THRESHOLD_M = 10;
+  var DEFAULT_SPEED_MPH = 30;
+  var MPH_TO_MPS = 0.44704;
+
+  // Caches
+  var geocodeCache = new Map(); // lower(addr) -> {lat,lng} | null
+
   // DOM
   var elDriverCount = document.getElementById("driver-count");
   var elArea = document.getElementById("sim-area");
   var elInterval = document.getElementById("update-interval");
+  var elSpeedMph = document.getElementById("speed-mph");
   var elSpawn = document.getElementById("btn-spawn");
   var elStop = document.getElementById("btn-stop");
   var elClear = document.getElementById("btn-clear");
@@ -196,21 +209,111 @@
     return ((Math.atan2(y, x) * 180 / Math.PI) + 360) % 360;
   }
 
-  function moveToward(driver, speed) {
-    var dlat = driver.dest.lat - driver.lat;
-    var dlng = driver.dest.lng - driver.lng;
-    var dist = Math.sqrt(dlat*dlat + dlng*dlng);
-    if (dist < 0.001) {
-      // Arrived — pick new destination
-      var area = AREAS[elArea.value] || AREAS.fortworth;
-      driver.dest = randomDestInArea(area);
+  function haversineMeters(lat1, lng1, lat2, lng2) {
+    var R = 6371000;
+    var p1 = lat1 * Math.PI / 180;
+    var p2 = lat2 * Math.PI / 180;
+    var dp = (lat2 - lat1) * Math.PI / 180;
+    var dl = (lng2 - lng1) * Math.PI / 180;
+    var a = Math.sin(dp/2)*Math.sin(dp/2) + Math.cos(p1)*Math.cos(p2)*Math.sin(dl/2)*Math.sin(dl/2);
+    return 2 * R * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+  }
+
+  function pickupAddrFromOrder(o) {
+    var s = [o.pick_up_street, o.pick_up_city, o.pick_up_state, o.pick_up_zip].filter(Boolean).join(", ");
+    return s || o.pick_up_address || "";
+  }
+  function deliveryAddrFromOrder(o) {
+    var s = [o.delivery_street, o.delivery_city, o.delivery_state, o.delivery_zip].filter(Boolean).join(", ");
+    return s || o.delivery || "";
+  }
+  function refLabel(o) {
+    return "#" + (o.reference_id || (o.reference_number != null ? String(o.reference_number) : o.id.slice(0, 8)));
+  }
+
+  async function geocode(address) {
+    var key = (address || "").trim().toLowerCase();
+    if (!key) return null;
+    if (geocodeCache.has(key)) return geocodeCache.get(key);
+    try {
+      var r = await fetch("https://photon.komoot.io/api/?q=" + encodeURIComponent(address) + "&limit=1");
+      var data = await r.json();
+      if (!data.features || !data.features.length) {
+        geocodeCache.set(key, null);
+        return null;
+      }
+      var c = data.features[0].geometry.coordinates;
+      var result = { lat: c[1], lng: c[0] };
+      geocodeCache.set(key, result);
+      return result;
+    } catch(e) {
+      geocodeCache.set(key, null);
+      return null;
+    }
+  }
+
+  async function fetchOsrmRoute(fromLat, fromLng, toLat, toLng) {
+    try {
+      var url = "https://router.project-osrm.org/route/v1/driving/" +
+        fromLng + "," + fromLat + ";" + toLng + "," + toLat +
+        "?overview=full&geometries=geojson";
+      var r = await fetch(url);
+      var data = await r.json();
+      if (data.code !== "Ok" || !data.routes || !data.routes.length) {
+        return [{ lat: fromLat, lng: fromLng }, { lat: toLat, lng: toLng }];
+      }
+      return data.routes[0].geometry.coordinates.map(function(c) {
+        return { lat: c[1], lng: c[0] };
+      });
+    } catch(e) {
+      return [{ lat: fromLat, lng: fromLng }, { lat: toLat, lng: toLng }];
+    }
+  }
+
+  // Walk along driver.route by stepM meters, advancing routeIndex segments.
+  function advanceAlongRoute(driver, stepM) {
+    var route = driver.route;
+    if (!route || route.length < 2) return;
+    var remaining = stepM;
+    while (remaining > 0 && driver.routeIndex < route.length - 1) {
+      var b = route[driver.routeIndex + 1];
+      var segDist = haversineMeters(driver.lat, driver.lng, b.lat, b.lng);
+      if (segDist < 0.1) {
+        driver.routeIndex++;
+        continue;
+      }
+      if (remaining >= segDist) {
+        driver.heading = bearing(driver.lat, driver.lng, b.lat, b.lng);
+        driver.lat = b.lat;
+        driver.lng = b.lng;
+        driver.routeIndex++;
+        remaining -= segDist;
+      } else {
+        var ratio = remaining / segDist;
+        var newLat = driver.lat + (b.lat - driver.lat) * ratio;
+        var newLng = driver.lng + (b.lng - driver.lng) * ratio;
+        driver.heading = bearing(driver.lat, driver.lng, b.lat, b.lng);
+        driver.lat = newLat;
+        driver.lng = newLng;
+        remaining = 0;
+      }
+    }
+  }
+
+  function moveTowardRoam(driver, stepM) {
+    var area = AREAS[elArea.value] || AREAS.fortworth;
+    if (!driver.roamDest) driver.roamDest = randomDestInArea(area);
+    var dist = haversineMeters(driver.lat, driver.lng, driver.roamDest.lat, driver.roamDest.lng);
+    if (dist < stepM) {
+      driver.lat = driver.roamDest.lat;
+      driver.lng = driver.roamDest.lng;
+      driver.roamDest = randomDestInArea(area);
       return;
     }
-    var step = speed + (Math.random() - 0.5) * speed * 0.3; // slight randomness
-    var ratio = Math.min(step / dist, 1);
-    driver.lat += dlat * ratio;
-    driver.lng += dlng * ratio;
-    driver.heading = bearing(driver.lat, driver.lng, driver.dest.lat, driver.dest.lng);
+    var ratio = stepM / dist;
+    driver.heading = bearing(driver.lat, driver.lng, driver.roamDest.lat, driver.roamDest.lng);
+    driver.lat += (driver.roamDest.lat - driver.lat) * ratio;
+    driver.lng += (driver.roamDest.lng - driver.lng) * ratio;
   }
 
   async function loginAsDriver(driverId, orgId) {
@@ -228,10 +331,8 @@
     }
   }
 
-  async function sendLocation(driver) {
+  async function sendLocationOnly(driver) {
     try {
-      // Login as this driver first (sets cookie)
-      await loginAsDriver(driver.id, "org-pilot-1");
       await C.requestJson(apiBase, "/drivers/location", {
         method: "POST",
         json: { lat: driver.lat, lng: driver.lng, heading: driver.heading },
@@ -242,6 +343,92 @@
     } catch(e) {
       log("Location failed for " + driver.name + ": " + e.message);
       return false;
+    }
+  }
+
+  async function fetchInbox() {
+    try {
+      return await C.requestJson(apiBase, "/orders/driver/inbox", { method: "GET" });
+    } catch(e) {
+      return [];
+    }
+  }
+
+  async function postStatus(orderId, status) {
+    try {
+      await C.requestJson(apiBase, "/orders/" + orderId + "/status", {
+        method: "POST",
+        json: { status: status },
+      });
+      return true;
+    } catch(e) {
+      log("Status update failed: " + e.message);
+      return false;
+    }
+  }
+
+  async function planRoute(driver, address) {
+    var coord = await geocode(address);
+    if (!coord) return false;
+    var route = await fetchOsrmRoute(driver.lat, driver.lng, coord.lat, coord.lng);
+    driver.route = route;
+    driver.routeIndex = 0;
+    driver.target = coord;
+    return true;
+  }
+
+  // Read driver's inbox (already authenticated) and progress dispatch state machine.
+  async function processDispatch(driver) {
+    var inbox = await fetchInbox();
+    var active = inbox.filter(function(o) {
+      return o.status !== "Delivered" && o.status !== "Failed";
+    });
+    var order = active.length ? active[0] : null;
+
+    if (!order) {
+      if (driver.state !== "roaming") {
+        driver.state = "roaming";
+        driver.activeOrderId = null;
+        driver.route = null;
+        driver.target = null;
+        log(driver.name + " → roaming");
+      }
+      return;
+    }
+
+    var pickupAddr = pickupAddrFromOrder(order);
+    var deliveryAddr = deliveryAddrFromOrder(order);
+
+    if (order.status === "Assigned") {
+      if (driver.state !== "to_pickup" || driver.activeOrderId !== order.id) {
+        var ok = await planRoute(driver, pickupAddr);
+        if (!ok) { log(driver.name + ": couldn't geocode pickup '" + pickupAddr + "'"); return; }
+        driver.state = "to_pickup";
+        driver.activeOrderId = order.id;
+        log(driver.name + " → pickup for " + refLabel(order));
+      }
+      if (driver.target && haversineMeters(driver.lat, driver.lng, driver.target.lat, driver.target.lng) < ARRIVAL_THRESHOLD_M) {
+        await postStatus(order.id, "PickedUp");
+        log(driver.name + " ↑ PickedUp " + refLabel(order));
+        var ok2 = await planRoute(driver, deliveryAddr);
+        if (!ok2) { log(driver.name + ": couldn't geocode delivery '" + deliveryAddr + "'"); return; }
+        driver.state = "to_delivery";
+      }
+    } else if (order.status === "PickedUp" || order.status === "EnRoute") {
+      if (driver.state !== "to_delivery" || driver.activeOrderId !== order.id) {
+        var ok3 = await planRoute(driver, deliveryAddr);
+        if (!ok3) return;
+        driver.state = "to_delivery";
+        driver.activeOrderId = order.id;
+      }
+      if (driver.target && haversineMeters(driver.lat, driver.lng, driver.target.lat, driver.target.lng) < ARRIVAL_THRESHOLD_M) {
+        await postStatus(order.id, "Delivered");
+        log(driver.name + " ✓ Delivered " + refLabel(order));
+        driver.state = "roaming";
+        driver.activeOrderId = null;
+        driver.route = null;
+        driver.target = null;
+      }
     }
   }
 
@@ -274,9 +461,14 @@
         color: color,
         lat: pos.lat,
         lng: pos.lng,
-        dest: dest,
+        roamDest: dest,
         heading: 0,
         marker: marker,
+        state: "roaming",
+        activeOrderId: null,
+        route: null,
+        routeIndex: 0,
+        target: null,
         active: true,
       });
 
@@ -288,28 +480,50 @@
     startSimulation();
   }
 
+  function stateLabel(d) {
+    if (d.state === "to_pickup") return "→ Pickup";
+    if (d.state === "to_delivery") return "→ Delivery";
+    return "Roaming";
+  }
+
   function renderDriverCards() {
     if (!simDrivers.length) {
       elDriverList.innerHTML = '<div style="color:var(--text-muted);font-size:.8rem;">No drivers spawned.</div>';
       return;
     }
     elDriverList.innerHTML = simDrivers.map(function(d) {
+      var statusLine = d.active
+        ? stateLabel(d) + " · " + d.lat.toFixed(4) + ", " + d.lng.toFixed(4)
+        : "Stopped";
       return '<div class="sim-driver-card' + (d.active ? ' active' : '') + '">' +
         '<div class="sim-driver-dot' + (d.active ? ' online' : '') + '" style="' + (d.active ? 'background:'+d.color : '') + '"></div>' +
         '<div class="sim-driver-info"><div class="sim-driver-name">' + d.name + '</div>' +
-        '<div class="sim-driver-status">' + (d.active ? d.lat.toFixed(4) + ', ' + d.lng.toFixed(4) : 'Stopped') + '</div></div>' +
+        '<div class="sim-driver-status">' + statusLine + '</div></div>' +
         '</div>';
     }).join("");
   }
 
   async function tickAll() {
-    var speed = 0.002; // ~200m per tick
+    var speedMph = parseFloat(elSpeedMph.value) || DEFAULT_SPEED_MPH;
+    var intervalSec = parseInt(elInterval.value) || 5;
+    var stepM = speedMph * MPH_TO_MPS * intervalSec;
+
     var active = simDrivers.filter(function(d) { return d.active; });
     for (var i = 0; i < active.length; i++) {
       var d = active[i];
-      moveToward(d, speed);
+      var authed = await loginAsDriver(d.id, "org-pilot-1");
+      if (!authed) continue;
+
+      await processDispatch(d);
+
+      if (d.state === "roaming" || !d.route) {
+        moveTowardRoam(d, stepM);
+      } else {
+        advanceAlongRoute(d, stepM);
+      }
+
       d.marker.setLngLat([d.lng, d.lat]);
-      await sendLocation(d);
+      await sendLocationOnly(d);
     }
     renderDriverCards();
   }

--- a/backend/geocode_service.py
+++ b/backend/geocode_service.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, Optional
 
+import requests
+
 try:
     import boto3
 except ImportError:  # pragma: no cover - boto3 available in Lambda
@@ -128,20 +130,73 @@ class AmazonLocationAddressGeocoder(AddressGeocoder):
         return GeocodePoint(lat=lat, lng=lng, source="amazon-location")
 
 
+class PhotonAddressGeocoder(AddressGeocoder):
+    """Free, public Photon (Komoot) geocoder. No auth required.
+
+    Used as the local-dev fallback when Amazon Location Service isn't
+    configured — replaces the previous hash-based dev geocoder which mapped
+    any address to a random-looking continental US lat/lng.
+    """
+
+    _ENDPOINT = "https://photon.komoot.io/api/"
+    # Photon blocks the default python-requests UA with 403; identify ourselves.
+    _USER_AGENT = "Discra/0.1 (dev geocoder)"
+
+    def __init__(self, timeout_s: float = 5.0):
+        self.timeout_s = timeout_s
+
+    def geocode(self, address: str) -> Optional[GeocodePoint]:
+        if not address or not address.strip():
+            return None
+        inline = _parse_inline_lat_lng(address)
+        if inline:
+            return inline
+        try:
+            r = requests.get(
+                self._ENDPOINT,
+                params={"q": address, "limit": 1},
+                timeout=self.timeout_s,
+                headers={"User-Agent": self._USER_AGENT},
+            )
+            r.raise_for_status()
+            data = r.json()
+            features = data.get("features") or []
+            if not features:
+                return None
+            coords = features[0].get("geometry", {}).get("coordinates", [])
+            if len(coords) != 2:
+                return None
+            lng, lat = float(coords[0]), float(coords[1])
+            if not _is_valid_lat_lng(lat, lng):
+                return None
+            return GeocodePoint(lat=lat, lng=lng, source="photon")
+        except Exception:
+            return None
+
+
 _IN_MEMORY_ADDRESS_GEOCODER = InMemoryAddressGeocoder()
+_PHOTON_ADDRESS_GEOCODER = PhotonAddressGeocoder()
 
 
 def get_address_geocoder() -> AddressGeocoder:
+    # Tests can opt into the deterministic in-memory geocoder explicitly.
     force_memory = _as_bool(os.environ.get("USE_IN_MEMORY_GEOCODER"), default=False)
     if force_memory:
         return _IN_MEMORY_ADDRESS_GEOCODER
 
+    # Production prefers AWS Location Service.
     place_index_name = (os.environ.get("LOCATION_PLACE_INDEX_NAME") or "").strip()
     if place_index_name:
         try:
             return AmazonLocationAddressGeocoder(place_index_name=place_index_name)
         except Exception:
-            return _IN_MEMORY_ADDRESS_GEOCODER
+            pass  # fall through
+
+    # Default for local dev: Photon. Set DISABLE_PHOTON_GEOCODER=true to fall
+    # back to the in-memory hash geocoder (e.g. for offline test runs).
+    if not _as_bool(os.environ.get("DISABLE_PHOTON_GEOCODER"), default=False):
+        return _PHOTON_ADDRESS_GEOCODER
+
     return _IN_MEMORY_ADDRESS_GEOCODER
 
 

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -8,6 +8,7 @@ from .pod import router as pod_router
 from .push import router as push_router
 from .reports import router as reports_router
 from .routes import router as routes_router
+from .simulator import router as simulator_router
 
 __all__ = [
     "billing_router",
@@ -20,4 +21,5 @@ __all__ = [
     "push_router",
     "reports_router",
     "routes_router",
+    "simulator_router",
 ]

--- a/backend/routers/simulator.py
+++ b/backend/routers/simulator.py
@@ -1,0 +1,137 @@
+"""HTTP control surface for the in-process dispatch simulator.
+
+Restricted to a small allow-list of usernames (dev tool, not for general
+admin use). Add usernames via SIMULATOR_ALLOWED_USERNAMES env var
+(comma-separated). Defaults to {"cody.carmichael"}.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+try:
+    from backend.auth import ROLE_ADMIN, ROLE_DISPATCHER, require_roles
+    from backend.simulator_service import AREAS, get_simulator, seed_orders
+except ModuleNotFoundError:  # local run from backend/ directory
+    from auth import ROLE_ADMIN, ROLE_DISPATCHER, require_roles  # type: ignore
+    from simulator_service import AREAS, get_simulator, seed_orders  # type: ignore
+
+
+router = APIRouter(prefix="/admin/simulator", tags=["simulator"])
+
+
+def _allowed_usernames() -> set[str]:
+    raw = os.environ.get("SIMULATOR_ALLOWED_USERNAMES", "").strip()
+    if not raw:
+        return {"cody.carmichael"}
+    return {u.strip().lower() for u in raw.split(",") if u.strip()}
+
+
+def _ensure_allowed(user: dict) -> None:
+    allowed = _allowed_usernames()
+    candidates = {
+        str(user.get("username") or "").strip().lower(),
+        str(user.get("email") or "").strip().lower().split("@")[0],
+        str(user.get("sub") or "").strip().lower(),
+    }
+    if not (candidates & allowed):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="simulator is not enabled for this account",
+        )
+
+
+class SpawnRequest(BaseModel):
+    count: int = Field(default=5, ge=1, le=20)
+    area: str = Field(default="fortworth")
+    interval_sec: float = Field(default=5.0, ge=2.0, le=60.0)
+    speed_mph: float = Field(default=30.0, ge=1.0, le=120.0)
+
+
+class DriverSnapshot(BaseModel):
+    id: str
+    name: str
+    lat: float
+    lng: float
+    heading: float
+    state: str
+    active_order_id: Optional[str] = None
+
+
+class SimulatorConfig(BaseModel):
+    area: str
+    interval_sec: float
+    speed_mph: float
+
+
+class SimulatorStatus(BaseModel):
+    running: bool
+    update_count: int
+    config: Optional[SimulatorConfig] = None
+    drivers: List[DriverSnapshot] = Field(default_factory=list)
+
+
+@router.post("/spawn", response_model=SimulatorStatus)
+async def spawn(
+    payload: SpawnRequest,
+    user=Depends(require_roles([ROLE_ADMIN, ROLE_DISPATCHER])),
+):
+    _ensure_allowed(user)
+    if payload.area not in AREAS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unknown area '{payload.area}'",
+        )
+    sim = get_simulator()
+    return await sim.spawn(
+        org_id=user["org_id"],
+        count=payload.count,
+        area_key=payload.area,
+        interval_sec=payload.interval_sec,
+        speed_mph=payload.speed_mph,
+    )
+
+
+@router.post("/stop", response_model=SimulatorStatus)
+async def stop(user=Depends(require_roles([ROLE_ADMIN, ROLE_DISPATCHER]))):
+    _ensure_allowed(user)
+    sim = get_simulator()
+    return await sim.stop()
+
+
+@router.get("/status", response_model=SimulatorStatus)
+async def get_status(user=Depends(require_roles([ROLE_ADMIN, ROLE_DISPATCHER]))):
+    _ensure_allowed(user)
+    return get_simulator().status()
+
+
+class SeedOrdersRequest(BaseModel):
+    count: int = Field(default=5, ge=1, le=20)
+    area: str = Field(default="fortworth")
+
+
+class SeedOrdersResponse(BaseModel):
+    created: int
+    order_ids: List[str]
+
+
+@router.post("/seed-orders", response_model=SeedOrdersResponse)
+async def seed_orders_endpoint(
+    payload: SeedOrdersRequest,
+    user=Depends(require_roles([ROLE_ADMIN, ROLE_DISPATCHER])),
+):
+    _ensure_allowed(user)
+    if payload.area not in AREAS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unknown area '{payload.area}'",
+        )
+    orders = seed_orders(org_id=user["org_id"], area_key=payload.area, count=payload.count)
+    return SeedOrdersResponse(
+        created=len(orders),
+        order_ids=[o.id for o in orders],
+    )

--- a/backend/simulator_service.py
+++ b/backend/simulator_service.py
@@ -1,0 +1,525 @@
+"""In-memory dispatch simulator.
+
+Spawns N synthetic drivers in a chosen city area, has them roam by default,
+react to order assignments by traveling (OSRM-routed) to pickup → delivery,
+and progresses order status on arrival. Drives `location_store` and
+`order_store` directly — no HTTP, no auth juggling.
+
+State is process-local: lost on backend restart. That's fine for a dev tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import random
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+import requests
+
+try:
+    from backend.location_service import build_driver_location_record, get_driver_location_store
+    from backend.order_store import get_order_store
+    from backend.schemas import LocationUpdate, Order, OrderStatus
+except ModuleNotFoundError:  # local run from backend/ directory
+    from location_service import build_driver_location_record, get_driver_location_store  # type: ignore
+    from order_store import get_order_store  # type: ignore
+    from schemas import LocationUpdate, Order, OrderStatus  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+# Tunables
+ARRIVAL_THRESHOLD_M = 10.0
+MPH_TO_MPS = 0.44704
+PHOTON_TIMEOUT_S = 5
+OSRM_TIMEOUT_S = 8
+
+AREAS: Dict[str, Dict[str, float]] = {
+    "fortworth": {"lat": 32.7555, "lng": -97.3308, "r": 0.08},
+    "dallas":    {"lat": 32.7767, "lng": -96.7970, "r": 0.10},
+    "austin":    {"lat": 30.2672, "lng": -97.7431, "r": 0.08},
+    "houston":   {"lat": 29.7604, "lng": -95.3698, "r": 0.12},
+    "nyc":       {"lat": 40.7128, "lng": -74.0060, "r": 0.06},
+    "la":        {"lat": 34.0522, "lng": -118.2437, "r": 0.10},
+}
+
+DRIVER_NAMES = [
+    "Alex Rivera", "Jordan Lee", "Taylor Kim", "Morgan Chen", "Casey Brooks",
+    "Riley Thompson", "Avery Garcia", "Quinn Martinez", "Drew Wilson", "Cameron Davis",
+    "Skyler Patel", "Dakota Nguyen", "Hayden Lopez", "Parker Adams", "Sawyer Hill",
+    "Finley Clark", "Emery Scott", "Reese Baker", "Blake Turner", "Rowan James",
+]
+
+# Curated, real-ish addresses per area. They need to geocode through Photon so
+# the simulator can plot OSRM routes to them when assigned.
+SEED_ADDRESSES: Dict[str, List[Tuple[str, str, str, str]]] = {
+    "fortworth": [
+        ("100 W Weatherford St", "Fort Worth", "TX", "76102"),
+        ("1300 Lancaster Ave", "Fort Worth", "TX", "76102"),
+        ("3501 Camp Bowie Blvd", "Fort Worth", "TX", "76107"),
+        ("500 Commerce St", "Fort Worth", "TX", "76102"),
+        ("4200 South Fwy", "Fort Worth", "TX", "76115"),
+        ("2900 W 7th St", "Fort Worth", "TX", "76107"),
+        ("1600 Main St", "Fort Worth", "TX", "76164"),
+        ("2200 University Dr", "Fort Worth", "TX", "76107"),
+    ],
+    "dallas": [
+        ("411 Elm St", "Dallas", "TX", "75202"),
+        ("2401 Victory Park Ln", "Dallas", "TX", "75219"),
+        ("3000 Pegasus Park Dr", "Dallas", "TX", "75247"),
+        ("8687 N Central Expy", "Dallas", "TX", "75225"),
+        ("1717 N Harwood St", "Dallas", "TX", "75201"),
+        ("2403 Flora St", "Dallas", "TX", "75201"),
+        ("5500 Greenville Ave", "Dallas", "TX", "75206"),
+        ("13355 Noel Rd", "Dallas", "TX", "75240"),
+    ],
+    "austin": [
+        ("1100 Congress Ave", "Austin", "TX", "78701"),
+        ("2901 S Capital of Texas Hwy", "Austin", "TX", "78746"),
+        ("301 W 6th St", "Austin", "TX", "78701"),
+        ("2300 Manor Rd", "Austin", "TX", "78722"),
+        ("11410 Century Oaks Ter", "Austin", "TX", "78758"),
+        ("500 E Cesar Chavez St", "Austin", "TX", "78701"),
+        ("4001 N Lamar Blvd", "Austin", "TX", "78756"),
+        ("2110 S Lamar Blvd", "Austin", "TX", "78704"),
+    ],
+    "houston": [
+        ("1200 McKinney St", "Houston", "TX", "77010"),
+        ("8400 Westpark Dr", "Houston", "TX", "77063"),
+        ("5615 Kirby Dr", "Houston", "TX", "77005"),
+        ("2727 Allen Pkwy", "Houston", "TX", "77019"),
+        ("9999 Bellaire Blvd", "Houston", "TX", "77036"),
+        ("4848 Loop Central Dr", "Houston", "TX", "77081"),
+        ("1500 Westheimer Rd", "Houston", "TX", "77006"),
+        ("11100 Northwest Fwy", "Houston", "TX", "77092"),
+    ],
+    "nyc": [
+        ("350 5th Ave", "New York", "NY", "10118"),
+        ("11 Wall St", "New York", "NY", "10005"),
+        ("200 Park Ave", "New York", "NY", "10166"),
+        ("405 Lexington Ave", "New York", "NY", "10174"),
+        ("1 World Trade Center", "New York", "NY", "10007"),
+        ("4 Times Sq", "New York", "NY", "10036"),
+        ("89 E 42nd St", "New York", "NY", "10017"),
+        ("250 Broadway", "New York", "NY", "10007"),
+    ],
+    "la": [
+        ("633 W 5th St", "Los Angeles", "CA", "90071"),
+        ("1100 S Hope St", "Los Angeles", "CA", "90015"),
+        ("6801 Hollywood Blvd", "Los Angeles", "CA", "90028"),
+        ("9876 Wilshire Blvd", "Beverly Hills", "CA", "90210"),
+        ("100 Universal City Plaza", "Universal City", "CA", "91608"),
+        ("2999 Olympic Blvd", "Santa Monica", "CA", "90404"),
+        ("400 World Way", "Los Angeles", "CA", "90045"),
+        ("1855 Industrial St", "Los Angeles", "CA", "90021"),
+    ],
+}
+
+CUSTOMER_NAMES = [
+    "Tarrant Logistics", "West 7th Couriers", "Sundance Express",
+    "Bluebonnet Freight", "Summit Cargo", "Pioneer Trucking",
+    "Lone Star Delivery", "Big D Logistics", "Texas Rush",
+    "Ironhorse Hauling", "Compass Couriers", "Crescent Cargo",
+    "Vanguard Freight", "Cascade Logistics", "Beacon Delivery",
+]
+
+
+def _haversine_m(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    R = 6371000.0
+    p1 = math.radians(lat1)
+    p2 = math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lng2 - lng1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * R * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _bearing(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    dl = math.radians(lng2 - lng1)
+    y = math.sin(dl) * math.cos(math.radians(lat2))
+    x = (
+        math.cos(math.radians(lat1)) * math.sin(math.radians(lat2))
+        - math.sin(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.cos(dl)
+    )
+    return (math.degrees(math.atan2(y, x)) + 360) % 360
+
+
+def _random_in_area(area: Dict[str, float]) -> Tuple[float, float]:
+    return (
+        area["lat"] + (random.random() - 0.5) * 2 * area["r"],
+        area["lng"] + (random.random() - 0.5) * 2 * area["r"],
+    )
+
+
+@dataclass
+class _Driver:
+    id: str
+    name: str
+    lat: float
+    lng: float
+    heading: float = 0.0
+    state: str = "roaming"  # "roaming" | "to_pickup" | "to_delivery"
+    active_order_id: Optional[str] = None
+    route: List[Tuple[float, float]] = field(default_factory=list)
+    target: Optional[Tuple[float, float]] = None
+    roam_dest: Optional[Tuple[float, float]] = None
+
+
+@dataclass
+class _Config:
+    org_id: str
+    area_key: str
+    interval_sec: float
+    speed_mph: float
+
+
+class _Simulator:
+    def __init__(self) -> None:
+        self._drivers: Dict[str, _Driver] = {}
+        self._config: Optional[_Config] = None
+        self._task: Optional[asyncio.Task] = None
+        self._lock = asyncio.Lock()
+        self._geocode_cache: Dict[str, Optional[Tuple[float, float]]] = {}
+        self._update_count = 0
+
+    @property
+    def running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    async def spawn(
+        self,
+        *,
+        org_id: str,
+        count: int,
+        area_key: str,
+        interval_sec: float,
+        speed_mph: float,
+    ) -> dict:
+        async with self._lock:
+            await self._stop_locked()
+            count = max(1, min(int(count), 20))
+            area = AREAS.get(area_key, AREAS["fortworth"])
+            self._drivers.clear()
+            self._geocode_cache.clear()
+            self._update_count = 0
+            for i in range(count):
+                name = DRIVER_NAMES[i % len(DRIVER_NAMES)]
+                slug = name.lower().replace(" ", "-")
+                driver_id = f"sim-{slug}-{uuid.uuid4().hex[:6]}"
+                lat, lng = _random_in_area(area)
+                self._drivers[driver_id] = _Driver(id=driver_id, name=name, lat=lat, lng=lng)
+            self._config = _Config(
+                org_id=org_id,
+                area_key=area_key,
+                interval_sec=float(interval_sec),
+                speed_mph=float(speed_mph),
+            )
+            self._task = asyncio.create_task(self._run_loop(), name="simulator-tick-loop")
+            logger.info("simulator spawned: org=%s count=%d area=%s", org_id, count, area_key)
+            return self._snapshot()
+
+    async def stop(self) -> dict:
+        async with self._lock:
+            await self._stop_locked()
+            return self._snapshot()
+
+    async def _stop_locked(self) -> None:
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._task = None
+
+    def status(self) -> dict:
+        return self._snapshot()
+
+    def _snapshot(self) -> dict:
+        cfg = self._config
+        return {
+            "running": self.running,
+            "update_count": self._update_count,
+            "config": (
+                {
+                    "area": cfg.area_key,
+                    "interval_sec": cfg.interval_sec,
+                    "speed_mph": cfg.speed_mph,
+                }
+                if cfg
+                else None
+            ),
+            "drivers": [
+                {
+                    "id": d.id,
+                    "name": d.name,
+                    "lat": d.lat,
+                    "lng": d.lng,
+                    "heading": d.heading,
+                    "state": d.state,
+                    "active_order_id": d.active_order_id,
+                }
+                for d in self._drivers.values()
+            ],
+        }
+
+    # ── Tick loop ────────────────────────────────────────────────────────
+
+    async def _run_loop(self) -> None:
+        try:
+            while True:
+                cfg = self._config
+                if cfg is None:
+                    return
+                step_m = cfg.speed_mph * MPH_TO_MPS * cfg.interval_sec
+                for driver in list(self._drivers.values()):
+                    try:
+                        await self._tick_driver(driver, step_m, cfg)
+                    except Exception:
+                        logger.exception("simulator tick failed for driver %s", driver.id)
+                await asyncio.sleep(cfg.interval_sec)
+        except asyncio.CancelledError:
+            return
+
+    async def _tick_driver(self, driver: _Driver, step_m: float, cfg: _Config) -> None:
+        await self._process_dispatch(driver, cfg.org_id)
+
+        if driver.state == "roaming" or not driver.route:
+            self._move_roam(driver, step_m, cfg.area_key)
+        else:
+            self._advance_along_route(driver, step_m)
+
+        await asyncio.to_thread(self._upsert_location, driver, cfg.org_id)
+        self._update_count += 1
+
+    @staticmethod
+    def _upsert_location(driver: _Driver, org_id: str) -> None:
+        store = get_driver_location_store()
+        record = build_driver_location_record(
+            org_id=org_id,
+            driver_id=driver.id,
+            payload=LocationUpdate(lat=driver.lat, lng=driver.lng, heading=driver.heading),
+        )
+        store.upsert_location(record)
+
+    # ── Dispatch state machine ──────────────────────────────────────────
+
+    async def _process_dispatch(self, driver: _Driver, org_id: str) -> None:
+        order = await asyncio.to_thread(self._first_active_order, driver.id, org_id)
+        if order is None:
+            if driver.state != "roaming":
+                driver.state = "roaming"
+                driver.active_order_id = None
+                driver.route = []
+                driver.target = None
+            return
+
+        pickup = self._pickup_address(order)
+        delivery = self._delivery_address(order)
+
+        if order.status == OrderStatus.ASSIGNED:
+            if driver.state != "to_pickup" or driver.active_order_id != order.id:
+                if not await self._plan_route(driver, pickup):
+                    return
+                driver.state = "to_pickup"
+                driver.active_order_id = order.id
+                logger.info("driver %s → pickup for order %s", driver.id, order.id)
+            if driver.target and _haversine_m(
+                driver.lat, driver.lng, driver.target[0], driver.target[1]
+            ) < ARRIVAL_THRESHOLD_M:
+                await asyncio.to_thread(self._set_status, order.id, org_id, OrderStatus.PICKED_UP)
+                logger.info("driver %s ↑ PickedUp %s", driver.id, order.id)
+                if await self._plan_route(driver, delivery):
+                    driver.state = "to_delivery"
+        elif order.status in (OrderStatus.PICKED_UP, OrderStatus.EN_ROUTE):
+            if driver.state != "to_delivery" or driver.active_order_id != order.id:
+                if not await self._plan_route(driver, delivery):
+                    return
+                driver.state = "to_delivery"
+                driver.active_order_id = order.id
+            if driver.target and _haversine_m(
+                driver.lat, driver.lng, driver.target[0], driver.target[1]
+            ) < ARRIVAL_THRESHOLD_M:
+                await asyncio.to_thread(self._set_status, order.id, org_id, OrderStatus.DELIVERED)
+                logger.info("driver %s ✓ Delivered %s", driver.id, order.id)
+                driver.state = "roaming"
+                driver.active_order_id = None
+                driver.route = []
+                driver.target = None
+
+    @staticmethod
+    def _first_active_order(driver_id: str, org_id: str):
+        store = get_order_store()
+        orders = store.list_assigned_orders(org_id=org_id, driver_id=driver_id, include_terminal=False)
+        if not orders:
+            return None
+        return sorted(orders, key=lambda o: o.created_at)[0]
+
+    @staticmethod
+    def _set_status(order_id: str, org_id: str, status: OrderStatus) -> None:
+        store = get_order_store()
+        order = store.get_order(org_id, order_id)
+        if order is None:
+            return
+        order.status = status
+        store.upsert_order(order)
+
+    @staticmethod
+    def _pickup_address(order) -> str:
+        parts = [order.pick_up_street, order.pick_up_city, order.pick_up_state, order.pick_up_zip]
+        return ", ".join(p for p in parts if p)
+
+    @staticmethod
+    def _delivery_address(order) -> str:
+        parts = [order.delivery_street, order.delivery_city, order.delivery_state, order.delivery_zip]
+        return ", ".join(p for p in parts if p)
+
+    # ── Routing & geocoding ─────────────────────────────────────────────
+
+    async def _plan_route(self, driver: _Driver, address: str) -> bool:
+        coord = await self._geocode(address)
+        if coord is None:
+            return False
+        route = await asyncio.to_thread(self._osrm_route, driver.lat, driver.lng, coord[0], coord[1])
+        driver.route = route
+        driver.target = coord
+        return True
+
+    async def _geocode(self, address: str) -> Optional[Tuple[float, float]]:
+        key = (address or "").strip().lower()
+        if not key:
+            return None
+        if key in self._geocode_cache:
+            return self._geocode_cache[key]
+        result = await asyncio.to_thread(self._photon_lookup, address)
+        self._geocode_cache[key] = result
+        return result
+
+    @staticmethod
+    def _photon_lookup(address: str) -> Optional[Tuple[float, float]]:
+        try:
+            r = requests.get(
+                "https://photon.komoot.io/api/",
+                params={"q": address, "limit": 1},
+                timeout=PHOTON_TIMEOUT_S,
+                headers={"User-Agent": "Discra/0.1 (dev simulator)"},
+            )
+            r.raise_for_status()
+            data = r.json()
+            features = data.get("features") or []
+            if not features:
+                return None
+            coords = features[0]["geometry"]["coordinates"]
+            return (float(coords[1]), float(coords[0]))
+        except Exception:
+            return None
+
+    @staticmethod
+    def _osrm_route(
+        from_lat: float,
+        from_lng: float,
+        to_lat: float,
+        to_lng: float,
+    ) -> List[Tuple[float, float]]:
+        fallback = [(from_lat, from_lng), (to_lat, to_lng)]
+        try:
+            url = (
+                "https://router.project-osrm.org/route/v1/driving/"
+                f"{from_lng},{from_lat};{to_lng},{to_lat}"
+                "?overview=full&geometries=geojson"
+            )
+            r = requests.get(url, timeout=OSRM_TIMEOUT_S)
+            r.raise_for_status()
+            data = r.json()
+            if data.get("code") != "Ok" or not data.get("routes"):
+                return fallback
+            coords = data["routes"][0]["geometry"]["coordinates"]
+            return [(float(c[1]), float(c[0])) for c in coords]
+        except Exception:
+            return fallback
+
+    # ── Movement ────────────────────────────────────────────────────────
+
+    def _advance_along_route(self, driver: _Driver, step_m: float) -> None:
+        remaining = step_m
+        while remaining > 0 and len(driver.route) >= 2:
+            target_lat, target_lng = driver.route[1]
+            seg_dist = _haversine_m(driver.lat, driver.lng, target_lat, target_lng)
+            if seg_dist < 0.1:
+                driver.route.pop(0)
+                continue
+            if remaining >= seg_dist:
+                driver.heading = _bearing(driver.lat, driver.lng, target_lat, target_lng)
+                driver.lat = target_lat
+                driver.lng = target_lng
+                driver.route.pop(0)
+                remaining -= seg_dist
+            else:
+                ratio = remaining / seg_dist
+                driver.heading = _bearing(driver.lat, driver.lng, target_lat, target_lng)
+                driver.lat = driver.lat + (target_lat - driver.lat) * ratio
+                driver.lng = driver.lng + (target_lng - driver.lng) * ratio
+                remaining = 0
+
+    def _move_roam(self, driver: _Driver, step_m: float, area_key: str) -> None:
+        area = AREAS.get(area_key, AREAS["fortworth"])
+        if not driver.roam_dest:
+            driver.roam_dest = _random_in_area(area)
+        target_lat, target_lng = driver.roam_dest
+        dist = _haversine_m(driver.lat, driver.lng, target_lat, target_lng)
+        if dist < step_m:
+            driver.lat = target_lat
+            driver.lng = target_lng
+            driver.roam_dest = _random_in_area(area)
+            return
+        ratio = step_m / dist
+        driver.heading = _bearing(driver.lat, driver.lng, target_lat, target_lng)
+        driver.lat += (target_lat - driver.lat) * ratio
+        driver.lng += (target_lng - driver.lng) * ratio
+
+
+_simulator: Optional[_Simulator] = None
+
+
+def get_simulator() -> _Simulator:
+    global _simulator
+    if _simulator is None:
+        _simulator = _Simulator()
+    return _simulator
+
+
+def seed_orders(*, org_id: str, area_key: str, count: int) -> List[Order]:
+    """Create N test orders for the given area. Pickup/delivery are different
+    addresses drawn from the curated list, so OSRM has something to route to."""
+    addrs = SEED_ADDRESSES.get(area_key) or SEED_ADDRESSES["fortworth"]
+    if len(addrs) < 2:
+        return []
+    count = max(1, min(int(count), 20))
+    store = get_order_store()
+    now = datetime.now(timezone.utc)
+    batch = int(time.time())
+    created: List[Order] = []
+    for i in range(count):
+        pu, dr = random.sample(addrs, 2)
+        order = Order(
+            id=str(uuid.uuid4()),
+            customer_name=random.choice(CUSTOMER_NAMES),
+            reference_id=f"SIM-{batch}-{i + 1}",
+            pick_up_street=pu[0], pick_up_city=pu[1], pick_up_state=pu[2], pick_up_zip=pu[3],
+            delivery_street=dr[0], delivery_city=dr[1], delivery_state=dr[2], delivery_zip=dr[3],
+            num_packages=1,
+            status=OrderStatus.CREATED,
+            assigned_to=None,
+            created_at=now,
+            org_id=org_id,
+        )
+        store.upsert_order(order)
+        created.append(order)
+    logger.info("seeded %d test orders for org=%s area=%s", len(created), org_id, area_key)
+    return created

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -19,7 +19,7 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { decodeJwtPayload, extractTokenGroups, normalizeApiBase } from "./lib";
+import { apiRequest, decodeJwtPayload, extractTokenGroups, extractUsername, normalizeApiBase } from "./lib";
 import AdminScreen from "./screens/AdminScreen";
 import DriverScreen from "./screens/DriverScreen";
 
@@ -27,7 +27,15 @@ import DriverScreen from "./screens/DriverScreen";
 
 const STORAGE_KEY = "discra_mobile_config_v4";
 const STORAGE_PKCE_KEY = "discra_mobile_pkce_v1";
-const DEFAULT_API_BASE = "https://m50fjhgrn7.execute-api.us-east-1.amazonaws.com/dev/backend";
+// When running the web preview locally (expo start --web on localhost), point
+// at the local FastAPI backend so dev-only endpoints (e.g. /admin/simulator/*)
+// are reachable. All other contexts use the deployed dev API.
+const DEFAULT_API_BASE =
+  Platform.OS === "web" &&
+  typeof window !== "undefined" &&
+  (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1")
+    ? "http://127.0.0.1:8000/dev/backend"
+    : "https://m50fjhgrn7.execute-api.us-east-1.amazonaws.com/dev/backend";
 const DEFAULT_COGNITO_USER_POOL_ID = "us-east-1_vMav7IRF7";
 const DEFAULT_COGNITO_CLIENT_ID = "4gq64lj8ndo8pltt6hj5ritqi";
 
@@ -121,6 +129,8 @@ export default function App() {
   const tokenGroups = useMemo(() => extractTokenGroups(token), [token]);
   const isDriver = tokenGroups.includes("Driver");
   const isAdmin = tokenGroups.includes("Admin") || tokenGroups.includes("Dispatcher");
+  const username = useMemo(() => extractUsername(token), [token]);
+  const simulatorEnabled = username === "cody.carmichael";
 
   // Auto-select workspace based on groups when token changes
   useEffect(() => {
@@ -387,44 +397,31 @@ export default function App() {
               </>
             ) : null}
           </View>
-          <Pressable style={styles.settingsGearBtn} onPress={() => setSettingsOpen(true)}>
-            <Text style={styles.settingsGearText}>⚙</Text>
-          </Pressable>
+          {simulatorEnabled ? (
+            <Pressable style={styles.settingsGearBtn} onPress={() => setSettingsOpen(true)}>
+              <Text style={styles.settingsGearText}>⚙</Text>
+            </Pressable>
+          ) : null}
         </View>
         {renderScreen()}
 
-        {/* Settings modal — opened via ⚙ in the top banner */}
-        <Modal visible={settingsOpen} animationType="slide" transparent onRequestClose={() => setSettingsOpen(false)}>
-          <View style={styles.settingsBackdrop}>
-            <SafeAreaView>
-              <View style={styles.settingsCard}>
-                <Text style={styles.loginHeading}>Settings</Text>
-                <Text style={styles.label}>API Base URL</Text>
-                <TextInput
-                  style={styles.input}
-                  value={apiBase}
-                  onChangeText={setApiBase}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  placeholderTextColor="#4A3F60"
-                />
-                <Text style={styles.label}>Cognito Domain (Hosted UI)</Text>
-                <TextInput
-                  style={styles.input}
-                  value={cognitoDomain}
-                  onChangeText={setCognitoDomain}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  placeholderTextColor="#4A3F60"
-                  placeholder="auth.example.com"
-                />
-                <Pressable style={[styles.btn, styles.btnGhost]} onPress={() => setSettingsOpen(false)}>
-                  <Text style={styles.btnGhostText}>Done</Text>
-                </Pressable>
-              </View>
-            </SafeAreaView>
-          </View>
-        </Modal>
+        {/* Settings modal — simulator controls (cody.carmichael only) */}
+        {simulatorEnabled ? (
+          <Modal visible={settingsOpen} animationType="slide" transparent onRequestClose={() => setSettingsOpen(false)}>
+            <View style={styles.settingsBackdrop}>
+              <SafeAreaView style={{ width: "100%" }}>
+                <View style={styles.settingsCard}>
+                  <SimulatorPanel
+                    apiBase={apiBase}
+                    token={token}
+                    open={settingsOpen}
+                    onClose={() => setSettingsOpen(false)}
+                  />
+                </View>
+              </SafeAreaView>
+            </View>
+          </Modal>
+        ) : null}
       </View>
     );
   }
@@ -486,6 +483,270 @@ export default function App() {
         </View>
       </View>
     </SafeAreaView>
+  );
+}
+
+// ─── Simulator Panel ──────────────────────────────────────────────────────────
+
+const SIM_AREAS: Array<{ key: string; label: string }> = [
+  { key: "fortworth", label: "Fort Worth, TX" },
+  { key: "dallas", label: "Dallas, TX" },
+  { key: "austin", label: "Austin, TX" },
+  { key: "houston", label: "Houston, TX" },
+  { key: "nyc", label: "New York City" },
+  { key: "la", label: "Los Angeles" },
+];
+
+type SimDriver = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  heading: number;
+  state: string;
+  active_order_id: string | null;
+};
+
+type SimStatus = {
+  running: boolean;
+  update_count: number;
+  config: { area: string; interval_sec: number; speed_mph: number } | null;
+  drivers: SimDriver[];
+};
+
+function SimulatorPanel({
+  apiBase,
+  token,
+  open,
+  onClose,
+}: {
+  apiBase: string;
+  token: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [count, setCount] = useState("5");
+  const [areaKey, setAreaKey] = useState("fortworth");
+  const [intervalSec, setIntervalSec] = useState("5");
+  const [speedMph, setSpeedMph] = useState("30");
+  const [seedCount, setSeedCount] = useState("5");
+  const [status, setStatus] = useState<SimStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  // Initial fetch + poll while open
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    async function refresh() {
+      try {
+        const s = await apiRequest<SimStatus>(apiBase, "/admin/simulator/status", { token });
+        if (!cancelled) setStatus(s);
+      } catch (e) {
+        if (!cancelled) setMsg(e instanceof Error ? e.message : "Status failed.");
+      }
+    }
+    refresh();
+    const id = setInterval(refresh, 4000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [open, apiBase, token]);
+
+  // Pre-fill form from current config when status loads
+  useEffect(() => {
+    if (status?.config) {
+      setAreaKey(status.config.area);
+      setIntervalSec(String(status.config.interval_sec));
+      setSpeedMph(String(status.config.speed_mph));
+    }
+  }, [status?.config?.area, status?.config?.interval_sec, status?.config?.speed_mph]);
+
+  async function spawn() {
+    setBusy(true);
+    setMsg("");
+    try {
+      const next = await apiRequest<SimStatus>(apiBase, "/admin/simulator/spawn", {
+        method: "POST",
+        token,
+        json: {
+          count: parseInt(count, 10) || 5,
+          area: areaKey,
+          interval_sec: parseFloat(intervalSec) || 5,
+          speed_mph: parseFloat(speedMph) || 30,
+        },
+      });
+      setStatus(next);
+      setMsg(`Spawned ${next.drivers.length} driver(s).`);
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : "Spawn failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function stop() {
+    setBusy(true);
+    setMsg("");
+    try {
+      const next = await apiRequest<SimStatus>(apiBase, "/admin/simulator/stop", {
+        method: "POST",
+        token,
+      });
+      setStatus(next);
+      setMsg("Simulator stopped.");
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : "Stop failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function seedOrders() {
+    setBusy(true);
+    setMsg("");
+    try {
+      const resp = await apiRequest<{ created: number; order_ids: string[] }>(
+        apiBase,
+        "/admin/simulator/seed-orders",
+        {
+          method: "POST",
+          token,
+          json: { count: parseInt(seedCount, 10) || 5, area: areaKey },
+        }
+      );
+      setMsg(`Seeded ${resp.created} order(s). Refresh the dispatch tab to see them.`);
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : "Seed failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const stateLabel = (s: string) =>
+    s === "to_pickup" ? "→ Pickup" : s === "to_delivery" ? "→ Delivery" : "Roaming";
+
+  return (
+    <View style={{ gap: 10 }}>
+      <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+        <Text style={styles.loginHeading}>Driver Simulator</Text>
+        <Pressable onPress={onClose}>
+          <Text style={{ color: "#968AA8", fontSize: 18 }}>✕</Text>
+        </Pressable>
+      </View>
+
+      {/* Configuration */}
+      <Text style={styles.label}>Number of drivers (1–20)</Text>
+      <TextInput
+        style={styles.input}
+        value={count}
+        onChangeText={setCount}
+        keyboardType="number-pad"
+        placeholderTextColor="#4A3F60"
+      />
+
+      <Text style={styles.label}>Area</Text>
+      <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
+        {SIM_AREAS.map((a) => (
+          <Pressable
+            key={a.key}
+            onPress={() => setAreaKey(a.key)}
+            style={[
+              styles.simChip,
+              areaKey === a.key && styles.simChipActive,
+            ]}
+          >
+            <Text style={[styles.simChipText, areaKey === a.key && styles.simChipTextActive]}>
+              {a.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={{ flexDirection: "row", gap: 8 }}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.label}>Interval (sec)</Text>
+          <TextInput
+            style={styles.input}
+            value={intervalSec}
+            onChangeText={setIntervalSec}
+            keyboardType="number-pad"
+          />
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.label}>Speed (mph)</Text>
+          <TextInput
+            style={styles.input}
+            value={speedMph}
+            onChangeText={setSpeedMph}
+            keyboardType="number-pad"
+          />
+        </View>
+      </View>
+
+      <View style={{ flexDirection: "row", gap: 8 }}>
+        <Pressable
+          style={[styles.btn, styles.btnPrimary, busy && { opacity: 0.5 }]}
+          onPress={spawn}
+          disabled={busy}
+        >
+          <Text style={styles.btnPrimaryText}>{status?.running ? "Respawn" : "Spawn"}</Text>
+        </Pressable>
+        <Pressable
+          style={[styles.btn, styles.btnGhost, (!status?.running || busy) && { opacity: 0.4 }]}
+          onPress={stop}
+          disabled={!status?.running || busy}
+        >
+          <Text style={styles.btnGhostText}>Stop</Text>
+        </Pressable>
+      </View>
+
+      {/* Status */}
+      <View style={styles.simStatusBar}>
+        <Text style={styles.simStatusText}>
+          {status?.running ? "● Running" : "○ Stopped"} · {status?.drivers.length ?? 0} drivers · {status?.update_count ?? 0} updates
+        </Text>
+      </View>
+
+      {/* Seed test orders */}
+      <View style={{ height: 1, backgroundColor: "#241A33", marginVertical: 4 }} />
+      <Text style={styles.label}>Seed test orders ({areaKey})</Text>
+      <View style={{ flexDirection: "row", gap: 8, alignItems: "flex-end" }}>
+        <View style={{ flex: 1 }}>
+          <TextInput
+            style={styles.input}
+            value={seedCount}
+            onChangeText={setSeedCount}
+            keyboardType="number-pad"
+            placeholder="5"
+            placeholderTextColor="#4A3F60"
+          />
+        </View>
+        <Pressable
+          style={[styles.btn, styles.btnPrimary, busy && { opacity: 0.5 }]}
+          onPress={seedOrders}
+          disabled={busy}
+        >
+          <Text style={styles.btnPrimaryText}>+ Seed Orders</Text>
+        </Pressable>
+      </View>
+
+      {msg ? <Text style={{ color: "#C8973A", fontSize: 12 }}>{msg}</Text> : null}
+
+      {/* Driver list */}
+      {status && status.drivers.length > 0 ? (
+        <View style={{ gap: 4, maxHeight: 220 }}>
+          <Text style={styles.label}>Drivers</Text>
+          {status.drivers.slice(0, 20).map((d) => (
+            <View key={d.id} style={styles.simDriverRow}>
+              <Text style={styles.simDriverName} numberOfLines={1}>{d.name}</Text>
+              <Text style={styles.simDriverState}>{stateLabel(d.state)}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
   );
 }
 
@@ -706,5 +967,37 @@ const styles = StyleSheet.create({
     borderColor: "#3A2F50",
     padding: 20,
     gap: 10,
+    maxHeight: "92%",
   },
+  // Simulator panel
+  simChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: "#3A2F50",
+    backgroundColor: "#0F0C16",
+  },
+  simChipActive: { borderColor: "#C8973A", backgroundColor: "#2A1E10" },
+  simChipText: { color: "#968AA8", fontSize: 12, fontWeight: "600" },
+  simChipTextActive: { color: "#C8973A" },
+  simStatusBar: {
+    backgroundColor: "#0F0C16",
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: "#3A2F50",
+    padding: 8,
+  },
+  simStatusText: { color: "#EDE0C4", fontSize: 12, fontWeight: "600" },
+  simDriverRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: "#241A33",
+  },
+  simDriverName: { color: "#EDE0C4", fontSize: 13, fontWeight: "600", flex: 1 },
+  simDriverState: { color: "#C8973A", fontSize: 12, fontWeight: "700" },
 });

--- a/mobile/lib.ts
+++ b/mobile/lib.ts
@@ -208,6 +208,34 @@ export function extractTokenGroups(token: string): string[] {
   return [];
 }
 
+/**
+ * Derive a human-readable display name from a driver_id.
+ * - `sim-alex-rivera-78c98b` → "Alex Rivera"
+ * - real driver IDs → returned as-is (caller can swap in roster lookup later)
+ */
+export function deriveDriverName(driverId: string): string {
+  if (!driverId) return "";
+  if (!driverId.startsWith("sim-")) return driverId;
+  const inner = driverId.slice(4);
+  const lastDash = inner.lastIndexOf("-");
+  const slug = lastDash > 0 ? inner.slice(0, lastDash) : inner;
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(" ");
+}
+
+export function extractUsername(token: string): string {
+  const payload = decodeJwtPayload(token);
+  if (!payload) return "";
+  const username = payload["cognito:username"] ?? payload.username ?? payload.preferred_username;
+  if (username) return String(username).toLowerCase();
+  const email = payload.email;
+  if (email && typeof email === "string") return email.toLowerCase().split("@")[0];
+  return "";
+}
+
 // ─── API ─────────────────────────────────────────────────────────────────────
 
 export function normalizeApiBase(url: string): string {
@@ -325,6 +353,47 @@ function _buildOsrmInstruction(maneuver: {
   else parts.push(`${mtype} ${mod}`.trim());
   if (name) parts.push(`onto ${name}`);
   return parts.join(" ").replace(/\s+/g, " ").trim();
+}
+
+/** Multi-waypoint OSRM driving route. Returns the full road polyline + total
+ *  distance/duration. Use for optimised driver routes (driver → stop1 → … → stopN).
+ *  Falls back to a straight-line connecting all waypoints on failure. */
+export async function fetchOsrmRouteMulti(
+  waypoints: Array<{ lat: number; lng: number }>
+): Promise<OsrmResult | null> {
+  if (waypoints.length < 2) return null;
+  const fallback: OsrmResult = {
+    coords: waypoints.map((p) => ({ latitude: p.lat, longitude: p.lng })),
+    steps: [],
+    distance_meters: 0,
+    duration_seconds: 0,
+  };
+  try {
+    const coordStr = waypoints.map((p) => `${p.lng},${p.lat}`).join(";");
+    const url = `https://router.project-osrm.org/route/v1/driving/${coordStr}?overview=full&geometries=geojson`;
+    const resp = await fetch(url);
+    const data = (await resp.json()) as {
+      code?: string;
+      routes?: Array<{
+        distance: number;
+        duration: number;
+        geometry: { coordinates: Array<[number, number]> };
+      }>;
+    };
+    if (data.code !== "Ok" || !data.routes?.length) return fallback;
+    const route = data.routes[0];
+    return {
+      coords: route.geometry.coordinates.map(([lng, lat]) => ({
+        latitude: lat,
+        longitude: lng,
+      })),
+      steps: [],
+      distance_meters: route.distance,
+      duration_seconds: route.duration,
+    };
+  } catch {
+    return fallback;
+  }
 }
 
 export async function fetchOsrmRoute(

--- a/mobile/react-native-maps.web.js
+++ b/mobile/react-native-maps.web.js
@@ -96,31 +96,306 @@ function MapView({ style, region, children }) {
 }
 
 // ─── Marker ───────────────────────────────────────────────────────────────────
+//
+// Supports two prop styles:
+//   1. Legacy:  pinColor="#hex"   → small white-bordered dot (back-compat)
+//   2. New:     pinKind="driver"  → WoW-style SVG pin matching the web app
+//               label="Alex …"    → optional text rendered next to the pin
+//
+// pinKind values:
+//   - "unassigned"        gold "!" in dark circle, gold border
+//   - "assigned"          gold "?" in dark circle, gold border
+//   - "picked_up"         purple up-arrow in dark circle
+//   - "en_route"          green right-arrow in dark circle
+//   - "driver"            dark circle, gold "D" glyph, gold border
+//   - "driver_selected"   bright gold border, brighter glyph
 
-function Marker({ coordinate, title, description, pinColor }) {
+function _wowSymbolPinSvg(symbol, symbolColor, glowColor, borderColor) {
+  return (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">' +
+    '<defs>' +
+    '<filter id="g-' + symbolColor.replace('#','') + '" x="-50%" y="-50%" width="200%" height="200%">' +
+    '<feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur"/>' +
+    '<feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>' +
+    '</filter>' +
+    '</defs>' +
+    '<circle cx="16" cy="16" r="14" fill="#130F1A" stroke="' + borderColor + '" stroke-width="2.5"/>' +
+    '<circle cx="16" cy="16" r="14" fill="none" stroke="' + glowColor + '" stroke-width="1" opacity="0.3"/>' +
+    '<text x="16" y="22" text-anchor="middle" font-family="Cinzel,Georgia,serif" font-size="20" font-weight="900" fill="' + symbolColor + '" filter="url(#g-' + symbolColor.replace('#','') + ')">' + symbol + '</text>' +
+    '</svg>'
+  );
+}
+
+function _wowArrowPinSvg(arrowPath, fillColor, glowColor) {
+  return (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">' +
+    '<defs>' +
+    '<filter id="g-arrow" x="-50%" y="-50%" width="200%" height="200%">' +
+    '<feGaussianBlur in="SourceGraphic" stdDeviation="1.5" result="blur"/>' +
+    '<feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>' +
+    '</filter>' +
+    '</defs>' +
+    '<circle cx="16" cy="16" r="14" fill="#130F1A" stroke="' + fillColor + '" stroke-width="2.5"/>' +
+    '<circle cx="16" cy="16" r="14" fill="none" stroke="' + glowColor + '" stroke-width="1" opacity="0.25"/>' +
+    '<g transform="translate(16,16)" filter="url(#g-arrow)">' + arrowPath + '</g>' +
+    '</svg>'
+  );
+}
+
+const _PIN_BUILDERS = {
+  unassigned:      () => _wowSymbolPinSvg("!", "#F0C060", "#F0C060", "#C8973A"),
+  assigned:        () => _wowSymbolPinSvg("?", "#F0C060", "#F0C060", "#C8973A"),
+  picked_up:       () => _wowArrowPinSvg('<path d="M0,-9 L5,2 L2,2 L2,9 L-2,9 L-2,2 L-5,2 Z" fill="#9D6FC8"/>', "#9D6FC8", "#7B4FA6"),
+  en_route:        () => _wowArrowPinSvg('<path d="M-9,0 L2,-5 L2,-2 L9,0 L2,2 L2,5 Z" fill="#6FBD80"/>', "#6FBD80", "#4A9E5C"),
+  driver:          () => _wowSymbolPinSvg("D", "#EDE0C4", "#7A5C22", "#7A5C22"),
+  driver_selected: () => _wowSymbolPinSvg("D", "#F5D98B", "#F0C060", "#C8973A"),
+};
+
+function _escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+}
+
+// Inject popup styling once. Mirrors the web app's WoW-flavored dark/gold theme.
+let _stylesInjected = false;
+function _injectPopupStyles() {
+  if (_stylesInjected || typeof document === "undefined") return;
+  _stylesInjected = true;
+
+  if (!document.getElementById("cinzel-font")) {
+    const fontLink = document.createElement("link");
+    fontLink.id = "cinzel-font";
+    fontLink.rel = "stylesheet";
+    fontLink.href = "https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&display=swap";
+    document.head.appendChild(fontLink);
+  }
+
+  const style = document.createElement("style");
+  style.id = "discra-popup-styles";
+  style.textContent = `
+    .leaflet-popup.discra-popup-wrapper .leaflet-popup-content-wrapper {
+      background: transparent;
+      box-shadow: none;
+      border-radius: 0;
+      padding: 0;
+    }
+    .leaflet-popup.discra-popup-wrapper .leaflet-popup-content {
+      margin: 0;
+      width: auto !important;
+      min-width: 220px;
+    }
+    .leaflet-popup.discra-popup-wrapper .leaflet-popup-tip {
+      background: #1C1628;
+      border: 1px solid #6B4F2A;
+      box-shadow: none;
+    }
+    .leaflet-popup.discra-popup-wrapper .leaflet-popup-close-button {
+      color: #968AA8 !important;
+      font-size: 18px;
+      padding: 6px 8px 0 0;
+    }
+    .leaflet-popup.discra-popup-wrapper .leaflet-popup-close-button:hover {
+      color: #F0C060 !important;
+    }
+    .discra-popup {
+      background: linear-gradient(180deg, #1C1628 0%, #130F1A 100%);
+      border: 2px solid #6B4F2A;
+      border-radius: 4px;
+      box-shadow:
+        inset 0 0 0 1px rgba(200,151,58,0.35),
+        0 6px 18px rgba(0,0,0,0.75),
+        0 0 12px rgba(200,151,58,0.25);
+      color: #EDE0C4;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      overflow: hidden;
+    }
+    .discra-popup-header {
+      background: linear-gradient(90deg, #2A1E10 0%, #1C1628 60%, #1C1628 100%);
+      border-bottom: 1px solid #6B4F2A;
+      padding: 8px 28px 8px 14px;
+    }
+    .discra-popup-title {
+      color: #F5D98B;
+      font-family: "Cinzel", Georgia, serif;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.6);
+    }
+    .discra-popup-body {
+      padding: 10px 14px 4px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .discra-popup-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 14px;
+    }
+    .discra-popup-label {
+      color: #968AA8;
+      font-family: "Cinzel", Georgia, serif;
+      font-size: 9px;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      flex-shrink: 0;
+    }
+    .discra-popup-value {
+      color: #EDE0C4;
+      font-size: 12px;
+      font-weight: 500;
+      text-align: right;
+      max-width: 180px;
+    }
+    .discra-popup-value--accent { color: #F0C060; font-weight: 700; }
+    .discra-popup-action {
+      display: block;
+      width: calc(100% - 20px);
+      margin: 8px 10px 10px 10px;
+      padding: 8px 10px;
+      background: linear-gradient(180deg, #C8973A 0%, #7A5C22 100%);
+      color: #0B0910;
+      border: 1px solid #F0C060;
+      border-radius: 3px;
+      font-family: "Cinzel", Georgia, serif;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: filter 0.15s, box-shadow 0.15s;
+    }
+    .discra-popup-action:hover {
+      filter: brightness(1.12);
+      box-shadow: 0 0 10px rgba(200,151,58,0.6);
+    }
+    .discra-popup-action:active { transform: translateY(1px); }
+  `;
+  document.head.appendChild(style);
+}
+
+function _buildPopupHtml({ title, popupRows, actionLabel }) {
+  const headerHtml = title
+    ? `<div class="discra-popup-header"><span class="discra-popup-title">${_escapeHtml(title)}</span></div>`
+    : "";
+  const rowsHtml = (popupRows || [])
+    .filter((r) => r && (r.value || r.value === 0))
+    .map((r) => (
+      `<div class="discra-popup-row">` +
+        `<span class="discra-popup-label">${_escapeHtml(r.label || "")}</span>` +
+        `<span class="discra-popup-value${r.accent ? " discra-popup-value--accent" : ""}">${_escapeHtml(String(r.value))}</span>` +
+      `</div>`
+    ))
+    .join("");
+  const bodyHtml = rowsHtml ? `<div class="discra-popup-body">${rowsHtml}</div>` : "";
+  const actionHtml = actionLabel
+    ? `<button class="discra-popup-action" data-discra-action>${_escapeHtml(actionLabel)}</button>`
+    : "";
+  return `<div class="discra-popup">${headerHtml}${bodyHtml}${actionHtml}</div>`;
+}
+
+function _buildLabelHtml(label) {
+  if (!label) return "";
+  return (
+    '<span style="' +
+    'margin-left:6px;padding:2px 8px;' +
+    'background:rgba(19,15,26,0.85);color:#EDE0C4;' +
+    'border:1px solid #6B4F2A;border-radius:4px;' +
+    'font:600 11px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;' +
+    'white-space:nowrap;letter-spacing:0.02em;' +
+    'box-shadow:0 1px 4px rgba(0,0,0,0.6);' +
+    '">' + _escapeHtml(label) + '</span>'
+  );
+}
+
+function Marker({
+  coordinate,
+  title,
+  description,
+  pinColor,
+  pinKind,
+  label,
+  popupRows,
+  onAction,
+  actionLabel,
+}) {
   const { L, map } = React.useContext(MapCtx);
+  // Keep latest onAction in a ref so the popup-open listener always calls the
+  // current closure (avoids tearing down/re-binding the marker on every render).
+  const onActionRef = React.useRef(onAction);
+  onActionRef.current = onAction;
 
   React.useEffect(() => {
     if (!L || !map || !coordinate) return;
+    _injectPopupStyles();
 
-    const icon = pinColor
-      ? L.divIcon({
-          className: "",
-          html: `<div style="width:13px;height:13px;border-radius:50%;background:${pinColor};border:2px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,.5)"></div>`,
-          iconSize: [13, 13],
-          iconAnchor: [6, 6],
-          popupAnchor: [0, -8],
-        })
-      : new L.Icon.Default();
+    let icon;
+    if (pinKind && _PIN_BUILDERS[pinKind]) {
+      const svgHtml = _PIN_BUILDERS[pinKind]();
+      const labelHtml = _buildLabelHtml(label);
+      const PIN_W = 32;
+      const labelW = label ? Math.min(220, 16 + label.length * 7) : 0;
+      const totalW = PIN_W + labelW;
+      icon = L.divIcon({
+        className: "",
+        html:
+          '<div style="display:flex;align-items:center;height:32px;">' +
+          svgHtml +
+          labelHtml +
+          '</div>',
+        iconSize: [totalW, 32],
+        iconAnchor: [16, 16],
+        popupAnchor: [0, -14],
+      });
+    } else if (pinColor) {
+      icon = L.divIcon({
+        className: "",
+        html: `<div style="width:13px;height:13px;border-radius:50%;background:${pinColor};border:2px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,.5)"></div>`,
+        iconSize: [13, 13],
+        iconAnchor: [6, 6],
+        popupAnchor: [0, -8],
+      });
+    } else {
+      icon = new L.Icon.Default();
+    }
 
     const marker = L.marker([coordinate.latitude, coordinate.longitude], { icon }).addTo(map);
-    if (title) {
-      marker.bindPopup(
-        `<strong>${title}</strong>${description ? "<br>" + description : ""}`
-      );
+
+    const hasStyledPopup = !!(title || (popupRows && popupRows.length) || actionLabel);
+    if (hasStyledPopup) {
+      const html = _buildPopupHtml({ title, popupRows, actionLabel });
+      marker.bindPopup(html, { className: "discra-popup-wrapper", maxWidth: 320 });
+
+      const handleOpen = () => {
+        const popup = marker.getPopup();
+        const el = popup && popup.getElement();
+        if (!el) return;
+        const btn = el.querySelector("[data-discra-action]");
+        if (!btn) return;
+        const onClick = (ev) => {
+          ev.stopPropagation();
+          if (onActionRef.current) onActionRef.current();
+          marker.closePopup();
+        };
+        btn.addEventListener("click", onClick, { once: true });
+      };
+      marker.on("popupopen", handleOpen);
+    } else if (description) {
+      // Legacy plain popup (kept for back-compat with the old description prop)
+      marker.bindPopup(`<strong>${_escapeHtml(title || "")}</strong><br>${_escapeHtml(description)}`);
     }
+
     return () => { map.removeLayer(marker); };
-  }, [L, map, coordinate && coordinate.latitude, coordinate && coordinate.longitude, pinColor, title, description]);
+  }, [
+    L, map,
+    coordinate && coordinate.latitude, coordinate && coordinate.longitude,
+    pinColor, pinKind, label, title, description, actionLabel,
+    // popupRows is an array; identity changes break memoization. Stringify for stable dep.
+    popupRows ? JSON.stringify(popupRows) : "",
+  ]);
 
   return null;
 }

--- a/mobile/screens/AdminScreen.tsx
+++ b/mobile/screens/AdminScreen.tsx
@@ -22,9 +22,14 @@ import {
   RouteOptimizeResponse,
   apiRequest,
   deliveryAddress,
+  deriveDriverName,
+  fetchOsrmRoute,
+  fetchOsrmRouteMulti,
   formatDistanceMiles,
   formatDurationShort,
   formatTime,
+  geocodeAddress,
+  haversineDistance,
   orderReference,
   pickupAddress,
 } from "../lib";
@@ -107,6 +112,27 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
   const [statusMsg, setStatusMsg] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedOrderIds, setSelectedOrderIds] = useState<Set<string>>(new Set());
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [assignSheetOrderIds, setAssignSheetOrderIds] = useState<string[] | null>(null);
+
+  // Preview state shown on the map while the assign sheet is open. The
+  // route is fetched on demand from OSRM (driver pos → first-order pickup).
+  type PreviewState = {
+    driverId: string;
+    pickupCoord: { lat: number; lng: number };
+    route: { latitude: number; longitude: number }[] | null;
+  };
+  const [previewState, setPreviewState] = useState<PreviewState | null>(null);
+  const previewReqRef = useRef(0);
+
+  // Toast for assignment confirmation. Slides in from the top, auto-dismisses.
+  const [toastMsg, setToastMsg] = useState<string | null>(null);
+  const toastAnim = useRef(new Animated.Value(0)).current;
+
+  // Pickup geocode cache. Refs avoid stale-closure issues; bump version to re-render.
+  const pickupCacheRef = useRef<Map<string, { lat: number; lng: number }>>(new Map());
+  const pickupInflightRef = useRef<Set<string>>(new Set());
+  const [, setPickupCoordsVersion] = useState(0);
 
   // ── Create order modal ─────────────────────────────────────────────────────
   const [createVisible, setCreateVisible] = useState(false);
@@ -214,17 +240,51 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
   );
 
   // ── Route points ──────────────────────────────────────────────────────────
-  const routePoints = useMemo(() => {
+  // Straight-line fallback (used while the OSRM call is in flight or if it fails).
+  const straightRoutePoints = useMemo(() => {
     if (!selectedDriver) return [];
     const pts: { latitude: number; longitude: number }[] = [
       { latitude: selectedDriver.lat, longitude: selectedDriver.lng },
     ];
     if (routePlan?.ordered_stops?.length) {
       for (const s of routePlan.ordered_stops) pts.push({ latitude: s.lat, longitude: s.lng });
-      return pts;
     }
     return pts;
   }, [selectedDriver, routePlan]);
+
+  // Road-following polyline from OSRM. Re-fetches whenever the selected driver
+  // or the optimised stop sequence changes.
+  const [roadRoutePoints, setRoadRoutePoints] = useState<
+    { latitude: number; longitude: number }[] | null
+  >(null);
+  const roadRouteReqRef = useRef(0);
+  const stopsKey = useMemo(
+    () =>
+      routePlan?.ordered_stops
+        ?.map((s) => `${s.lat.toFixed(5)},${s.lng.toFixed(5)}`)
+        .join("|") || "",
+    [routePlan]
+  );
+  useEffect(() => {
+    if (!selectedDriver || !routePlan?.ordered_stops?.length) {
+      setRoadRoutePoints(null);
+      return;
+    }
+    const reqId = ++roadRouteReqRef.current;
+    const waypoints = [
+      { lat: selectedDriver.lat, lng: selectedDriver.lng },
+      ...routePlan.ordered_stops.map((s) => ({ lat: s.lat, lng: s.lng })),
+    ];
+    fetchOsrmRouteMulti(waypoints)
+      .then((result) => {
+        if (roadRouteReqRef.current !== reqId) return;
+        setRoadRoutePoints(result?.coords && result.coords.length > 1 ? result.coords : null);
+      })
+      .catch(() => undefined);
+  }, [selectedDriver?.driver_id, selectedDriver?.lat, selectedDriver?.lng, stopsKey]);
+
+  // What the map actually renders: road polyline if we have it, else straight lines.
+  const routePoints = roadRoutePoints || straightRoutePoints;
 
   // ── Filtered orders ────────────────────────────────────────────────────────
   const filteredOrders = useMemo(() => {
@@ -244,6 +304,27 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
     () => filteredOrders.filter((o) => !o.assigned_to),
     [filteredOrders]
   );
+
+  // ── Pickup geocoding (for proximity ranking + map pins) ───────────────────
+  const ensurePickupGeocode = useCallback(async (address: string) => {
+    const key = address.trim().toLowerCase();
+    if (!key) return;
+    if (pickupCacheRef.current.has(key)) return;
+    if (pickupInflightRef.current.has(key)) return;
+    pickupInflightRef.current.add(key);
+    try {
+      const result = await geocodeAddress(address, pickupCacheRef.current);
+      if (result) setPickupCoordsVersion((v) => v + 1);
+    } finally {
+      pickupInflightRef.current.delete(key);
+    }
+  }, []);
+
+  const getPickupCoord = useCallback((order: OrderRecord) => {
+    const addr = pickupAddress(order);
+    if (!addr) return null;
+    return pickupCacheRef.current.get(addr.trim().toLowerCase()) || null;
+  }, []);
 
   const assignedOrders = useMemo(
     () =>
@@ -318,12 +399,27 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Auto-optimise route whenever the selected driver changes
+  // Pre-fetch pickup coords for unassigned orders so the assign sheet ranks
+  // by proximity instantly. ensurePickupGeocode is a no-op for cached/inflight keys.
+  useEffect(() => {
+    for (const o of unassignedOrders) {
+      const addr = pickupAddress(o);
+      if (addr) ensurePickupGeocode(addr).catch(() => undefined);
+    }
+  }, [unassignedOrders, ensurePickupGeocode]);
+
+  // Auto-optimise route whenever the selected driver changes OR their assigned
+  // orders change (e.g. dispatcher just assigned a new order to this driver).
+  // The set-of-IDs key avoids spurious reruns from unrelated order edits.
+  const assignedOrderIdsKey = useMemo(
+    () => assignedOrders.map((o) => o.id).sort().join(","),
+    [assignedOrders]
+  );
   useEffect(() => {
     if (!selectedDriverId) return;
     optimiseRoute().catch(() => undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedDriverId]);
+  }, [selectedDriverId, assignedOrderIdsKey]);
 
   // ── Optimise route ────────────────────────────────────────────────────────
   async function optimiseRoute() {
@@ -350,6 +446,10 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
   async function assignOrder(orderId: string) {
     const driverId = (selectedDriverId || "").trim();
     if (!driverId) { setStatusMsg("Select a driver first."); return; }
+    await assignOrderToDriver(orderId, driverId);
+  }
+
+  async function assignOrderToDriver(orderId: string, driverId: string) {
     setLoading(true);
     try {
       await apiRequest(apiBase, `/orders/${orderId}/assign`, {
@@ -397,22 +497,107 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
   }
 
   // ── Bulk assign ────────────────────────────────────────────────────────────
-  async function bulkAssign() {
-    const driverId = selectedDriverId || "";
-    if (!driverId) { setStatusMsg("Select a driver first."); return; }
-    if (!selectedOrderIds.size) { setStatusMsg("Select orders to assign."); return; }
+  async function bulkAssignToDriver(orderIds: string[], driverId: string) {
+    if (!orderIds.length) return;
     setLoading(true);
     let ok = 0;
-    for (const id of selectedOrderIds) {
+    for (const id of orderIds) {
       try {
         await apiRequest(apiBase, `/orders/${id}/assign`, { method: "POST", token, json: { driver_id: driverId } });
         ok++;
       } catch { /* skip */ }
     }
     setSelectedOrderIds(new Set());
+    setSelectionMode(false);
     await loadData(true);
     setStatusMsg(`Assigned ${ok} order(s).`);
     setLoading(false);
+  }
+
+  // ── Assign sheet open / close ─────────────────────────────────────────────
+  function openAssignSheet(orderIds: string[]) {
+    if (!orderIds.length) return;
+    setAssignSheetOrderIds(orderIds);
+  }
+
+  function closeAssignSheet() {
+    setAssignSheetOrderIds(null);
+    setPreviewState(null);
+    previewReqRef.current++;  // invalidate any in-flight OSRM request
+  }
+
+  // Tap-to-preview: fetch driver → pickup polyline and show on map.
+  async function startPreview(driverId: string | null) {
+    if (!driverId) {
+      setPreviewState(null);
+      return;
+    }
+    const driver = drivers.find((d) => d.driver_id === driverId);
+    const firstOrderId = assignSheetOrderIds?.[0];
+    const order = firstOrderId ? orders.find((o) => o.id === firstOrderId) : null;
+    const pickup = order ? getPickupCoord(order) : null;
+    if (!driver || !pickup) return;
+
+    const reqId = ++previewReqRef.current;
+    // Show straight-line preview immediately while OSRM is in flight.
+    setPreviewState({
+      driverId,
+      pickupCoord: pickup,
+      route: [
+        { latitude: driver.lat, longitude: driver.lng },
+        { latitude: pickup.lat, longitude: pickup.lng },
+      ],
+    });
+    const result = await fetchOsrmRoute(driver.lat, driver.lng, pickup.lat, pickup.lng);
+    if (previewReqRef.current !== reqId) return; // superseded
+    setPreviewState({
+      driverId,
+      pickupCoord: pickup,
+      route:
+        result?.coords && result.coords.length > 1
+          ? result.coords
+          : [
+              { latitude: driver.lat, longitude: driver.lng },
+              { latitude: pickup.lat, longitude: pickup.lng },
+            ],
+    });
+  }
+
+  function showAssignToast(message: string) {
+    setToastMsg(message);
+    toastAnim.setValue(0);
+    Animated.sequence([
+      Animated.timing(toastAnim, {
+        toValue: 1,
+        duration: 220,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+      Animated.delay(2200),
+      Animated.timing(toastAnim, {
+        toValue: 0,
+        duration: 280,
+        easing: Easing.in(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start(() => setToastMsg(null));
+  }
+
+  async function handleSheetAssign(driverId: string) {
+    const ids = assignSheetOrderIds || [];
+    const driverName = deriveDriverName(driverId);
+    const firstOrder = orders.find((o) => o.id === ids[0]);
+    const orderLabel =
+      ids.length === 1 && firstOrder
+        ? firstOrder.customer_name
+        : `${ids.length} orders`;
+    closeAssignSheet();
+    if (ids.length === 1) {
+      await assignOrderToDriver(ids[0], driverId);
+    } else {
+      await bulkAssignToDriver(ids, driverId);
+    }
+    showAssignToast(`✓ Assigned ${orderLabel} to ${driverName}`);
   }
 
   // ── Create order ───────────────────────────────────────────────────────────
@@ -579,18 +764,63 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
                 onRegionChangeComplete={setMapRegion}
                 showsUserLocation={false}
               >
-                {drivers.map((driver) => (
-                  <Marker
-                    key={`drv-${driver.driver_id}`}
-                    coordinate={{ latitude: driver.lat, longitude: driver.lng }}
-                    pinColor={driver.driver_id === selectedDriverId ? "#C8973A" : "#0e7aa6"}
-                    title={driver.driver_id}
-                    description={formatTime(driver.timestamp)}
-                    onPress={() => focusDriver(driver)}
-                  />
-                ))}
+                {drivers.map((driver) => {
+                  const isSelected = driver.driver_id === selectedDriverId;
+                  const displayName = deriveDriverName(driver.driver_id);
+                  const driverOrderCount = orders.filter((o) => o.assigned_to === driver.driver_id).length;
+                  return (
+                    <Marker
+                      key={`drv-${driver.driver_id}`}
+                      coordinate={{ latitude: driver.lat, longitude: driver.lng }}
+                      title={displayName}
+                      onPress={() => focusDriver(driver)}
+                      // @ts-expect-error - pinKind/label/popupRows are web-shim props (react-native-maps.web.js)
+                      pinKind={isSelected ? "driver_selected" : "driver"}
+                      label={displayName}
+                      popupRows={[
+                        {
+                          label: "Status",
+                          value: driverOrderCount > 0 ? "On delivery" : "Available",
+                          accent: true,
+                        },
+                        { label: "Assigned", value: `${driverOrderCount} order${driverOrderCount === 1 ? "" : "s"}` },
+                        { label: "Last update", value: formatTime(driver.timestamp) },
+                      ]}
+                    />
+                  );
+                })}
+                {unassignedOrders.map((order) => {
+                  const coord = getPickupCoord(order);
+                  if (!coord) return null;
+                  const pickup = pickupAddress(order) || "Unknown pickup";
+                  const delivery = deliveryAddress(order) || "Unknown delivery";
+                  return (
+                    <Marker
+                      key={`pickup-${order.id}`}
+                      coordinate={{ latitude: coord.lat, longitude: coord.lng }}
+                      title={order.customer_name}
+                      onPress={() => openAssignSheet([order.id])}
+                      // @ts-expect-error - pinKind/popupRows/onAction/actionLabel are web-shim props
+                      pinKind="unassigned"
+                      popupRows={[
+                        { label: "Status", value: "Unassigned", accent: true },
+                        { label: "Pickup", value: pickup },
+                        { label: "Delivery", value: delivery },
+                      ]}
+                      onAction={() => openAssignSheet([order.id])}
+                      actionLabel="⚡ Assign Driver"
+                    />
+                  );
+                })}
                 {routePoints.length > 1 ? (
                   <Polyline coordinates={routePoints} strokeColor="#C8973A" strokeWidth={3} />
+                ) : null}
+                {previewState?.route && previewState.route.length > 1 ? (
+                  <Polyline
+                    coordinates={previewState.route}
+                    strokeColor="#9D6FC8"
+                    strokeWidth={5}
+                  />
                 ) : null}
               </MapView>
 
@@ -642,11 +872,11 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
                   drivers={drivers}
                   selectedOrderIds={selectedOrderIds}
                   setSelectedOrderIds={setSelectedOrderIds}
-                  onAssign={assignOrder}
+                  selectionMode={selectionMode}
+                  setSelectionMode={setSelectionMode}
                   onUnassign={unassignOrder}
-                  onBulkAssign={bulkAssign}
+                  onOpenAssignSheet={openAssignSheet}
                   onSelectDriver={focusDriver}
-                  onOptimise={optimiseRoute}
                   routePlan={routePlan}
                   orders={orders}
                 />
@@ -912,6 +1142,41 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
         </>
       ) : null}
 
+      {/* ── Assign sheet ───────────────────────────────────────── */}
+      <AssignSheet
+        orderIds={assignSheetOrderIds}
+        orders={orders}
+        drivers={drivers}
+        getPickupCoord={getPickupCoord}
+        previewDriverId={previewState?.driverId || null}
+        onPreview={startPreview}
+        onConfirm={handleSheetAssign}
+        onClose={closeAssignSheet}
+      />
+
+      {/* ── Assignment toast ───────────────────────────────────── */}
+      {toastMsg ? (
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            styles.assignToast,
+            {
+              opacity: toastAnim,
+              transform: [
+                {
+                  translateY: toastAnim.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [-20, 0],
+                  }),
+                },
+              ],
+            },
+          ]}
+        >
+          <Text style={styles.assignToastText}>{toastMsg}</Text>
+        </Animated.View>
+      ) : null}
+
       {/* ── Create order modal ──────────────────────────────────── */}
       <Modal visible={createVisible} animationType="slide" transparent onRequestClose={() => setCreateVisible(false)}>
         <View style={styles.modalBackdrop}>
@@ -996,11 +1261,11 @@ type DispatchTabProps = {
   drivers: DriverLocationRecord[];
   selectedOrderIds: Set<string>;
   setSelectedOrderIds: (fn: (prev: Set<string>) => Set<string>) => void;
-  onAssign: (id: string) => void;
+  selectionMode: boolean;
+  setSelectionMode: (next: boolean) => void;
   onUnassign: (id: string) => void;
-  onBulkAssign: () => void;
+  onOpenAssignSheet: (orderIds: string[]) => void;
   onSelectDriver: (d: DriverLocationRecord) => void;
-  onOptimise: () => void;
   routePlan: RouteOptimizeResponse | null;
   orders: OrderRecord[];
 };
@@ -1012,11 +1277,11 @@ function DispatchTab({
   drivers,
   selectedOrderIds,
   setSelectedOrderIds,
-  onAssign,
+  selectionMode,
+  setSelectionMode,
   onUnassign,
-  onBulkAssign,
+  onOpenAssignSheet,
   onSelectDriver,
-  onOptimise,
   routePlan,
   orders,
 }: DispatchTabProps) {
@@ -1025,8 +1290,29 @@ function DispatchTab({
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
+      // Auto-exit selection mode if nothing is selected.
+      if (next.size === 0) setSelectionMode(false);
       return next;
     });
+  }
+
+  function handleCardPress(id: string) {
+    if (selectionMode) toggleSelect(id);
+    else onOpenAssignSheet([id]);
+  }
+
+  function handleCardLongPress(id: string) {
+    if (!selectionMode) setSelectionMode(true);
+    setSelectedOrderIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  }
+
+  function exitSelection() {
+    setSelectedOrderIds(() => new Set());
+    setSelectionMode(false);
   }
 
   return (
@@ -1040,6 +1326,7 @@ function DispatchTab({
           {drivers.map((driver) => {
             const isSelected = driver.driver_id === selectedDriverId;
             const driverOrderCount = orders.filter((o) => o.assigned_to === driver.driver_id).length;
+            const displayName = deriveDriverName(driver.driver_id);
             return (
               <Pressable
                 key={driver.driver_id}
@@ -1049,7 +1336,7 @@ function DispatchTab({
                 <View style={[styles.driverDot, { backgroundColor: isSelected ? "#C8973A" : "#0e7aa6" }]} />
                 <View>
                   <Text style={[styles.driverPillName, isSelected && { color: "#C8973A" }]} numberOfLines={1}>
-                    {driver.driver_id}
+                    {displayName}
                   </Text>
                   <Text style={styles.metaText}>{driverOrderCount} order{driverOrderCount !== 1 ? "s" : ""}</Text>
                 </View>
@@ -1062,12 +1349,7 @@ function DispatchTab({
       {/* Selected driver detail */}
       {selectedDriverId ? (
         <View style={styles.sectionCard}>
-          <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
-            <Text style={styles.sectionTitle} numberOfLines={1}>{selectedDriverId}</Text>
-            <Pressable style={[styles.btn, styles.btnGhost, { paddingHorizontal: 10, paddingVertical: 5 }]} onPress={onOptimise}>
-              <Text style={styles.btnGhostText}>⚡ Optimise</Text>
-            </Pressable>
-          </View>
+          <Text style={styles.sectionTitle} numberOfLines={1}>{deriveDriverName(selectedDriverId)}</Text>
           {routePlan ? (
             <>
               <Text style={styles.metaText}>
@@ -1085,62 +1367,66 @@ function DispatchTab({
         </View>
       ) : null}
 
-      {/* Bulk assign */}
-      {selectedOrderIds.size > 0 ? (
-        <View style={styles.sectionCard}>
-          <Text style={styles.sectionSubtitle}>Bulk Assign ({selectedOrderIds.size} selected)</Text>
-          {selectedDriverId ? (
-            <Text style={styles.metaText}>Assign to: {selectedDriverId}</Text>
-          ) : (
-            <Text style={[styles.metaText, { color: "#C8973A" }]}>Tap a driver above to select them first</Text>
-          )}
-          <View style={styles.row}>
+      {/* Unassigned queue header + selection toolbar */}
+      <View style={styles.unassignedHeader}>
+        <Text style={styles.sectionSubtitle}>
+          {selectionMode
+            ? `${selectedOrderIds.size} selected`
+            : `Unassigned (${unassignedOrders.length})`}
+        </Text>
+        {selectionMode ? (
+          <View style={{ flexDirection: "row", gap: 6 }}>
             <Pressable
-              style={[styles.btn, styles.btnPrimary, !selectedDriverId && { opacity: 0.4 }]}
-              onPress={onBulkAssign}
-              disabled={!selectedDriverId}
+              style={[styles.btn, styles.btnPrimary, { paddingHorizontal: 12, paddingVertical: 6 }, !selectedOrderIds.size && { opacity: 0.4 }]}
+              onPress={() => onOpenAssignSheet(Array.from(selectedOrderIds))}
+              disabled={!selectedOrderIds.size}
             >
-              <Text style={styles.btnText}>Assign Selected</Text>
+              <Text style={styles.btnText}>Assign {selectedOrderIds.size}</Text>
             </Pressable>
-            <Pressable style={[styles.btn, styles.btnGhost]} onPress={() => setSelectedOrderIds(() => new Set())}>
-              <Text style={styles.btnGhostText}>Clear</Text>
+            <Pressable
+              style={[styles.btn, styles.btnGhost, { paddingHorizontal: 12, paddingVertical: 6 }]}
+              onPress={exitSelection}
+            >
+              <Text style={styles.btnGhostText}>Cancel</Text>
             </Pressable>
           </View>
-        </View>
-      ) : null}
-
-      {/* Unassigned queue */}
-      <Text style={styles.sectionSubtitle}>Unassigned ({unassignedOrders.length})</Text>
+        ) : null}
+      </View>
       {unassignedOrders.length === 0 ? (
         <Text style={styles.metaText}>All orders assigned ✓</Text>
       ) : null}
-      {unassignedOrders.map((order) => (
-        <View key={order.id} style={[styles.orderCard, selectedOrderIds.has(order.id) && styles.orderCardSelected]}>
-          <Pressable onPress={() => toggleSelect(order.id)} style={styles.orderCheckRow}>
-            <View style={[styles.checkbox, selectedOrderIds.has(order.id) && styles.checkboxChecked]}>
-              {selectedOrderIds.has(order.id) ? <Text style={styles.checkboxMark}>✓</Text> : null}
-            </View>
-            <View style={{ flex: 1 }}>
-              <Text style={styles.orderTitle}>{order.customer_name}</Text>
-              <Text style={styles.orderMeta}>#{orderReference(order)} · {order.status}</Text>
-              <Text style={styles.orderMeta} numberOfLines={1}>Pick up: {pickupAddress(order) || "-"}</Text>
-              <Text style={styles.orderMeta} numberOfLines={1}>Deliver: {deliveryAddress(order) || "-"}</Text>
-              {order.time_window_end ? (
-                <Text style={styles.orderMeta}>Due: {formatTime(order.time_window_end)}</Text>
+      {unassignedOrders.map((order) => {
+        const isSelected = selectedOrderIds.has(order.id);
+        return (
+          <Pressable
+            key={order.id}
+            onPress={() => handleCardPress(order.id)}
+            onLongPress={() => handleCardLongPress(order.id)}
+            delayLongPress={350}
+            style={[styles.orderCard, isSelected && styles.orderCardSelected]}
+          >
+            <View style={styles.orderCheckRow}>
+              {selectionMode ? (
+                <View style={[styles.checkbox, isSelected && styles.checkboxChecked]}>
+                  {isSelected ? <Text style={styles.checkboxMark}>✓</Text> : null}
+                </View>
+              ) : null}
+              <View style={{ flex: 1 }}>
+                <Text style={styles.orderTitle}>{order.customer_name}</Text>
+                <Text style={styles.orderMeta}>#{orderReference(order)} · {order.status}</Text>
+                <Text style={styles.orderMeta} numberOfLines={1}>Pick up: {pickupAddress(order) || "-"}</Text>
+                <Text style={styles.orderMeta} numberOfLines={1}>Deliver: {deliveryAddress(order) || "-"}</Text>
+                {order.time_window_end ? (
+                  <Text style={styles.orderMeta}>Due: {formatTime(order.time_window_end)}</Text>
+                ) : null}
+              </View>
+              {!selectionMode ? (
+                <Text style={styles.orderChevron}>›</Text>
               ) : null}
             </View>
           </Pressable>
-          <Pressable
-            style={[styles.btn, styles.btnPrimary, { marginTop: 8 }, !selectedDriverId && { opacity: 0.4 }]}
-            onPress={() => onAssign(order.id)}
-            disabled={!selectedDriverId}
-          >
-            <Text style={styles.btnText}>
-              {selectedDriverId ? `Assign to ${selectedDriverId}` : "Select a driver first"}
-            </Text>
-          </Pressable>
-        </View>
-      ))}
+        );
+      })}
 
       {/* Assigned orders for selected driver */}
       {selectedDriverId && assignedOrders.length > 0 ? (
@@ -1161,6 +1447,162 @@ function DispatchTab({
         </>
       ) : null}
     </>
+  );
+}
+
+// ── Assign sheet ─────────────────────────────────────────────────────────────
+
+type AssignSheetProps = {
+  orderIds: string[] | null;
+  orders: OrderRecord[];
+  drivers: DriverLocationRecord[];
+  getPickupCoord: (order: OrderRecord) => { lat: number; lng: number } | null;
+  previewDriverId: string | null;
+  onPreview: (driverId: string | null) => void;
+  onConfirm: (driverId: string) => void;
+  onClose: () => void;
+};
+
+function AssignSheet({
+  orderIds,
+  orders,
+  drivers,
+  getPickupCoord,
+  previewDriverId,
+  onPreview,
+  onConfirm,
+  onClose,
+}: AssignSheetProps) {
+  const visible = !!orderIds && orderIds.length > 0;
+
+  const refOrder = useMemo(() => {
+    if (!orderIds?.length) return null;
+    return orders.find((o) => o.id === orderIds[0]) || null;
+  }, [orderIds, orders]);
+
+  const pickupCoord = refOrder ? getPickupCoord(refOrder) : null;
+  const isMulti = (orderIds?.length || 0) > 1;
+
+  const rankedDrivers = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const o of orders) {
+      if (o.assigned_to) counts.set(o.assigned_to, (counts.get(o.assigned_to) || 0) + 1);
+    }
+    const enriched = drivers.map((d) => {
+      const distance =
+        pickupCoord && !isMulti
+          ? haversineDistance(pickupCoord.lat, pickupCoord.lng, d.lat, d.lng)
+          : null;
+      return { driver: d, distance, load: counts.get(d.driver_id) || 0 };
+    });
+    enriched.sort((a, b) => {
+      if (isMulti || !pickupCoord) {
+        if (a.load !== b.load) return a.load - b.load;
+        return a.driver.driver_id.localeCompare(b.driver.driver_id);
+      }
+      if (a.distance == null && b.distance == null) return a.load - b.load;
+      if (a.distance == null) return 1;
+      if (b.distance == null) return -1;
+      return a.distance - b.distance;
+    });
+    return enriched;
+  }, [drivers, orders, pickupCoord, isMulti]);
+
+  const headerLabel = isMulti
+    ? `Assign ${orderIds!.length} orders`
+    : refOrder
+      ? `Assign · ${refOrder.customer_name}`
+      : "Assign";
+
+  const previewedDriver =
+    previewDriverId && !isMulti
+      ? rankedDrivers.find((r) => r.driver.driver_id === previewDriverId)
+      : null;
+  const previewedDriverName = previewedDriver
+    ? deriveDriverName(previewedDriver.driver.driver_id)
+    : null;
+
+  function handleRowPress(driverId: string) {
+    if (isMulti) {
+      // Bulk-assign: skip preview, confirm immediately.
+      onConfirm(driverId);
+    } else {
+      // Toggle preview: tapping the already-selected driver clears it.
+      onPreview(previewDriverId === driverId ? null : driverId);
+    }
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable style={styles.modalBackdrop} onPress={onClose}>
+        <Pressable style={styles.modalCard} onPress={() => undefined}>
+          <View style={styles.modalHeader}>
+            <Text style={styles.modalTitle} numberOfLines={1}>{headerLabel}</Text>
+            <Pressable onPress={onClose}>
+              <Text style={styles.modalClose}>✕</Text>
+            </Pressable>
+          </View>
+          {!isMulti && refOrder ? (
+            <Text style={styles.metaText} numberOfLines={1}>
+              Pick up: {pickupAddress(refOrder) || "-"}
+            </Text>
+          ) : null}
+          {!isMulti && !pickupCoord ? (
+            <Text style={[styles.metaText, { color: "#8A7AA8" }]}>
+              Locating pickup… drivers sorted by load.
+            </Text>
+          ) : null}
+          {!isMulti && previewedDriverName ? (
+            <Text style={[styles.metaText, { color: "#9D6FC8", fontWeight: "700" }]}>
+              Previewing route for {previewedDriverName}
+            </Text>
+          ) : !isMulti && pickupCoord ? (
+            <Text style={[styles.metaText, { color: "#8A7AA8" }]}>
+              Tap a driver to preview their route to pickup.
+            </Text>
+          ) : null}
+          {drivers.length === 0 ? (
+            <Text style={[styles.metaText, { paddingVertical: 16, textAlign: "center" }]}>
+              No active drivers. Drivers must share location to appear here.
+            </Text>
+          ) : (
+            <ScrollView style={{ maxHeight: 320 }}>
+              {rankedDrivers.map(({ driver, distance, load }) => {
+                const isPreviewed = previewDriverId === driver.driver_id;
+                const displayName = deriveDriverName(driver.driver_id);
+                return (
+                  <Pressable
+                    key={driver.driver_id}
+                    style={[styles.driverRow, isPreviewed && styles.driverRowSelected]}
+                    onPress={() => handleRowPress(driver.driver_id)}
+                  >
+                    <View style={[styles.driverDot, { backgroundColor: isPreviewed ? "#9D6FC8" : "#0e7aa6" }]} />
+                    <View style={{ flex: 1 }}>
+                      <Text style={styles.driverRowName} numberOfLines={1}>{displayName}</Text>
+                      <Text style={styles.metaText}>
+                        {distance != null ? `${formatDistanceMiles(distance)} away · ` : ""}
+                        {load} order{load !== 1 ? "s" : ""}
+                      </Text>
+                    </View>
+                    <Text style={[styles.driverRowAction, isPreviewed && { color: "#9D6FC8" }]}>
+                      {isMulti ? "Assign ›" : isPreviewed ? "● Preview" : "Preview ›"}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+          )}
+          {!isMulti && previewDriverId && previewedDriverName ? (
+            <Pressable
+              style={[styles.btn, styles.btnPrimary, { marginTop: 8 }]}
+              onPress={() => onConfirm(previewDriverId)}
+            >
+              <Text style={styles.btnText}>✓ Assign to {previewedDriverName}</Text>
+            </Pressable>
+          ) : null}
+        </Pressable>
+      </Pressable>
+    </Modal>
   );
 }
 
@@ -1481,6 +1923,50 @@ const styles = StyleSheet.create({
   },
   checkboxChecked: { backgroundColor: "#C8973A", borderColor: "#C8973A" },
   checkboxMark: { color: "#0B0910", fontWeight: "800", fontSize: 12 },
+  orderChevron: { color: "#6B5F80", fontSize: 22, lineHeight: 22, marginLeft: 6 },
+  unassignedHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: 4,
+  },
+  driverRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: "#241A33",
+  },
+  driverRowName: { color: "#EDE0C4", fontSize: 14, fontWeight: "700" },
+  driverRowAction: { color: "#C8973A", fontSize: 13, fontWeight: "700" },
+  driverRowSelected: {
+    backgroundColor: "#1F1730",
+    borderBottomColor: "#9D6FC8",
+  },
+  assignToast: {
+    position: "absolute",
+    top: 64,
+    alignSelf: "center",
+    backgroundColor: "#1C1628",
+    borderColor: "#C8973A",
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 6,
+    shadowColor: "#000",
+    shadowOpacity: 0.6,
+    shadowRadius: 10,
+    elevation: 8,
+    zIndex: 1000,
+  },
+  assignToastText: {
+    color: "#F5D98B",
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
   editBtn: {
     borderWidth: 1,
     borderColor: "#3A2F50",


### PR DESCRIPTION
## Summary

- **Order-first assign flow** in the mobile dispatch view: tap an unassigned order → bottom sheet of drivers ranked by proximity → tap a driver to preview their road-following route to pickup (purple polyline) → confirm to commit. Replaces the previous driver-first flow that required selecting a driver before any assignment was possible.
- **Server-side driver simulator** with an in-memory state machine + asyncio tick loop. Spawns N synthetic drivers per area, has them roam, and on assignment routes them OSRM → pickup → delivery, auto-progressing order status. Controlled from a new gear-icon settings panel in the mobile app, gated to the `cody.carmichael` account.
- **Photon-backed geocoder** in the backend: previously local dev fell back to a deterministic address-hash that produced 1484-mile "Fort Worth → Fort Worth" routes. Now uses https://photon.komoot.io with a real User-Agent header (the default `python-requests` UA was being 403'd). Tests are unaffected — they explicitly set `USE_IN_MEMORY_GEOCODER=true`.
- **Visual polish**: WoW-style SVG marker pins matching the web app (dark circle, gold border, glyph), driver name labels next to driver pins, restyled popups with structured rows and an in-popup "⚡ Assign Driver" button, animated toast confirming assignment, route polyline now follows streets via OSRM multi-waypoint routing.

## Files of note

- `backend/simulator_service.py` (new) — state machine, OSRM/Photon, dispatch logic
- `backend/routers/simulator.py` (new) — `/admin/simulator/{spawn,stop,status,seed-orders}`, allow-listed by Cognito username
- `backend/geocode_service.py` — `PhotonAddressGeocoder`, default for local dev
- `mobile/screens/AdminScreen.tsx` — assign sheet rewrite, route preview, toast, marker prop changes
- `mobile/react-native-maps.web.js` — SVG pins, popup builder, action button wiring
- `mobile/App.tsx` — `SimulatorPanel`, gear gating, web-localhost API base default

## Test plan

- [ ] `npx tsc --noEmit` in `mobile/` (clean ✅)
- [ ] Backend imports load (`from backend.app import app`) ✅
- [ ] `cody.carmichael` sees the gear ⚙ icon; other users do not
- [ ] Spawn 5 sim drivers in Fort Worth → drivers appear on the map with name labels
- [ ] `+ Seed Orders` creates 5 unassigned orders → orange "!" pins on the map
- [ ] Tap order pin → popup shows pickup/delivery + working "Assign Driver" button
- [ ] Tap driver in assign sheet → purple road-following preview line draws on map
- [ ] Confirm assignment → toast slides down at top, sheet closes, driver pill updates load count
- [ ] Optimised route polyline (gold) follows streets, not straight lines
- [ ] Sim driver state transitions: Roaming → → Pickup → → Delivery → back to Roaming, with order status auto-progressing in the order list

## Caveats / follow-ups

- Native `react-native-maps` (iOS/Android) hasn't been updated to match the web shim's pin/popup styling — falls back to default teardrop pins on device builds. Web preview is fully styled.
- Real (non-`sim-*`) driver names still show as raw user IDs. Wiring up `/drivers/roster` lookup to display Cognito usernames is a TODO.
- Cognito ID tokens have a 1-hour TTL and the mobile app doesn't auto-refresh — sessions silently break mid-use until you sign out + back in. Worth fixing as a separate change.
- Status-aware order pins (assigned/picked_up/en_route variants) are scaffolded in the web shim but the dispatch view only renders unassigned pickup pins today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)