### PR TITLE
feat(admin): replace driver id text filter with name dropdown on Orders page

### DIFF
--- a/backend/frontend/admin.html
+++ b/backend/frontend/admin.html
@@ -172,7 +172,9 @@
               </label>
               <label class="field">
                 <span>Assigned Driver</span>
-                <input id="orders-assigned-filter" name="assigned_to" placeholder="driver id">
+                <select id="orders-assigned-filter" name="assigned_to">
+                  <option value="">Any driver</option>
+                </select>
               </label>
               <label class="field">
                 <span>Assignment</span>

--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -2529,16 +2529,11 @@
 
   function renderDriverOptions(users) {
     assignableDriverList = Array.isArray(users) ? users : [];
-    if (!el.driverOptions) {
-      return;
-    }
-    if (!users || !users.length) {
-      el.driverOptions.innerHTML = "";
-      return;
-    }
     const seen = new Set();
-    const options = [];
-    users.forEach(function (user) {
+    const datalistOpts = [];
+    const filterOpts = ["<option value=\"\">Any driver</option>"];
+
+    assignableDriverList.forEach(function (user) {
       const userId = (user && user.user_id ? String(user.user_id) : "").trim();
       if (!userId || seen.has(userId)) {
         return;
@@ -2547,15 +2542,26 @@
       const displayName = (user && (user.name || user.username)) ? String(user.name || user.username).trim() : "";
       const email = user && user.email ? String(user.email).trim() : "";
       const label = [displayName, email].filter(Boolean).join(" | ");
-      options.push(
+      datalistOpts.push(
         "<option value=\"" +
         C.escapeHtml(userId) +
         "\"" +
         (label ? " label=\"" + C.escapeHtml(label) + "\"" : "") +
         "></option>"
       );
+      filterOpts.push(
+        "<option value=\"" + C.escapeHtml(userId) + "\">" + C.escapeHtml(displayName || userId) + "</option>"
+      );
     });
-    el.driverOptions.innerHTML = options.join("");
+
+    if (el.driverOptions) {
+      el.driverOptions.innerHTML = datalistOpts.join("");
+    }
+    if (el.ordersAssignedFilter) {
+      const currentValue = el.ordersAssignedFilter.value;
+      el.ordersAssignedFilter.innerHTML = filterOpts.join("");
+      el.ordersAssignedFilter.value = currentValue;
+    }
   }
 
   async function refreshAssignableDrivers() {


### PR DESCRIPTION
## Summary

- Replaces the free-text `driver id` input in the Orders filter bar with a `<select>` dropdown
- Dropdown is populated with driver display names (first/last name from Cognito) via the existing `refreshAssignableDrivers()` call — no new API requests needed
- Filter value remains the driver's `user_id`, so the existing `order.assigned_to` comparison logic is unchanged
- Current selection is preserved when the driver list refreshes
- Clearing filters resets the dropdown to "Any driver" as expected

## What changed

**`backend/frontend/admin.html`** — swapped the `<input placeholder="driver id">` for a `<select id="orders-assigned-filter">` with a default "Any driver" option.

**`backend/frontend/assets/admin.js`** — refactored `renderDriverOptions` to build both the existing datalist (used by the bulk-assign input) and the new filter `<select>` in a single pass over the driver list.

## Reviewer notes

- The `_readOrderFilters`, `_writeOrderFilters`, and `clearOrderFilters` functions all use `el.ordersAssignedFilter.value`, which works identically on a `<select>` — no changes needed there.
- Driver names shown are `user.name || user.username`, consistent with the fix in #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)