### PR TITLE
fix(sw): bump cache names + sync PRECACHE_URLS to force client cache clear

### DIFF
--- a/backend/frontend/admin-sw.js
+++ b/backend/frontend/admin-sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "discra-admin-v20260603a";
+const CACHE_NAME = "discra-admin-v20260529a";
 const CACHE_PREFIX = "discra-admin-";
 const PRECACHE_URLS = [
-  "assets/styles.css?v=20260322e",
-  "assets/common.js?v=20260322e",
-  "assets/admin.js?v=20260322e",
+  "assets/styles.css?v=20260603a",
+  "assets/common.js?v=20260603a",
+  "assets/admin.js?v=20260603a",
   "assets/admin-manifest.json",
 ];
 

--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -1226,7 +1226,7 @@
     if (!("serviceWorker" in navigator)) {
       return;
     }
-    navigator.serviceWorker.register("admin-sw.js?v=20260322e", { scope: "./" }).catch(function () {
+    navigator.serviceWorker.register("admin-sw.js?v=20260529a", { scope: "./" }).catch(function () {
       // Keep dispatch workflow available even if worker registration fails.
     });
   }

--- a/backend/frontend/driver-sw.js
+++ b/backend/frontend/driver-sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "discra-driver-v20260524a";
+const CACHE_NAME = "discra-driver-v20260529a";
 const PRECACHE_URLS = [
   "driver",
-  "assets/driver-mobile.css",
-  "assets/common.js",
-  "assets/driver.js",
+  "assets/driver-mobile.css?v=20260524a",
+  "assets/common.js?v=20260524a",
+  "assets/driver.js?v=20260524a",
   "assets/driver-manifest.json",
 ];
 


### PR DESCRIPTION
## Root cause

There is no AWS-side cache in this stack (no CloudFront, API Gateway caching is off — the app serves directly from Lambda). The stale UI the user sees is entirely a **browser service worker** problem.

Two issues were found:

### 1. `admin-sw.js` — PRECACHE_URLS pointed to old version strings
\`admin.html\` references \`?v=20260603a\` assets, but the service worker was pre-caching \`?v=20260322e\` URLs. The SW used \`staleWhileRevalidate\`, so the \`?v=20260603a\` assets fetched fine on first load — but the stale pre-cache entries wasted network requests on install and left the cache in an inconsistent state.

### 2. Both SWs — CACHE_NAME not bumped since recent deploys
Neither service worker's \`CACHE_NAME\` had been bumped since the recent UI changes. The activate handler in both workers deletes all caches with the old name, but only when the new SW installs — which only happens when the browser detects the SW file has changed (byte-diff). The CACHE_NAME bump makes the SW file change, triggering reinstall + old cache deletion on every client's next visit.

## Fix
| File | Change |
|---|---|
| `admin-sw.js` | CACHE_NAME: `v20260603a` → `v20260529a`; PRECACHE_URLS: `v=20260322e` → `v=20260603a` |
| `driver-sw.js` | CACHE_NAME: `v20260524a` → `v20260529a`; PRECACHE_URLS: added `?v=20260524a` to match `driver.html` |
| `admin.js` | SW registration URL: `admin-sw.js?v=20260322e` → `admin-sw.js?v=20260529a` |

## What happens after deploy
On the user's next page visit, the browser detects the SW file has changed, installs the new SW, \`skipWaiting()\` activates it immediately, and the activate handler deletes all old caches. The page then loads all assets fresh from the network.

## For immediate relief (before this deploys)
In Chrome DevTools → Application → Service Workers → click **Skip waiting** + **Unregister**, then hard-reload with Ctrl+Shift+R.

## Note on mobile
The React Native / Expo mobile app has no service worker and no AWS-side cache. If the Expo app is showing stale content it's an OTA update delay — force-close and reopen the app to pull the latest JS bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)