### PR TITLE
fix(orders): convert floats to Decimal before DynamoDB put_item (fixes #151)

### DIFF
--- a/backend/order_store.py
+++ b/backend/order_store.py
@@ -1,6 +1,8 @@
+import json
 import os
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     import boto3
@@ -8,6 +10,17 @@ try:
 except ImportError:  # pragma: no cover - boto3 available in Lambda
     boto3 = None
     Key = None
+
+
+def _floats_to_decimal(item: Any) -> Any:
+    """Recursively convert Python floats to Decimal for DynamoDB compatibility.
+
+    boto3's high-level Table resource serializer rejects Python floats and
+    requires Decimal. `Order.model_dump(mode="json")` produces JSON-compatible
+    types where Decimal becomes float — we round-trip through JSON with
+    `parse_float=Decimal` to flip them back without touching int / bool / str.
+    """
+    return json.loads(json.dumps(item), parse_float=Decimal)
 
 try:
     from backend.schemas import Order, OrderStatus
@@ -165,7 +178,9 @@ class DynamoOrderStore(OrderStore):
         else:
             item.pop(_EXTERNAL_LOOKUP_ATTR, None)
 
-        self._table.put_item(Item=item)
+        # boto3 Table resource serializer rejects Python floats; flip floats to
+        # Decimal so numeric fields like `weight` persist correctly.
+        self._table.put_item(Item=_floats_to_decimal(item))
         return order
 
     def _query_orders(self, **query_kwargs) -> List[Order]:

--- a/backend/tests/test_order_store.py
+++ b/backend/tests/test_order_store.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Optional
 
 from backend.order_store import DynamoOrderStore
@@ -187,3 +188,44 @@ def test_upsert_order_writes_derived_index_keys():
     assert first["source_external_order_id"] == "shopify#ext-1"
     assert "assigned_driver_id" not in second
     assert "source_external_order_id" not in second
+
+
+def test_upsert_order_serializes_weight_as_decimal_not_float():
+    """Regression: boto3 Table.put_item rejects Python floats — must be Decimal.
+
+    Previously `order.model_dump(mode="json")` produced a `float` for `weight`,
+    which caused HTTP 500 on POST /orders/ whenever weight was supplied.
+    """
+    table = _FakeTable()
+    store = _store_with_table(table)
+    now = datetime.now(timezone.utc)
+
+    store.upsert_order(
+        Order(
+            id="ord-weight",
+            customer_name="Alice",
+            reference_id="200",
+            pick_up_street="Warehouse 1",
+            pick_up_city="Test City",
+            pick_up_state="TS",
+            pick_up_zip="00000",
+            delivery_street="123 Main St",
+            delivery_city="Dest City",
+            delivery_state="DS",
+            delivery_zip="99999",
+            weight=4.5,
+            num_packages=1,
+            status=OrderStatus.CREATED,
+            created_at=now,
+            org_id="org-1",
+        )
+    )
+
+    item = table.put_calls[0]
+    assert isinstance(item["weight"], Decimal), (
+        f"weight must be Decimal for DynamoDB; got {type(item['weight']).__name__}"
+    )
+    assert item["weight"] == Decimal("4.5")
+    # Integer-shaped fields must stay int so they don't become Decimal("1") and
+    # confuse strict consumers.
+    assert isinstance(item["num_packages"], int)


### PR DESCRIPTION
## Summary
- `POST /backend/orders/` returned HTTP 500 whenever the payload included `weight` (any positive int/float).
- Root cause: `order.model_dump(mode="json")` converts the schema's float/Decimal to Python `float`, then `boto3.dynamodb.Table.put_item` rejects floats with a `TypeError`.
- Fix: round-trip the dumped item through `json.dumps`/`json.loads(parse_float=Decimal)` before `put_item` so floats become `Decimal`. Integers, strings, and booleans are untouched.
- Includes a regression test that asserts `weight` is serialized as `Decimal` and `num_packages` stays `int`.

## QA repro that prompted this fix
```bash
$ curl -X POST -b admin.txt -H 'Content-Type: application/json' \
  -d '{"customer_name":"X","reference_id":"R","pick_up_street":"1","pick_up_city":"C","pick_up_state":"S","pick_up_zip":"Z","delivery_street":"2","delivery_city":"D","delivery_state":"S","delivery_zip":"Z","weight":5.0}' \
  https://m50fjhgrn7.execute-api.us-east-1.amazonaws.com/dev/backend/orders/
HTTP/1.1 500 Internal Server Error
```

Same payload without `weight` → 200 OK.

## Test plan
- [x] `pytest backend/tests/test_order_store.py` — 5/5 pass including the new regression test.
- [x] Pydantic round-trip check: `Order.model_validate({...'weight': Decimal('4.5')...}).weight == 4.5` (float).
- [ ] After deploy: rerun the curl repro against dev — expect 200 OK with persisted weight.
- [ ] QA plan §4.1 A9 (Create order with all required fields) row passes.

Fixes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)