### PR TITLE
chore(admin-js): remove dead element references that always resolve to null

### DIFF
--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -61,19 +61,14 @@
     statsUpcomingDue: document.getElementById("stats-upcoming-due"),
     statsUpcomingDueCard: document.getElementById("stats-upcoming-due-card"),
     orderSortButtons: Array.from(document.querySelectorAll("[data-order-sort-field]")),
-    driverOptions: document.getElementById("driver-options"),  // legacy hidden datalist (kept for back-compat callers)
     bulkDriverSelect: document.getElementById("bulk-driver-select"),
     bulkDriverTrigger: document.getElementById("bulk-driver-trigger"),
     bulkDriverTriggerLabel: document.getElementById("bulk-driver-trigger-label"),
     bulkDriverPanel: document.getElementById("bulk-driver-panel"),
     bulkDriverSearch: document.getElementById("bulk-driver-search"),
     bulkDriverList: document.getElementById("bulk-driver-list"),
-    refreshDrivers: document.getElementById("refresh-drivers"),
     driversMessage: document.getElementById("drivers-message"),
     driverList: document.getElementById("driver-list"),
-    optimizeForm: document.getElementById("optimize-form"),  // removed from DOM
-    routeResult: document.getElementById("route-result"),    // removed from DOM
-    routeMessage: document.getElementById("route-message"),  // removed from DOM
     inflightList: document.getElementById("inflight-list"),
     inflightCount: document.getElementById("inflight-count"),
     inflightMessage: document.getElementById("inflight-message"),
@@ -736,12 +731,6 @@
         button.disabled = !enabled;
       });
     }
-    if (el.refreshDrivers) el.refreshDrivers.disabled = !enabled;
-    if (el.optimizeForm) {
-      el.optimizeForm.querySelectorAll("input, textarea, button").forEach(function (element) {
-        element.disabled = !enabled;
-      });
-    }
     if (el.refreshInflight) el.refreshInflight.disabled = !enabled;
     if (el.refreshAuditLogs) el.refreshAuditLogs.disabled = !enabled;
     if (el.auditFilterForm) el.auditFilterForm.querySelectorAll("input, button").forEach(function (element) {
@@ -1319,7 +1308,6 @@
       el.billingInvitations.innerHTML = "<li>No invitations found.</li>";
       renderInflight([]);
       el.auditLogsView.innerHTML = "No audit logs loaded.";
-      if (el.routeResult) el.routeResult.innerHTML = "No route computed yet.";
       return;
     }
     isAuthorizedRole = hasAllowedRole(claims);
@@ -3544,7 +3532,6 @@
       renderBillingInvitations([]);
       renderInflight([]);
       el.auditLogsView.innerHTML = "No audit logs loaded.";
-      if (el.routeResult) el.routeResult.innerHTML = "No route computed yet.";
     }
     // Initialize email settings and real-time notifications
     initEmailSettings();
@@ -3587,7 +3574,6 @@
         renderDriverMarkers([]);
         renderAssignmentQueues([]);
         renderInflight([]);
-        if (el.routeResult) el.routeResult.innerHTML = "No route computed yet.";
         updateOrderStats([]);
         updateActiveDriverStat(0);
         C.showMessage(el.authMessage, "Session cleared.", "success");
@@ -3725,7 +3711,6 @@
       });
     });
   }
-  if (el.refreshDrivers) el.refreshDrivers.addEventListener("click", refreshDrivers);
   if (el.driverList) {
     el.driverList.addEventListener("click", function (event) {
       onDriverListClick(event).catch(function (error) {
@@ -3746,7 +3731,6 @@
       C.showMessage(el.auditMessage, error.message, "error");
     });
   });
-  if (el.optimizeForm) { el.optimizeForm.addEventListener("submit", function(e) { e.preventDefault(); }); }
   el.refreshBilling.addEventListener("click", refreshBillingSummary);
   el.refreshInvitations.addEventListener("click", refreshBillingInvitations);
   el.billingCheckoutForm.addEventListener("submit", startBillingCheckout);


### PR DESCRIPTION
## What's dead

Five entries in the `el` object in `admin.js` call `document.getElementById()` on elements that **do not exist in `admin.html`**. They return `null` on every page load:

| `el` key | Reason |
|---|---|
| `driverOptions` | Commented _"legacy hidden datalist (kept for back-compat callers)"_ — the element was removed, nothing reads the property |
| `refreshDrivers` | No `refresh-drivers` element anywhere in `admin.html` |
| `optimizeForm` | Commented _"removed from DOM"_ |
| `routeResult` | Commented _"removed from DOM"_ |
| `routeMessage` | Commented _"removed from DOM"_ |

Every usage site was already guarded with `if (el.X)` — confirming the original authors knew these were null. They were permanent null-ops.

## Removed
- 5 `el` object entries (definitions)
- 8 guarded usage sites:
  - `if (el.refreshDrivers)` in `setInteractiveState` and the event-listener wiring
  - `if (el.optimizeForm)` in `setInteractiveState` and the event-listener wiring
  - 3× `if (el.routeResult) el.routeResult.innerHTML = "..."` in `evaluateAuthorization`, `bootstrap`, and the clear-token handler

## Verification
`node --check backend/frontend/assets/admin.js` passes. No behavior change — all removed branches were unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)