### PR TITLE
fix(admin): bump admin.js cache-busting version string

### DIFF
--- a/backend/frontend/admin.html
+++ b/backend/frontend/admin.html
@@ -703,6 +703,6 @@
 
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
   <script src="assets/common.js?v=20260420a"></script>
-  <script src="assets/admin.js?v=20260420a"></script>
+  <script src="assets/admin.js?v=20260513a"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Previous PRs (#141, #142) fixed the driver UUID display bug in `admin.js`, but browsers were still serving the cached old file because the `?v=` query string on the `<script>` tag hadn't changed
- Bumping `?v=20260420a` → `?v=20260513a` forces browsers to fetch the updated `admin.js`

## Test plan

- [ ] Hard-refresh the dispatch page after deploy
- [ ] Select a driver in the panel — confirm "Assign to [name]" on order cards shows the driver's name instead of UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)