### PR TITLE
fix(pod): prevent duplicate submissions, fix broken images, show driver name

### DIFF
--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -672,7 +672,7 @@
       }).join("");
       return (i > 0 ? "<hr style=\"border-color:var(--border);margin:16px 0\">" : "") +
         "<div class=\"pod-record\">" +
-        "<div class=\"pod-meta\">Driver: <strong>" + C.escapeHtml(record.driver_id || "—") + "</strong>" +
+        "<div class=\"pod-meta\">Driver: <strong>" + C.escapeHtml(record.driver_name || record.driver_id || "—") + "</strong>" +
         " &bull; Captured: <strong>" + C.escapeHtml(C.formatTimestamp(record.captured_at)) + "</strong>" +
         (record.notes ? " &bull; Notes: <em>" + C.escapeHtml(record.notes) + "</em>" : "") +
         "</div>" +

--- a/backend/frontend/assets/driver.js
+++ b/backend/frontend/assets/driver.js
@@ -1086,7 +1086,15 @@
         var canvas = el.detailBody.querySelector("canvas.signature-pad");
         if (canvas) clearSignature(canvas);
       } else if (action === "submit-pod") {
-        await submitPod(orderId);
+        var submitBtn = el.detailBody.querySelector('[data-action="submit-pod"]');
+        if (submitBtn && submitBtn.disabled) return; // already in-flight
+        if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = "Submitting…"; }
+        try {
+          await submitPod(orderId);
+        } catch (podErr) {
+          if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = "Submit POD & Deliver"; }
+          throw podErr;
+        }
         C.showMessage(el.ordersMessage, "POD submitted & delivered.", "success");
         await refreshInbox();
         closeDetailPanel();

--- a/backend/routers/pod.py
+++ b/backend/routers/pod.py
@@ -13,6 +13,7 @@ try:
         pod_key_prefix,
         validate_presign_artifact,
     )
+    from backend.repositories import get_identity_repository
     from backend.routers.orders import _require_tenant_order
     from backend.schemas import (
         PodMetadataCreateRequest,
@@ -33,6 +34,7 @@ except ModuleNotFoundError:  # local run from backend/ directory
         pod_key_prefix,
         validate_presign_artifact,
     )
+    from repositories import get_identity_repository
     from routers.orders import _require_tenant_order
     from schemas import (
         PodMetadataCreateRequest,
@@ -142,22 +144,39 @@ async def create_pod_metadata(
 POD_VIEW_EXPIRES_SECONDS = 600
 
 
+def _driver_display_name(user_record) -> str:
+    """Return 'First Last', falling back to username/email, then raw sub."""
+    if user_record is None:
+        return ""
+    first = (user_record.first_name or "").strip()
+    last = (user_record.last_name or "").strip()
+    if first or last:
+        return f"{first} {last}".strip()
+    return user_record.username or user_record.email or ""
+
+
 @router.get("/order/{order_id}", response_model=List[PodViewRecord])
 async def list_pod_for_order(
     order_id: str,
     user=Depends(require_roles([ROLE_ADMIN, ROLE_DISPATCHER])),
     pod_store=Depends(get_pod_data_store),
+    identity_repo=Depends(get_identity_repository),
 ):
     _require_tenant_order(order_id, user["org_id"])
     records = pod_store.list_by_order_id(user["org_id"], order_id)
+    driver_name_cache: dict = {}
     result = []
     for record in records:
         photo_urls = [pod_store.generate_presigned_get_url(k, POD_VIEW_EXPIRES_SECONDS) for k in record.photo_keys]
         sig_urls = [pod_store.generate_presigned_get_url(k, POD_VIEW_EXPIRES_SECONDS) for k in record.signature_keys]
+        if record.driver_id not in driver_name_cache:
+            driver_record = identity_repo.get_user(user["org_id"], record.driver_id)
+            driver_name_cache[record.driver_id] = _driver_display_name(driver_record) or record.driver_id
         result.append(PodViewRecord(
             pod_id=record.pod_id,
             order_id=record.order_id,
             driver_id=record.driver_id,
+            driver_name=driver_name_cache[record.driver_id],
             captured_at=record.captured_at,
             notes=record.notes,
             photo_urls=photo_urls,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -441,6 +441,7 @@ class PodViewRecord(BaseModel):
     pod_id: str
     order_id: str
     driver_id: str
+    driver_name: Optional[str] = None
     captured_at: datetime
     notes: Optional[str] = None
     photo_urls: List[str] = Field(default_factory=list)

--- a/template.yaml
+++ b/template.yaml
@@ -656,6 +656,7 @@ Resources:
             Action:
               - s3:PutObject
               - s3:AbortMultipartUpload
+              - s3:GetObject
             Resource: !Sub "${PodArtifactsBucket.Arn}/*"
         - Statement:
             Effect: Allow


### PR DESCRIPTION
## Summary

- **Duplicate POD submissions (web)** — `driver.js` submit button is now disabled immediately on click (showing "Submitting…") and only re-enabled on error. Prevents spam-clicks from creating multiple POD records for the same delivery. The detail panel already closes on success, which serves as the visual confirmation.
- **Broken delivery photos / signatures in POD viewer** — The Lambda's IAM policy only had `s3:PutObject`; presigned GET URLs generated by `GET /pod/order/{id}` were returning 403 because the signing identity lacked `s3:GetObject`. Added `s3:GetObject` to `template.yaml`.
- **Raw driver Cognito sub shown instead of name** — `GET /pod/order/{id}` now injects the identity repo, looks up each driver's `first_name`/`last_name` (falls back to `username → email → sub`), and returns it as `driver_name` in `PodViewRecord`. `renderPodModal` in `admin.js` uses `driver_name` with `driver_id` as fallback.

## Mobile status
`DriverScreen.tsx` already prevents duplicate submissions via `pod.submitting` state (`disabled={pod.submitting}`, shows "Submitting…", clears POD state on success) — no changes needed.

## Test plan
- [ ] Web driver: click "Submit POD & Deliver" once — button disables and label changes to "Submitting…"; detail panel closes on success; clicking during upload does nothing
- [ ] Web driver: force an upload failure (bad network) — button re-enables with original label so driver can retry
- [ ] Admin Order History → View POD: delivery photo and signature thumbnails load (not broken images)
- [ ] Admin Order History → View POD: driver shows as "First Last" (or username/email) not raw UUID
- [ ] `sam deploy` succeeds with updated IAM policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)