### PR TITLE
fix(backend): preserve user profile on privilege-grant paths

### DIFF
--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -732,6 +732,16 @@ async def activate_invitation(
         user_id=invitation.user_id,
         username=existing_user.username if existing_user else invitation.user_id,
         email=existing_user.email if existing_user and existing_user.email else invitation.email,
+        # Preserve user-editable profile fields. Activating an invitation for an
+        # existing user (e.g. a driver who is also granted a dispatcher seat)
+        # must never wipe the name / contact / photo / TSA data they previously
+        # saved via PUT /users/me. Mirrors identity._sync_user.
+        name=existing_user.name if existing_user else None,
+        first_name=existing_user.first_name if existing_user else None,
+        last_name=existing_user.last_name if existing_user else None,
+        phone=existing_user.phone if existing_user else None,
+        photo_url=existing_user.photo_url if existing_user else None,
+        tsa_certified=existing_user.tsa_certified if existing_user else False,
         roles=roles,
         is_active=True,
         created_at=existing_user.created_at if existing_user else now,

--- a/backend/routers/onboarding.py
+++ b/backend/routers/onboarding.py
@@ -283,6 +283,15 @@ def _apply_review_decision_for_registration(
             user_id=registration.identity_sub,
             username=registration.identity_username or registration.identity_sub,
             email=registration.requester_email or (existing_user.email if existing_user else None),
+            # Preserve any profile fields already saved for this user in the org
+            # so granting admin on approval never wipes them. Mirrors
+            # identity._sync_user; new users simply default to None/False.
+            name=existing_user.name if existing_user else None,
+            first_name=existing_user.first_name if existing_user else None,
+            last_name=existing_user.last_name if existing_user else None,
+            phone=existing_user.phone if existing_user else None,
+            photo_url=existing_user.photo_url if existing_user else None,
+            tsa_certified=existing_user.tsa_certified if existing_user else False,
             roles=_roles_with_admin(existing_user.roles if existing_user else []),
             is_active=True,
             created_at=existing_user.created_at if existing_user else now,

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -347,6 +347,58 @@ def test_activation_writes_audit_event_on_success():
     assert any(event.action == "billing.invitation.activated" for event in audit_events)
 
 
+def test_activation_preserves_existing_user_profile():
+    """Activating an invitation for a user who already exists must not wipe the
+    profile fields (name/phone/photo/TSA) they saved via PUT /users/me."""
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    set_limit = client.post(
+        "/billing/seats",
+        json={"dispatcher_seat_limit": 5, "driver_seat_limit": 5},
+        headers=_auth_header(admin_token),
+    )
+    assert set_limit.status_code == 200
+
+    # Existing driver who has already filled in their profile.
+    driver_token = make_token("prof-user", "org-1", ["Driver"])
+    assert client.post("/users/me/sync", headers=_auth_header(driver_token)).status_code == 200
+    profile = client.put(
+        "/users/me",
+        json={
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "phone": "(555) 123-4567",
+            "photo_url": "https://example.com/jane.jpg",
+            "tsa_certified": True,
+        },
+        headers=_auth_header(driver_token),
+    )
+    assert profile.status_code == 200
+
+    # Admin invites the same user to a dispatcher seat, then activates it.
+    invite = client.post(
+        "/billing/invitations",
+        json={"user_id": "prof-user", "email": "prof-user@example.com", "role": "Dispatcher"},
+        headers=_auth_header(admin_token),
+    )
+    assert invite.status_code == 200
+    invitation_id = invite.json()["invitation_id"]
+
+    activate = client.post(
+        f"/billing/invitations/{invitation_id}/activate",
+        headers=_auth_header(admin_token),
+    )
+    assert activate.status_code == 200
+
+    activated_user = activate.json()
+    assert activated_user["first_name"] == "Jane"
+    assert activated_user["last_name"] == "Doe"
+    assert activated_user["phone"] == "(555) 123-4567"
+    assert activated_user["photo_url"] == "https://example.com/jane.jpg"
+    assert activated_user["tsa_certified"] is True
+    assert "Driver" in activated_user["roles"]
+    assert "Dispatcher" in activated_user["roles"]
+
+
 def test_admin_can_list_and_cancel_pending_invitations():
     admin_token = make_token("admin-1", "org-1", ["Admin"])
     limit_response = client.post(


### PR DESCRIPTION
## Problem (P2 — data loss)
Two endpoints rebuild a user's `UserRecord` from scratch when granting a role, but only carry over `username`, `email`, and `roles`. Every other profile field — `name`, `first_name`, `last_name`, `phone`, `photo_url`, `tsa_certified` — is left at its default, so `upsert_user` **overwrites the saved values with null/false**:

1. **`POST /billing/invitations/{id}/activate`** (primary, high impact). Activating an invitation for a user who already exists — e.g. a driver who set up their profile and is then granted a dispatcher seat — silently wipes their name, phone, profile photo, and TSA flag.
2. **`POST /onboarding/review/decision` (approval path)** — same omission. Narrower impact (the granted org is usually freshly generated, so the user is new), but fixed for consistency/defense-in-depth.

Most likely a regression from the recent addition of `first_name`/`last_name` to `UserRecord` ([2727b7b](https://github.com/cody-carmichael/discra/commit/2727b7b)): `identity._sync_user` was updated to preserve these fields, but these two grant paths were not.

## Fix
Carry the user-editable profile fields over from `existing_user` in both paths, mirroring `identity._sync_user`. New users still default to None/False.

## Verification
- Added `test_activation_preserves_existing_user_profile`. It **fails on the old code** (`assert None == 'Jane'`) and **passes with the fix** — verified by stashing the fix and re-running.
- Full suite: `199 passed` (198 + the new test), with the 4 documented pre-existing failures unchanged (billing webhook-signature test + 3× `test_order_store` DynamoDB Key tests). Existing onboarding approval tests still pass.

## Scope
`backend/routers/billing.py`, `backend/routers/onboarding.py`, and a regression test. No schema or API-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)