### PR TITLE
fix(dispatch): show driver name instead of UUID on assign button

### DIFF
--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -314,7 +314,7 @@
       if (isUnassigned) {
         assignBtnHtml = "<button class=\"dispatch-card-assign-btn\" type=\"button\" data-queue-action=\"assign-selected\" data-order-id=\"" +
           C.escapeHtml(order.id) + "\"" + (selectedDriverId ? "" : " disabled") + ">Assign" +
-          (selectedDriverId ? " to " + C.escapeHtml(selectedDriverId) : " (select driver)") + "</button>";
+          (selectedDriverId ? " to " + C.escapeHtml(_driverDisplayName(selectedDriverId)) : " (select driver)") + "</button>";
       } else if (order.status !== "Delivered" && order.status !== "Failed") {
         assignBtnHtml = "<button class=\"dispatch-card-unassign-btn\" type=\"button\" data-queue-action=\"unassign\" data-order-id=\"" +
           C.escapeHtml(order.id) + "\">Unassign</button>";


### PR DESCRIPTION
## Summary

- The "Assign to" button on dispatch order cards was displaying the raw driver UUID (e.g. `8488E458-50F1-7067-6FE5-A7B5732A7B95`) instead of the driver's name
- Fixed by replacing `selectedDriverId` with `_driverDisplayName(selectedDriverId)` in the button label — this helper already exists and is used elsewhere in the dispatch UI to resolve UUIDs to driver usernames from the roster

## Test plan

- [ ] Select a driver in the dispatch panel
- [ ] Confirm the "Assign to" button on order cards shows the driver's name (e.g. "Assign to Tyler Furmiss") instead of their UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)