### PR TITLE
fix(auth): Sign In routes to Stage C custom login, not Cognito Hosted UI (fixes #158)

### DIFF
--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -3628,9 +3628,10 @@
   });
   if (el.loginScreenBtn) {
     el.loginScreenBtn.addEventListener("click", function () {
-      launchHostedLogin().catch(function (error) {
-        C.showMessage(el.loginScreenMessage, error.message, "error");
-      });
+      // Stage C: route to the in-app SRP login page, not the Cognito Hosted
+      // UI. Pass `?next=` so login.js redirects us back here after success.
+      var next = window.location.pathname + (window.location.search || "");
+      window.location.assign(apiBase + "/ui/login?next=" + encodeURIComponent(next));
     });
   }
   var loginCreateAccount = document.getElementById("login-create-account");

--- a/backend/frontend/assets/driver.js
+++ b/backend/frontend/assets/driver.js
@@ -1111,9 +1111,10 @@
   // Login screen button
   if (el.loginScreenBtn) {
     el.loginScreenBtn.addEventListener("click", function () {
-      launchHostedLogin().catch(function (e) {
-        if (el.loginScreenMessage) C.showMessage(el.loginScreenMessage, e.message, "error");
-      });
+      // Stage C: route to the in-app SRP login page, not the Cognito Hosted
+      // UI. Pass `?next=` so login.js redirects us back to the driver app.
+      var next = window.location.pathname + (window.location.search || "");
+      window.location.assign(apiBase + "/ui/login?next=" + encodeURIComponent(next));
     });
   }
   var loginCreateAccount = document.getElementById("login-create-account");

--- a/backend/frontend/assets/login.js
+++ b/backend/frontend/assets/login.js
@@ -39,7 +39,18 @@
     });
   }
 
-  function resolveAdminPath() {
+  function resolvePostLoginPath() {
+    // Honor an explicit ?next=<same-origin path> if the caller (admin.js /
+    // driver.js Sign In buttons) handed us one. Strictly validate that it
+    // begins with "/" and contains no scheme/host so we can't be coerced into
+    // redirecting off-domain.
+    try {
+      var params = new URLSearchParams(window.location.search || "");
+      var next = (params.get("next") || "").trim();
+      if (next && next.charAt(0) === "/" && next.indexOf("//") !== 0 && next.indexOf(":") === -1) {
+        return next;
+      }
+    } catch (_) {}
     if (_adminPath.trim()) return _adminPath.trim();
     var p = window.location.pathname;
     return p.endsWith("/login") ? p.slice(0, -"/login".length) + "/admin" : "/ui/admin";
@@ -84,7 +95,7 @@
         return;
       }
       await setSessionCookie(result.idToken);
-      window.location.assign(resolveAdminPath());
+      window.location.assign(resolvePostLoginPath());
     } catch (err) {
       C.showMessage(el.message, friendlyError(err), "error");
       el.submit.disabled = false;
@@ -101,7 +112,7 @@
     try {
       var result = await DiscraAuth.completeNewPassword(_pendingChallengeUser, newPw);
       await setSessionCookie(result.idToken);
-      window.location.assign(resolveAdminPath());
+      window.location.assign(resolvePostLoginPath());
     } catch (err) {
       C.showMessage(el.newPasswordMessage, friendlyError(err), "error");
       el.newPasswordSubmit.disabled = false;
@@ -161,7 +172,7 @@
     try {
       var session = await C.getAuthSession(apiBase);
       if (session && session.active) {
-        window.location.assign(resolveAdminPath());
+        window.location.assign(resolvePostLoginPath());
         return;
       }
     } catch (_) {}

--- a/backend/tests/test_ui.py
+++ b/backend/tests/test_ui.py
@@ -64,7 +64,7 @@ def test_ui_assets_and_service_worker_are_served():
     assert "DiscraCommon" in common_js.text
     assert "startHostedLogin" in common_js.text
     assert "consumeHostedLoginCallback" in common_js.text
-    assert "resolveAdminPath" in login_js.text
+    assert "resolvePostLoginPath" in login_js.text
     assert "IntersectionObserver" in landing_js.text
     assert "DiscraAdmin" in admin_manifest.text
     assert "DiscraDriver" in driver_manifest.text


### PR DESCRIPTION
## Summary
- The full-screen Sign In button on the admin dispatch console and the driver app still called `launchHostedLogin()` and sent users to the default Amazon Cognito login screen. Stage C (commit `bd930d8`) added the custom SRP login flow but never rewired these entry points.
- Wires both `#login-screen-btn` click handlers to navigate to `<apiBase>/ui/login?next=<current path>`.
- Teaches `login.js` to honor `?next=` for post-success redirect, with strict same-origin validation so the param can't be used to redirect off-domain.
- Leaves the explicit "Hosted UI login" fallback button inside the Admin tab Session/Auth panel untouched.

## Verification (driven through a static preview of `backend/frontend/`)
- **Admin** — click Sign In → navigates to `/ui/login?next=%2Fadmin.html` ✓
- **Driver** — click Sign In → navigates to `/ui/login?next=%2Fdriver.html` ✓
- **`next=` validator** — same-origin paths accepted; rejects `https://evil.com/admin`, `//evil.com/admin`, `javascript:alert(1)`, `data:text/html,xxx`, and `admin` (relative).

## Test plan
- [x] Static-preview verification of both click handlers + `next=` validator (above).
- [ ] After deploy:
  - [ ] Open `/dev/backend/ui/admin` logged-out — click Sign In — confirm lands on Stage C login (no Cognito Hosted UI).
  - [ ] Complete SRP login with a real Cognito user — confirm redirected back to `/dev/backend/ui/admin`.
  - [ ] Repeat from `/dev/backend/ui/driver` — confirm redirected back to driver app.
  - [ ] Try a tampered URL like `/ui/login?next=https://evil.com` — confirm login.js falls back to `admin_redirect_path` and does NOT navigate to the attacker URL.

## Out of scope (filed in #158 for follow-up)
- "Create one" link on the same login screens still calls `launchHostedSignup()` → Cognito hosted signup form. Same regression class. Should land in a separate PR once we confirm `register.html` is the right destination for the signup flow.

Fixes #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)