### PR TITLE
fix(mobile): prevent double-submit on order/invite/profile forms + show driver name

### DIFF
--- a/mobile/screens/AdminScreen.tsx
+++ b/mobile/screens/AdminScreen.tsx
@@ -1066,8 +1066,12 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
                   ))}
                 </View>
                 {inviteMsg ? <Text style={[styles.metaText, { color: inviteMsg.includes("sent") ? "#6ABF7B" : "#F0C060" }]}>{inviteMsg}</Text> : null}
-                <Pressable style={[styles.btn, styles.btnPrimary, { alignSelf: "flex-start" }]} onPress={() => sendInvitation().catch(() => undefined)}>
-                  <Text style={styles.btnText}>Send Invitation</Text>
+                <Pressable
+                  style={[styles.btn, styles.btnPrimary, { alignSelf: "flex-start" }, adminLoading && { opacity: 0.6 }]}
+                  onPress={() => sendInvitation().catch(() => undefined)}
+                  disabled={adminLoading}
+                >
+                  <Text style={styles.btnText}>{adminLoading ? "Sending…" : "Send Invitation"}</Text>
                 </Pressable>
               </View>
             </View>
@@ -1199,8 +1203,12 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
               <OrderFormFields form={createForm} setForm={setCreateForm} />
               {createMsg ? <Text style={styles.errorText}>{createMsg}</Text> : null}
               <View style={styles.row}>
-                <Pressable style={[styles.btn, styles.btnPrimary]} onPress={() => createOrder().catch(() => undefined)}>
-                  <Text style={styles.btnText}>Create Order</Text>
+                <Pressable
+                  style={[styles.btn, styles.btnPrimary, loading && { opacity: 0.6 }]}
+                  onPress={() => createOrder().catch(() => undefined)}
+                  disabled={loading}
+                >
+                  <Text style={styles.btnText}>{loading ? "Creating…" : "Create Order"}</Text>
                 </Pressable>
                 <Pressable style={[styles.btn, styles.btnGhost]} onPress={() => setCreateVisible(false)}>
                   <Text style={styles.btnGhostText}>Cancel</Text>
@@ -1223,8 +1231,12 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
               <OrderFormFields form={editForm} setForm={setEditForm} />
               {editMsg ? <Text style={styles.errorText}>{editMsg}</Text> : null}
               <View style={styles.row}>
-                <Pressable style={[styles.btn, styles.btnPrimary]} onPress={() => saveEditOrder().catch(() => undefined)}>
-                  <Text style={styles.btnText}>Save Changes</Text>
+                <Pressable
+                  style={[styles.btn, styles.btnPrimary, loading && { opacity: 0.6 }]}
+                  onPress={() => saveEditOrder().catch(() => undefined)}
+                  disabled={loading}
+                >
+                  <Text style={styles.btnText}>{loading ? "Saving…" : "Save Changes"}</Text>
                 </Pressable>
                 <Pressable style={[styles.btn, styles.btnGhost]} onPress={() => setEditOrder(null)}>
                   <Text style={styles.btnGhostText}>Cancel</Text>
@@ -1441,7 +1453,7 @@ function DispatchTab({
       {/* Assigned orders for selected driver */}
       {selectedDriverId && assignedOrders.length > 0 ? (
         <>
-          <Text style={styles.sectionSubtitle}>Assigned to {selectedDriverId}</Text>
+          <Text style={styles.sectionSubtitle} numberOfLines={1}>Assigned to {deriveDriverName(selectedDriverId)}</Text>
           {assignedOrders.map((order) => (
             <View key={order.id} style={styles.orderCard}>
               <Text style={styles.orderTitle}>{order.customer_name}</Text>

--- a/mobile/screens/DriverScreen.tsx
+++ b/mobile/screens/DriverScreen.tsx
@@ -1061,8 +1061,12 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
               </View>
               {profileMsg ? <Text style={styles.profileMsg}>{profileMsg}</Text> : null}
               <View style={styles.row}>
-                <Pressable style={[styles.btn, styles.btnPrimary]} onPress={() => saveProfile().catch(() => undefined)}>
-                  <Text style={styles.btnText}>Save</Text>
+                <Pressable
+                  style={[styles.btn, styles.btnPrimary, loading && { opacity: 0.6 }]}
+                  onPress={() => saveProfile().catch(() => undefined)}
+                  disabled={loading}
+                >
+                  <Text style={styles.btnText}>{loading ? "Saving…" : "Save"}</Text>
                 </Pressable>
                 <Pressable style={[styles.btn, styles.btnGhost]} onPress={onSignOut}>
                   <Text style={styles.btnGhostText}>Sign Out</Text>


### PR DESCRIPTION
## Problem
QA audit of the mobile app found two functional UX defects:

1. **Forms can be submitted twice.** The **Create Order**, **Save Changes** (edit order), **Send Invitation** (AdminScreen) and **Save** (DriverScreen profile) buttons stayed tappable while their API request was in flight. A fast double-tap fired the request twice → **duplicate orders, duplicate invitations, duplicate profile writes**. The loading flags (`loading` / `adminLoading`) already existed but weren't bound to the buttons.

2. **Raw driver id shown in dispatch.** The dispatch panel's "Assigned to …" header rendered the raw `assigned_to` id (e.g. `sim-alex-rivera-78c98b`) instead of the human-readable name. Every other driver label in the app uses `deriveDriverName()`.

## Fix
- Bind `disabled` to the in-flight flag on each write button, with a dimmed style and an in-progress label ("Creating…", "Saving…", "Sending…"). One submit per request.
- Use `deriveDriverName(selectedDriverId)` + `numberOfLines={1}` for the "Assigned to" header so it matches the rest of the UI and can't overflow.

## Scope
`mobile/screens/AdminScreen.tsx`, `mobile/screens/DriverScreen.tsx`. No backend or API changes. Style pattern (`loading && { opacity: 0.6 }`) matches existing buttons in the same files (login, simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)