### PR TITLE
fix(mobile): exclude Delivered/Failed from Dispatch tab order lists (mobile parity for #164)

### DIFF
--- a/mobile/screens/AdminScreen.tsx
+++ b/mobile/screens/AdminScreen.tsx
@@ -300,8 +300,14 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
     );
   }, [orders, searchQuery]);
 
+  // Dispatch tab is about active work — exclude Delivered/Failed so the
+  // map markers and assignment lists don't show completed orders. Matches
+  // the web behavior introduced in PR #164 for the desktop dispatch list.
   const unassignedOrders = useMemo(
-    () => filteredOrders.filter((o) => !o.assigned_to),
+    () =>
+      filteredOrders.filter(
+        (o) => !o.assigned_to && o.status !== "Delivered" && o.status !== "Failed"
+      ),
     [filteredOrders]
   );
 
@@ -326,11 +332,15 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
     return pickupCacheRef.current.get(addr.trim().toLowerCase()) || null;
   }, []);
 
+  // Active assigned orders only — terminal orders live in Order History.
   const assignedOrders = useMemo(
-    () =>
-      selectedDriverId
-        ? filteredOrders.filter((o) => o.assigned_to === selectedDriverId)
-        : filteredOrders.filter((o) => !!o.assigned_to),
+    () => {
+      const isActive = (o: OrderRecord) =>
+        o.status !== "Delivered" && o.status !== "Failed";
+      return selectedDriverId
+        ? filteredOrders.filter((o) => o.assigned_to === selectedDriverId && isActive(o))
+        : filteredOrders.filter((o) => !!o.assigned_to && isActive(o));
+    },
     [filteredOrders, selectedDriverId]
   );
 


### PR DESCRIPTION
## Summary

Mobile parity for the dispatch-list filter fix shipped in PR #164. The Dispatch tab on mobile (mobile/screens/AdminScreen.tsx) was showing Delivered/Failed orders in both:
- Map markers for unassigned pickups (\`unassignedOrders\`)
- Assigned-orders list grouped by driver (\`assignedOrders\`)

Order History (Orders tab > History sub-tab) already covers the terminal-status view, so these orders had no business cluttering the active dispatch view.

Now both computed values filter to non-terminal statuses.

## Mobile audit results — for the record

While verifying parity I checked all 5 web fixes against the mobile codebase:

| Web fix | Mobile equivalent? | Action |
|---|---|---|
| #1 Delivered in active list | **YES — same bug** | **Fix in this PR** |
| #2 Driver dropdown UX | NO — mobile already uses a custom Modal bottom sheet with names, distance, and load | none |
| #3 Audit Logs on wrong page | NO — mobile already renders Audit Logs inside the Admin tab | none |
| #4 POD required for Delivered (backend) | Backend-enforced; mobile drivers benefit automatically | none |
| #4 \"View POD\" UI on Admin | **Gap** — mobile Admin has no POD viewer at all | Feature gap, flagged as follow-up |
| #5 Invitation white bg | NO — mobile invitationRow has no background, inherits dark theme | none |

## Test plan
- [x] Code change verified by inspection — both \`useMemo\` computations now exclude \`status === \"Delivered\"\` and \`status === \"Failed\"\`.
- [ ] CI: \`mobile-ci.yml\` typecheck runs against this branch.
- [ ] After merge + deploy / Expo Go reload:
  - [ ] Dispatch tab map — pickup pins shown only for unassigned **active** orders.
  - [ ] Dispatch tab right-side assigned list — Delivered/Failed orders do not appear under their drivers.
  - [ ] Orders tab > Order History — Delivered/Failed orders still listed there.

## Follow-up worth filing
Mobile Admin lacks a \"View POD\" modal — a driver can upload POD on mobile, a web admin can view it via the POD modal, but a mobile admin currently can't. Not blocking; useful for field-supervisor use cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)