### PR TITLE
fix(admin-js): prevent duplicate order creation + remove dead code

### DIFF
--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -305,9 +305,6 @@
     var nowDate = new Date();
 
     if (el.unassignedQueueCount) {
-      var unassignedCount = allOrders.filter(function (o) {
-        return !o.assigned_to || o.status === "Created";
-      }).length;
       el.unassignedQueueCount.textContent = String(filtered.length);
     }
 
@@ -1718,6 +1715,17 @@
     if (!requireAuthorized(el.createMessage)) {
       return;
     }
+    // Guard against double-submit: a second click (or Enter keypress) before
+    // the POST resolves would create a duplicate order. Lock the submit button
+    // for the duration of the request — a disabled submit button also blocks
+    // the implicit Enter-to-submit path.
+    const submitBtn = el.createForm.querySelector("button[type=\"submit\"]");
+    if (submitBtn && submitBtn.disabled) {
+      return;
+    }
+    if (submitBtn) {
+      submitBtn.disabled = true;
+    }
     const formData = new FormData(el.createForm);
     try {
       const payload = normalizeCreatePayload(formData);
@@ -1732,6 +1740,10 @@
       await refreshOrders();
     } catch (error) {
       C.showMessage(el.createMessage, error.message, "error");
+    } finally {
+      if (submitBtn) {
+        submitBtn.disabled = false;
+      }
     }
   }
 


### PR DESCRIPTION
## Problem
QA audit of the web dispatch console (`admin.js`):

1. **Create Order can be submitted twice.** The submit button stayed enabled while the `POST /orders/` was in flight, so a fast double-click — or pressing Enter again — fired the request twice and created **duplicate orders**.
2. **Dead code.** In `renderDispatchOrderList`, `unassignedCount` was computed but never read (the "Active Orders" badge is set from `filtered.length`).

## Fix
- Lock the Create Order submit button for the duration of the request, releasing it in a `finally`. A disabled submit button also blocks the implicit Enter-to-submit path, so both re-fire routes are covered. A re-entrancy check (`if (submitBtn.disabled) return`) avoids any overlap.
- Delete the unused `unassignedCount` computation. No behavior change — the badge already rendered `filtered.length`.

## Verification
`node --check backend/frontend/assets/admin.js` passes. The dead-var removal is behavior-preserving; the guard is a standard button-lock pattern and self-contained within `createOrder`.

## Scope
`backend/frontend/assets/admin.js` only. No backend/Python changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)