### PR TITLE
fix(styles): dark-theme backgrounds for audit/billing/assignment cards

### DIFF
--- a/backend/frontend/assets/styles.css
+++ b/backend/frontend/assets/styles.css
@@ -983,7 +983,7 @@ td small {
 .assignment-item {
   border: 1px solid var(--panel-border);
   border-radius: var(--radius-md);
-  background: #fff;
+  background: var(--panel-2);
   padding: 0.54rem;
   display: grid;
   gap: 0.38rem;
@@ -1115,7 +1115,7 @@ td small {
   border: 1px solid var(--panel-border);
   border-radius: var(--radius-md);
   padding: 0.6rem;
-  background: #fff;
+  background: var(--panel-2);
 }
 
 .audit-item-head,
@@ -1155,7 +1155,7 @@ td small {
   border: 1px solid var(--panel-border);
   border-radius: var(--radius-md);
   padding: 0.52rem;
-  background: #fff;
+  background: var(--panel-2);
 }
 
 .kv-label {


### PR DESCRIPTION
## Problem (visual)
The console is entirely dark-themed — `admin.html`, `register.html`, and `review.html` all use `class="theme-admin"`, with light text (`--text-primary` cream `#EDE0C4`, `--text-muted` grey `#968AA8`). But three card classes hard-coded `background: #fff`:

| Class | Rendered into | Visible? |
|-------|---------------|----------|
| `.audit-item` | `#audit-logs-view` (Admin → Audit Logs) | **Yes — cream/grey text on white, unreadable** |
| `.kv-item` | billing provider status + register/review status panels | Yes (register/review) |
| `.assignment-item` | dispatch assignment queues | when shown |

The audit-log panel is the clearest offender: every log entry is a white card with near-invisible light text.

## Fix
Swap the three white backgrounds for `var(--panel-2)` — the dark card surface every other card in the app already uses (`.order-card`, `.mobile-order-card`, `.invitation-list li`, `.data-surface`, …). Text colors were already designed for a dark surface, so they become legible with no other change.

Intentional whites are left untouched: the signature canvas (`canvas.signature-pad`), the signature image (`.pod-signature`), and the decorative pin dot (`.dispatch-card-pin-inner`) — all of which display dark content on white on purpose.

## Scope
`backend/frontend/assets/styles.css` — 3 single-line color-token swaps. No HTML/JS/structural change. (Noted separately: `.metric-item` also hard-codes `#fff` but is dead — no HTML/JS references it — so it was left alone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)