### PR TITLE
feat(users+map): first_name/last_name fields + driver markers with photo/name

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -13,7 +13,14 @@ def _load_dotenv() -> None:
     env_file = Path(__file__).parent.parent / ".env"
     if not env_file.exists():
         return
-    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+    # Try UTF-8 first; fall back to UTF-16 (Windows Notepad sometimes writes .env with BOM).
+    try:
+        content = env_file.read_text(encoding="utf-8-sig")
+        if "\x00" in content:
+            raise ValueError("null bytes — likely UTF-16")
+    except (UnicodeDecodeError, ValueError):
+        content = env_file.read_text(encoding="utf-16")
+    for raw_line in content.splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue

--- a/backend/frontend/admin-sw.js
+++ b/backend/frontend/admin-sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "discra-admin-v20260530a";
+const CACHE_NAME = "discra-admin-v20260603a";
 const CACHE_PREFIX = "discra-admin-";
 const PRECACHE_URLS = [
   "assets/styles.css?v=20260322e",

--- a/backend/frontend/admin.html
+++ b/backend/frontend/admin.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <link rel="manifest" href="assets/admin-manifest.json">
   <meta name="theme-color" content="#0b1117">
-  <link rel="stylesheet" href="assets/styles.css?v=20260530a">
+  <link rel="stylesheet" href="assets/styles.css?v=20260603a">
 </head>
 <body class="theme-admin">
 
@@ -740,7 +740,7 @@
   </button>
 
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-  <script src="assets/common.js?v=20260530a"></script>
-  <script src="assets/admin.js?v=20260530a"></script>
+  <script src="assets/common.js?v=20260603a"></script>
+  <script src="assets/admin.js?v=20260603a"></script>
 </body>
 </html>

--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -2303,6 +2303,12 @@
 
   function _markerDisplayName(rosterEntry, fallbackDriverId) {
     if (rosterEntry) {
+      // Prefer structured first + last name over the legacy single-field name.
+      var first = (rosterEntry.first_name || "").trim();
+      var last = (rosterEntry.last_name || "").trim();
+      if (first && last) return first + " " + last;
+      if (first) return first;
+      if (last) return last;
       var name = (rosterEntry.name || "").trim();
       if (name) return name;
       var username = (rosterEntry.username || "").trim();
@@ -2481,7 +2487,7 @@
       html += "<li class=\"dispatch-driver-section-label\">Online (" + driverLocations.length + ")</li>";
       html += driverLocations.map(function (item) {
         var rosterEntry = roster.find(function (r) { return r.user_id === item.driver_id; });
-        var displayName = (rosterEntry && (rosterEntry.name || rosterEntry.username)) || item.driver_id;
+        var displayName = _markerDisplayName(rosterEntry, item.driver_id);
         var photoUrl = rosterEntry && rosterEntry.photo_url;
         var selectedClass = item.driver_id === selectedDriverId ? " is-selected" : "";
         var avatarHtml = photoUrl

--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -2301,15 +2301,44 @@
       .catch(function () { /* silently skip */ });
   }
 
+  function _markerDisplayName(rosterEntry, fallbackDriverId) {
+    if (rosterEntry) {
+      var name = (rosterEntry.name || "").trim();
+      if (name) return name;
+      var username = (rosterEntry.username || "").trim();
+      if (username) return username;
+    }
+    return String(fallbackDriverId || "").trim();
+  }
+
+  function _driverInitials(displayName) {
+    var raw = (displayName || "").trim();
+    if (!raw) return "?";
+    // First letter of first word + first letter of last word.
+    // "John Smith" -> "JS", "Mary Jane Watson-Doe" -> "MW", "cher" -> "C".
+    var words = raw.split(/\s+/).filter(Boolean);
+    if (words.length === 1) return words[0].charAt(0).toUpperCase();
+    var first = words[0].charAt(0).toUpperCase();
+    var last = words[words.length - 1].charAt(0).toUpperCase();
+    return first + last;
+  }
+
   function _createDriverMarkerElement(item, rosterEntry, isSelectedDriver) {
     var photoUrl = rosterEntry && rosterEntry.photo_url;
     var isTsa = rosterEntry && rosterEntry.tsa_certified;
     var borderColor = isSelectedDriver ? "#C8973A" : (isTsa ? "#7B4FA6" : "#7A5C22");
+    var displayName = _markerDisplayName(rosterEntry, item.driver_id);
+
+    // Outer wrapper: icon on top, always-visible name pill below it.
+    var wrapper = document.createElement("div");
+    wrapper.className = "dispatch-map-marker" + (isSelectedDriver ? " is-selected" : "");
+
+    var iconEl;
+
     if (isTsa) {
-      var tsaEl = document.createElement("div");
-      tsaEl.className = "dispatch-map-marker-tsa";
-      tsaEl.style.cssText = "width:42px;height:42px;cursor:pointer;position:relative;";
-      tsaEl.innerHTML = '<svg width="42" height="42" viewBox="0 0 42 42">' +
+      iconEl = document.createElement("div");
+      iconEl.className = "dispatch-map-marker-icon dispatch-map-marker-tsa";
+      iconEl.innerHTML = '<svg width="42" height="42" viewBox="0 0 42 42">' +
         '<circle cx="21" cy="21" r="19" fill="#7B4FA6" stroke="#F0C060" stroke-width="2.5"/>' +
         '<circle cx="21" cy="21" r="16" fill="none" stroke="#F0C060" stroke-width="1" opacity=".5"/>' +
         '<g transform="translate(21,22) rotate(-45) scale(.55)">' +
@@ -2319,25 +2348,39 @@
       '</svg>';
       if (photoUrl) {
         var photoOverlay = document.createElement("div");
-        photoOverlay.style.cssText = "position:absolute;bottom:-2px;right:-2px;width:18px;height:18px;border-radius:50%;border:2px solid #7B4FA6;overflow:hidden;background:#130F1A;";
+        photoOverlay.className = "dispatch-map-marker-tsa-photo";
         var pImg = document.createElement("img");
-        pImg.src = photoUrl; pImg.alt = "";
-        pImg.style.cssText = "width:100%;height:100%;object-fit:cover;";
+        pImg.src = photoUrl;
+        pImg.alt = "";
         photoOverlay.appendChild(pImg);
-        tsaEl.appendChild(photoOverlay);
+        iconEl.appendChild(photoOverlay);
       }
-      return { element: tsaEl, offset: 20 };
     } else if (photoUrl) {
-      var elDiv = document.createElement("div");
-      elDiv.className = "dispatch-map-marker-photo";
-      elDiv.style.cssText = "width:36px;height:36px;border-radius:50%;border:3px solid " + borderColor + ";overflow:hidden;cursor:pointer;background:#130F1A;box-shadow:0 0 8px rgba(200,151,58,0.35);";
+      iconEl = document.createElement("div");
+      iconEl.className = "dispatch-map-marker-icon dispatch-map-marker-photo";
+      iconEl.style.borderColor = borderColor;
       var img = document.createElement("img");
-      img.src = photoUrl; img.alt = "";
-      img.style.cssText = "width:100%;height:100%;object-fit:cover;";
-      elDiv.appendChild(img);
-      return { element: elDiv, offset: 15 };
+      img.src = photoUrl;
+      img.alt = "";
+      iconEl.appendChild(img);
+    } else {
+      // No photo — render initials so the marker stays identifiable.
+      iconEl = document.createElement("div");
+      iconEl.className = "dispatch-map-marker-icon dispatch-map-marker-initials";
+      iconEl.style.borderColor = borderColor;
+      iconEl.textContent = _driverInitials(displayName);
     }
-    return { color: borderColor, offset: 15 };
+
+    var labelEl = document.createElement("div");
+    labelEl.className = "dispatch-map-marker-label";
+    labelEl.textContent = displayName;
+
+    wrapper.appendChild(iconEl);
+    wrapper.appendChild(labelEl);
+
+    // Anchor offset accounts for the larger TSA shield (42px) vs 36px circles.
+    var offset = isTsa ? 22 : 18;
+    return { element: wrapper, offset: offset };
   }
 
   function renderDriverMarkers(driverLocations, options) {
@@ -2361,7 +2404,9 @@
       activeIds.add(item.driver_id);
       const isSelectedDriver = !!focusDriverId && item.driver_id === focusDriverId;
       var rosterEntry = roster.find(function (r) { return r.user_id === item.driver_id; });
-      var driverName = (rosterEntry && rosterEntry.username) || item.driver_id;
+      // Prefer full name; fall back to username, then user_id. Same helper
+      // backs the visible marker label so popup + label always agree.
+      var driverName = _markerDisplayName(rosterEntry, item.driver_id);
       var isTsa = rosterEntry && rosterEntry.tsa_certified;
       var popupHtml = "<strong>" + C.escapeHtml(driverName) + "</strong>" +
         (isTsa ? "<br><span style=\"color:#9D6FC8;font-weight:700;font-size:.75rem;letter-spacing:0.08em;\">TSA CERTIFIED</span>" : "") +

--- a/backend/frontend/assets/styles.css
+++ b/backend/frontend/assets/styles.css
@@ -4078,3 +4078,107 @@ body.theme-admin .billing-seat-cards .stat-card small {
   font-size: 0.75rem;
   color: var(--text-muted);
 }
+
+/* ─── Dispatch map driver markers (photo + always-visible name) ─────── */
+.dispatch-map-marker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  /* MapLibre anchors at center; the icon sits above the anchor and the
+     label floats just below. Tight gap so they read as one unit. */
+  gap: 4px;
+  /* Help the wrapper sit naturally over the point it's anchored to. */
+  transform: translateY(0);
+}
+
+.dispatch-map-marker-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #130F1A;
+  box-shadow: 0 0 8px rgba(200, 151, 58, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 3px solid var(--gold-dim, #7A5C22);
+  flex: 0 0 auto;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.dispatch-map-marker-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.dispatch-map-marker-initials {
+  background: linear-gradient(180deg, #2a2138, #1c1628);
+  color: var(--text-heading, #F5D98B);
+  font-family: var(--font-display, inherit);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dispatch-map-marker-tsa {
+  width: 42px;
+  height: 42px;
+  background: transparent;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  position: relative;
+}
+
+.dispatch-map-marker-tsa-photo {
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid #7B4FA6;
+  overflow: hidden;
+  background: #130F1A;
+}
+
+.dispatch-map-marker-tsa-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.dispatch-map-marker-label {
+  max-width: 140px;
+  padding: 2px 8px;
+  background: rgba(15, 12, 24, 0.88);
+  color: var(--text-primary, #EDE0C4);
+  font-family: var(--font-display, inherit);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border: 1px solid rgba(200, 151, 58, 0.35);
+  border-radius: 999px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
+  /* Stay above other markers' shadows but below popups. */
+  position: relative;
+  pointer-events: none;
+}
+
+.dispatch-map-marker.is-selected .dispatch-map-marker-icon {
+  transform: scale(1.08);
+  box-shadow: 0 0 14px rgba(200, 151, 58, 0.7);
+}
+
+.dispatch-map-marker.is-selected .dispatch-map-marker-label {
+  background: rgba(200, 151, 58, 0.95);
+  color: #1A1208;
+  border-color: var(--gold-primary, #C8973A);
+}

--- a/backend/routers/drivers.py
+++ b/backend/routers/drivers.py
@@ -21,6 +21,8 @@ router = APIRouter(prefix="/drivers", tags=["drivers"])
 class DriverRosterEntry(BaseModel):
     user_id: str
     username: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
     name: Optional[str] = None
     email: Optional[str] = None
     phone: Optional[str] = None
@@ -91,6 +93,8 @@ async def list_driver_roster(
         entry = DriverRosterEntry(
             user_id=u.user_id,
             username=u.username,
+            first_name=getattr(u, "first_name", None),
+            last_name=getattr(u, "last_name", None),
             name=u.name,
             email=u.email,
             phone=getattr(u, "phone", None),

--- a/backend/routers/identity.py
+++ b/backend/routers/identity.py
@@ -90,8 +90,10 @@ def _sync_user(user, repo) -> UserRecord:
         roles=user.get("groups", []),
         is_active=True,
         # User-editable profile fields — preserve whatever was last saved so
-        # that a plain GET /users/me never wipes phone, photo_url, or
-        # tsa_certified that the user previously set via PUT /users/me.
+        # that a plain GET /users/me never wipes these values that the user
+        # previously set via PUT /users/me.
+        first_name=existing_user.first_name if existing_user else None,
+        last_name=existing_user.last_name if existing_user else None,
         phone=existing_user.phone if existing_user else None,
         photo_url=existing_user.photo_url if existing_user else None,
         tsa_certified=existing_user.tsa_certified if existing_user else False,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -170,6 +170,8 @@ class UserRecord(BaseModel):
     org_id: str
     user_id: str
     username: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
     name: Optional[str] = None
     email: Optional[str] = None
     phone: Optional[str] = None
@@ -182,6 +184,8 @@ class UserRecord(BaseModel):
 
 
 class UserProfileUpdate(BaseModel):
+    first_name: Optional[str] = Field(default=None, max_length=80)
+    last_name: Optional[str] = Field(default=None, max_length=80)
     phone: Optional[str] = Field(default=None, max_length=40)
     email: Optional[str] = Field(default=None, max_length=320)
     photo_url: Optional[str] = Field(default=None, max_length=2048)

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -219,3 +219,45 @@ def test_audit_logs_filter_is_applied_before_limit():
     events = response.json()
     assert len(events) == 1
     assert events[0]["action"] == "order.assigned"
+
+
+def test_profile_update_persists_first_and_last_name():
+    """PUT /users/me saves first_name + last_name; GET /users/me returns them."""
+    token = make_token("driver-800", "org-800", ["Driver"])
+
+    # Create the user record via GET.
+    get_resp = client.get("/users/me", headers={"Authorization": f"Bearer {token}"})
+    assert get_resp.status_code == 200
+    body = get_resp.json()
+    assert body["first_name"] is None
+    assert body["last_name"] is None
+
+    # Save first + last name.
+    put_resp = client.put(
+        "/users/me",
+        json={"first_name": "Jane", "last_name": "Smith"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert put_resp.status_code == 200
+    updated = put_resp.json()
+    assert updated["first_name"] == "Jane"
+    assert updated["last_name"] == "Smith"
+
+    # Confirm they survive a re-sync (GET /users/me triggers _sync_user again).
+    get2 = client.get("/users/me", headers={"Authorization": f"Bearer {token}"})
+    assert get2.status_code == 200
+    synced = get2.json()
+    assert synced["first_name"] == "Jane"
+    assert synced["last_name"] == "Smith"
+
+
+def test_profile_update_first_name_max_length():
+    """first_name exceeding 80 chars returns 422."""
+    token = make_token("driver-801", "org-801", ["Driver"])
+    client.get("/users/me", headers={"Authorization": f"Bearer {token}"})
+    resp = client.put(
+        "/users/me",
+        json={"first_name": "A" * 81},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 422

--- a/mobile/lib.ts
+++ b/mobile/lib.ts
@@ -55,6 +55,8 @@ export type OsrmResult = {
 
 export type UserProfile = {
   sub?: string;
+  first_name?: string | null;
+  last_name?: string | null;
   email?: string;
   phone?: string | null;
   photo_url?: string | null;

--- a/mobile/screens/DriverScreen.tsx
+++ b/mobile/screens/DriverScreen.tsx
@@ -94,6 +94,8 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
   const [podState, setPodState] = useState<Map<string, PodState>>(new Map());
   const [profileVisible, setProfileVisible] = useState(false);
   const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [profileFirstName, setProfileFirstName] = useState("");
+  const [profileLastName, setProfileLastName] = useState("");
   const [profilePhone, setProfilePhone] = useState("");
   const [profileEmail, setProfileEmail] = useState("");
   const [profileTsa, setProfileTsa] = useState(false);
@@ -499,6 +501,8 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
     try {
       const data = await apiRequest<UserProfile>(apiBase, "/users/me", { token });
       setProfile(data);
+      setProfileFirstName(data.first_name || "");
+      setProfileLastName(data.last_name || "");
       setProfilePhone(formatPhoneNumber(data.phone || ""));
       setProfileEmail(data.email || "");
       setProfileTsa(!!data.tsa_certified);
@@ -571,10 +575,19 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
   async function saveProfile() {
     setLoading(true);
     try {
+      const trimmedFirst = profileFirstName.trim();
+      const trimmedLast = profileLastName.trim();
+      if (!trimmedFirst || !trimmedLast) {
+        setProfileMsg("First and last name are required.");
+        setLoading(false);
+        return;
+      }
       await apiRequest(apiBase, "/users/me", {
         method: "PUT",
         token,
         json: {
+          first_name: trimmedFirst,
+          last_name: trimmedLast,
           phone: profilePhone || null,
           tsa_certified: profileTsa,
           // Only persist URLs the backend can actually store and share.
@@ -593,6 +606,8 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
         prev
           ? {
               ...prev,
+              first_name: trimmedFirst,
+              last_name: trimmedLast,
               phone: profilePhone || undefined,
               tsa_certified: profileTsa,
               // Always reflect the picked photo locally (for top-bar avatar)
@@ -1001,6 +1016,26 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                 )}
                 <Text style={styles.avatarPickerLabel}>Change Photo</Text>
               </Pressable>
+              <Text style={styles.detailLabel}>FIRST NAME <Text style={{ color: "#E05A3B" }}>*</Text></Text>
+              <TextInput
+                style={styles.input}
+                value={profileFirstName}
+                onChangeText={setProfileFirstName}
+                placeholder="First name"
+                placeholderTextColor="#4A3F60"
+                autoCapitalize="words"
+                maxLength={80}
+              />
+              <Text style={styles.detailLabel}>LAST NAME <Text style={{ color: "#E05A3B" }}>*</Text></Text>
+              <TextInput
+                style={styles.input}
+                value={profileLastName}
+                onChangeText={setProfileLastName}
+                placeholder="Last name"
+                placeholderTextColor="#4A3F60"
+                autoCapitalize="words"
+                maxLength={80}
+              />
               <Text style={styles.detailLabel}>EMAIL</Text>
               <Text style={styles.detailValue}>{profile?.email || profileEmail || "-"}</Text>
               <Text style={styles.detailLabel}>PHONE</Text>


### PR DESCRIPTION
## Summary
- Adds `first_name` and `last_name` as distinct fields on `UserRecord`, `UserProfileUpdate`, and `DriverRosterEntry` (backward-compatible — existing rows without these fields default to `null`)
- `_sync_user` preserves first/last name across JWT re-syncs, same pattern as `phone` / `photo_url`
- Driver roster (`GET /drivers/roster`) now returns `first_name` + `last_name` alongside the legacy `name` field
- Mobile profile form (`DriverScreen`) collects first + last name and requires both before saving
- Map markers and dispatch driver list prefer `first_name + last_name` over the legacy single `name` field when present; initials are derived from the structured names automatically
- Fixes `_load_dotenv` to handle UTF-16 `.env` files written by Windows Notepad

## Test plan
- [ ] `test_profile_update_persists_first_and_last_name` — round-trip via PUT /users/me
- [ ] `test_profile_update_first_name_max_length` — 422 on >80 chars
- [ ] All 16 identity + drivers tests green
- [ ] Mobile: open Profile modal → first/last name inputs appear, Save without filling them shows error
- [ ] Dispatch map: driver marker label uses `First Last` for any driver that has set their name

🤖 Generated with [Claude Code](https://claude.com/claude-code)