### PR TITLE
fix(mobile): polish — dead code/styles cleanup + profile touch target

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -137,8 +137,8 @@ export default function App() {
     if (!token) return;
     if (isDriver && !isAdmin) setWorkspace("driver");
     else if (isAdmin && !isDriver) setWorkspace("admin");
-    // if both (like cody.carmichael), keep current choice or default to admin
-    else if (isAdmin && isDriver && workspace === "driver" && !isDriver) setWorkspace("admin");
+    // If the user has both roles (e.g. cody.carmichael), keep whatever
+    // workspace is already selected (restored from storage; defaults to "driver").
   }, [token, isDriver, isAdmin]);
 
   // ── Storage ────────────────────────────────────────────────────────────────
@@ -865,17 +865,6 @@ const styles = StyleSheet.create({
   loginBtn: {
     marginTop: 4,
     paddingVertical: 13,
-  },
-  settingsLink: {
-    color: "#968AA8",
-    fontSize: 12,
-    marginTop: 4,
-    textDecorationLine: "underline",
-  },
-  row: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 8,
   },
   // Workspace banner — always visible when authenticated
   workspaceBanner: {

--- a/mobile/screens/AdminScreen.tsx
+++ b/mobile/screens/AdminScreen.tsx
@@ -1751,14 +1751,6 @@ const styles = StyleSheet.create({
   brandMarkText: { color: "#0B0910", fontWeight: "800", fontSize: 16 },
   brandName: { color: "#F5D98B", fontSize: 16, fontWeight: "700" },
   headerRight: { flexDirection: "row", alignItems: "center", gap: 10 },
-  signOutBtn: {
-    borderWidth: 1,
-    borderColor: "#6B4F2A",
-    borderRadius: 999,
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-  },
-  signOutText: { color: "#C8973A", fontWeight: "700", fontSize: 12 },
 
   // Dispatch layout
   dispatchLayout: { flex: 1 },

--- a/mobile/screens/DriverScreen.tsx
+++ b/mobile/screens/DriverScreen.tsx
@@ -692,6 +692,9 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
             {loading ? <ActivityIndicator size="small" color="#C8973A" style={{ marginRight: 8 }} /> : null}
             <Pressable
               style={styles.profileBtn}
+              // The avatar is 36×36; expand the tap target to ~52×52 so it
+              // clears the 44×44 minimum touch-target guideline.
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
               onPress={() => {
                 setProfileMsg("");
                 loadProfile().catch(() => undefined);


### PR DESCRIPTION
## Problem
QA audit found bloat and a sub-spec touch target in the mobile app:

1. **Unreachable code** — `App.tsx`'s workspace auto-select had a dead branch:
   ```ts
   else if (isAdmin && isDriver && workspace === "driver" && !isDriver) setWorkspace("admin");
   ```
   `isDriver && !isDriver` is always false, so this never runs. (It also referenced `workspace`, which isn't in the effect deps.)
2. **Dead styles** — `StyleSheet` entries defined but referenced nowhere: `settingsLink` + `row` (`App.tsx`), `signOutBtn` + `signOutText` (`AdminScreen.tsx`).
3. **Touch target below 44×44** — the driver top-bar profile avatar button is 36×36, under the platform minimum.

## Fix
- Remove the unreachable branch (dual-role users already fall through to "keep current selection") and correct the comment. Net effect unchanged; the effect no longer references an out-of-deps variable.
- Delete the four unused style definitions.
- Add `hitSlop` to the profile button so the tappable area is ~52×52 while the avatar stays 36×36 visually.

## Scope
`mobile/App.tsx`, `mobile/screens/AdminScreen.tsx`, `mobile/screens/DriverScreen.tsx`. No behavior change beyond the larger tap target; no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)