### PR TITLE
fix(dispatch): resolve driver display name from Cognito name claims

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -357,9 +357,14 @@ def _claims_to_identity(claims: Dict[str, Any]) -> Dict[str, Any]:
     if not sub:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing sub claim")
 
+    given = claims.get("given_name", "").strip()
+    family = claims.get("family_name", "").strip()
+    full_name = claims.get("name", "").strip() or " ".join(filter(None, [given, family])) or None
+
     return {
         "sub": sub,
         "username": claims.get("cognito:username") or claims.get("username"),
+        "name": full_name,
         "email": claims.get("email"),
         "org_id": _extract_org_id(claims),
         "groups": groups,

--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -2417,7 +2417,7 @@
       html += "<li class=\"dispatch-driver-section-label\">Online (" + driverLocations.length + ")</li>";
       html += driverLocations.map(function (item) {
         var rosterEntry = roster.find(function (r) { return r.user_id === item.driver_id; });
-        var displayName = (rosterEntry && rosterEntry.username) || item.driver_id;
+        var displayName = (rosterEntry && (rosterEntry.name || rosterEntry.username)) || item.driver_id;
         var photoUrl = rosterEntry && rosterEntry.photo_url;
         var selectedClass = item.driver_id === selectedDriverId ? " is-selected" : "";
         var avatarHtml = photoUrl
@@ -2440,7 +2440,7 @@
     if (offlineDrivers.length) {
       html += "<li class=\"dispatch-driver-section-label\">Offline (" + offlineDrivers.length + ")</li>";
       html += offlineDrivers.map(function (d) {
-        var displayName = d.username || d.user_id;
+        var displayName = d.name || d.username || d.user_id;
         var photoUrl = d.photo_url;
         var selectedClass = d.user_id === selectedDriverId ? " is-selected" : "";
         var avatarHtml = photoUrl
@@ -2471,10 +2471,12 @@
     if (!driverId) return "Unassigned";
     var roster = lastDriverRoster || [];
     var match = roster.find(function (r) { return r.user_id === driverId; });
+    if (match && match.name) return match.name;
     if (match && match.username) return match.username;
     var loc = (lastDriverLocations || []).find(function (d) { return d.driver_id === driverId; });
     if (loc && loc.username) return loc.username;
     var assignable = assignableDriverList.find(function (u) { return u.user_id === driverId; });
+    if (assignable && assignable.name) return assignable.name;
     if (assignable && assignable.username) return assignable.username;
     return driverId.length > 12 ? driverId.substring(0, 8) + "\u2026" : driverId;
   }
@@ -2542,9 +2544,9 @@
         return;
       }
       seen.add(userId);
-      const username = user && user.username ? String(user.username).trim() : "";
+      const displayName = (user && (user.name || user.username)) ? String(user.name || user.username).trim() : "";
       const email = user && user.email ? String(user.email).trim() : "";
-      const label = [username, email].filter(Boolean).join(" | ");
+      const label = [displayName, email].filter(Boolean).join(" | ");
       options.push(
         "<option value=\"" +
         C.escapeHtml(userId) +

--- a/backend/routers/drivers.py
+++ b/backend/routers/drivers.py
@@ -21,6 +21,7 @@ router = APIRouter(prefix="/drivers", tags=["drivers"])
 class DriverRosterEntry(BaseModel):
     user_id: str
     username: Optional[str] = None
+    name: Optional[str] = None
     email: Optional[str] = None
     phone: Optional[str] = None
     photo_url: Optional[str] = None
@@ -90,6 +91,7 @@ async def list_driver_roster(
         entry = DriverRosterEntry(
             user_id=u.user_id,
             username=u.username,
+            name=u.name,
             email=u.email,
             phone=getattr(u, "phone", None),
             photo_url=getattr(u, "photo_url", None),

--- a/backend/routers/identity.py
+++ b/backend/routers/identity.py
@@ -85,6 +85,7 @@ def _sync_user(user, repo) -> UserRecord:
         user_id=user["sub"],
         # Fields sourced from the JWT / Cognito — always overwrite.
         username=user.get("username"),
+        name=user.get("name") or (existing_user.name if existing_user else None),
         email=user.get("email"),
         roles=user.get("groups", []),
         is_active=True,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -170,6 +170,7 @@ class UserRecord(BaseModel):
     org_id: str
     user_id: str
     username: Optional[str] = None
+    name: Optional[str] = None
     email: Optional[str] = None
     phone: Optional[str] = None
     photo_url: Optional[str] = None

--- a/email_poller_fn/schemas.py
+++ b/email_poller_fn/schemas.py
@@ -170,6 +170,7 @@ class UserRecord(BaseModel):
     org_id: str
     user_id: str
     username: Optional[str] = None
+    name: Optional[str] = None
     email: Optional[str] = None
     phone: Optional[str] = None
     photo_url: Optional[str] = None


### PR DESCRIPTION
## Summary

- The assign button and driver list were showing UUIDs because `cognito:username` is an auto-generated UUID for email-based Cognito accounts — my previous fix used `_driverDisplayName()` but that still returned the UUID since it was stored as the username
- This change threads the actual Cognito `name` / `given_name` + `family_name` attributes through the full stack

**Changes:**
- `auth.py` — extract `name` from `name`, `given_name`+`family_name` JWT claims
- `schemas.py` (backend + email_poller_fn) — add `name: Optional[str]` to `UserRecord`
- `identity.py` — write `name` when syncing user record from JWT on login
- `drivers.py` — add `name` to `DriverRosterEntry`, pass it through the roster endpoint
- `admin.js` — prefer `name` over `username` in `_driverDisplayName`, driver list cards, and the assignable driver options label

## Test plan

- [ ] Log in as a driver whose Cognito account has `given_name`/`family_name` set
- [ ] In the dispatch panel, select that driver
- [ ] Confirm "Assign to [First Last]" appears on order cards instead of the UUID
- [ ] Confirm driver list cards also show the full name

🤖 Generated with [Claude Code](https://claude.com/claude-code)