### PR TITLE
fix(frontend): bump cache-bust + SW versions after #159 and #162

### DIFF
--- a/backend/frontend/admin-sw.js
+++ b/backend/frontend/admin-sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "discra-admin-v20260404a";
+const CACHE_NAME = "discra-admin-v20260524a";
 const CACHE_PREFIX = "discra-admin-";
 const PRECACHE_URLS = [
   "assets/styles.css?v=20260322e",

--- a/backend/frontend/admin.html
+++ b/backend/frontend/admin.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <link rel="manifest" href="assets/admin-manifest.json">
   <meta name="theme-color" content="#0b1117">
-  <link rel="stylesheet" href="assets/styles.css?v=20260420a">
+  <link rel="stylesheet" href="assets/styles.css?v=20260524a">
 </head>
 <body class="theme-admin">
 
@@ -730,7 +730,7 @@
   </button>
 
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-  <script src="assets/common.js?v=20260420a"></script>
-  <script src="assets/admin.js?v=20260513a"></script>
+  <script src="assets/common.js?v=20260524a"></script>
+  <script src="assets/admin.js?v=20260524a"></script>
 </body>
 </html>

--- a/backend/frontend/driver-sw.js
+++ b/backend/frontend/driver-sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "discra-driver-v20260404a";
+const CACHE_NAME = "discra-driver-v20260524a";
 const PRECACHE_URLS = [
   "driver",
   "assets/driver-mobile.css",

--- a/backend/frontend/driver.html
+++ b/backend/frontend/driver.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <link rel="manifest" href="assets/driver-manifest.json">
   <meta name="theme-color" content="#0b1117">
-  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260420a">
+  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260524a">
 </head>
 <body>
 
@@ -162,7 +162,7 @@
   </div>
 
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-  <script src="assets/common.js?v=20260420a"></script>
-  <script src="assets/driver.js?v=20260420a"></script>
+  <script src="assets/common.js?v=20260524a"></script>
+  <script src="assets/driver.js?v=20260524a"></script>
 </body>
 </html>

--- a/backend/frontend/index.html
+++ b/backend/frontend/index.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700;900&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="ui/assets/styles.css?v=20260419a">
+  <link rel="stylesheet" href="ui/assets/styles.css?v=20260524a">
 </head>
 <body class="landing-theme">
   <div class="landing-atmosphere" aria-hidden="true">
@@ -136,6 +136,6 @@
       <span>Delivery Operations Platform</span>
     </footer>
   </main>
-  <script src="ui/assets/landing.js?v=20260419a"></script>
+  <script src="ui/assets/landing.js?v=20260524a"></script>
 </body>
 </html>

--- a/backend/frontend/login.html
+++ b/backend/frontend/login.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css?v=20260420a">
+  <link rel="stylesheet" href="assets/styles.css?v=20260524a">
 </head>
 <body class="theme-admin">
   <main class="center-stage">
@@ -92,8 +92,8 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/amazon-cognito-identity-js@6.3.7/dist/amazon-cognito-identity.min.js"></script>
-  <script src="assets/common.js?v=20260420a"></script>
-  <script src="assets/auth.js?v=20260420a"></script>
-  <script src="assets/login.js?v=20260420a"></script>
+  <script src="assets/common.js?v=20260524a"></script>
+  <script src="assets/auth.js?v=20260524a"></script>
+  <script src="assets/login.js?v=20260524a"></script>
 </body>
 </html>

--- a/backend/frontend/register.html
+++ b/backend/frontend/register.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css?v=20260420a">
+  <link rel="stylesheet" href="assets/styles.css?v=20260524a">
 </head>
 <body class="theme-admin">
   <div class="app-shell app-shell-compact">
@@ -96,7 +96,7 @@
     </main>
   </div>
 
-  <script src="assets/common.js?v=20260420a"></script>
-  <script src="assets/register.js?v=20260420a"></script>
+  <script src="assets/common.js?v=20260524a"></script>
+  <script src="assets/register.js?v=20260524a"></script>
 </body>
 </html>

--- a/backend/frontend/review.html
+++ b/backend/frontend/review.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css?v=20260420a">
+  <link rel="stylesheet" href="assets/styles.css?v=20260524a">
 </head>
 <body class="theme-admin">
   <div class="app-shell app-shell-compact">
@@ -85,7 +85,7 @@
     </main>
   </div>
 
-  <script src="assets/common.js?v=20260420a"></script>
-  <script src="assets/review.js?v=20260420a"></script>
+  <script src="assets/common.js?v=20260524a"></script>
+  <script src="assets/review.js?v=20260524a"></script>
 </body>
 </html>

--- a/backend/frontend/simulator.html
+++ b/backend/frontend/simulator.html
@@ -123,7 +123,7 @@
 </div>
 
 <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-<script src="assets/common.js?v=20260420a"></script>
+<script src="assets/common.js?v=20260524a"></script>
 <script>
 (function() {
   var C = window.DiscraCommon;


### PR DESCRIPTION
## Summary

After PRs #159 and #162 modified `admin.js`, `driver.js`, and `login.js`, the cache-bust query strings on the HTML pages and the service worker `CACHE_NAME` were not bumped. Browsers and the PWA service worker keep serving the pre-fix cached version, so users still see the **default Cognito Hosted UI** when clicking "Sign In" on `/backend/ui/admin` even though the deployed admin.js has the Stage C fix.

This was reported by QA testing — confirmed the deployed admin.js contains the new `?next=` handler, but the cache strings still point at `?v=20260513a` (from #143), so browsers refuse to refetch.

## What changed

Bumps every `?v=...` cache-bust string and both service-worker `CACHE_NAME` values to today's date `20260524a`:

| File | Old | New |
|---|---|---|
| admin.html, driver.html, login.html, register.html, review.html, simulator.html | `?v=20260513a`, `?v=20260420a` | `?v=20260524a` |
| index.html | `?v=20260419a` | `?v=20260524a` |
| admin-sw.js | `discra-admin-v20260404a` | `discra-admin-v20260524a` |
| driver-sw.js | `discra-driver-v20260404a` | `discra-driver-v20260524a` |

21 string replacements across 9 files.

## How users get the fix

For browser-only users (no PWA install):
- Hard refresh (`Ctrl+Shift+R` / `Cmd+Shift+R`) — the new `?v=` triggers a fresh fetch.

For PWA installs:
- The next visit triggers the service worker to detect the new `CACHE_NAME`, evict the old cache (the cleanup logic in the SW already does this for any key with `CACHE_PREFIX` that isn't the current `CACHE_NAME`), and refetch.
- Some browsers may require a second reload after the SW activates.

## Follow-up worth doing

This is the **second time** the cache-bust string has needed a manual bump after merging frontend changes (first time was PR #143 in May). It will keep happening. Two ways to make it automatic:

1. **Build-step approach** — derive `?v=` from the file's git SHA or content hash. A simple `pre-build` script reads `admin.js`, computes a short hash, and rewrites the `?v=` in admin.html.
2. **CI lint** — a check that fails the PR if `admin.js` (or any other versioned asset) was modified without bumping its `?v=` in the referencing HTML.

Worth filing as a tooling task. For now, the manual bump unblocks the QA cycle.

## Test plan

- [x] Confirmed deployed admin.js contains the post-#159 click handler that navigates to `/ui/login?next=...`.
- [ ] After this PR merges + deploys:
  - Open `/dev/backend/ui/admin` in a clean browser session, click **Sign In** — should land on the Discra-branded login page at `/dev/backend/ui/login?next=...` (NOT Cognito).
  - Hard-refresh existing tabs with the old cache; same expectation.
  - PWA-installed users: open the installed app, confirm the SW updates and Sign In goes to the custom login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)