### PR TITLE
feat(web): MMO level-up flourish on POD delivery (driver PWA)

### DIFF
--- a/backend/frontend/assets/driver-mobile.css
+++ b/backend/frontend/assets/driver-mobile.css
@@ -675,3 +675,192 @@ body {
     border-left: 1px solid var(--drv-border);
   }
 }
+
+/* ── Delivery celebration (MMO level-up flourish on POD delivery) ───────── */
+.drv-celebrate {
+  position: fixed; inset: 0; z-index: 10000;
+  overflow: hidden; cursor: pointer;
+  opacity: 1; transition: opacity .36s ease-in;
+}
+.drv-celebrate.is-leaving { opacity: 0; }
+
+.drv-celebrate-backdrop {
+  position: absolute; inset: 0; background: #070510;
+  opacity: 0; animation: drv-cel-dim .22s ease-out forwards;
+}
+@keyframes drv-cel-dim { to { opacity: .92; } }
+
+/* Sunburst rays — a single repeating-conic-gradient masked to a ring band. */
+.drv-celebrate-rays {
+  position: absolute; left: 50%; top: 50%;
+  width: 200vmax; height: 200vmax;
+  background: repeating-conic-gradient(from 0deg,
+    rgba(240, 192, 96, .5) 0deg 1.1deg, transparent 1.1deg 15deg);
+  -webkit-mask: radial-gradient(closest-side, transparent 9%, #000 16%, #000 52%, transparent 78%);
+          mask: radial-gradient(closest-side, transparent 9%, #000 16%, #000 52%, transparent 78%);
+  opacity: 0; transform: translate(-50%, -50%) scale(.2);
+  animation: drv-cel-rays 1.1s cubic-bezier(.16, 1, .3, 1) forwards;
+}
+@keyframes drv-cel-rays {
+  0%   { opacity: 0;   transform: translate(-50%, -50%) scale(.2)  rotate(0deg); }
+  15%  { opacity: .55; }
+  70%  { opacity: .16; }
+  100% { opacity: 0;   transform: translate(-50%, -50%) scale(1.15) rotate(20deg); }
+}
+
+/* Core flash */
+.drv-celebrate-flash {
+  position: absolute; left: 50%; top: 50%;
+  width: 150px; height: 150px; border-radius: 50%;
+  background: radial-gradient(circle, rgba(245, 217, 139, .95), rgba(245, 217, 139, 0) 70%);
+  opacity: 0; transform: translate(-50%, -50%) scale(.2);
+  animation: drv-cel-flash 1.1s ease-out forwards;
+}
+@keyframes drv-cel-flash {
+  0%   { opacity: 0;   transform: translate(-50%, -50%) scale(.2); }
+  12%  { opacity: .85; }
+  35%  { opacity: 0;   transform: translate(-50%, -50%) scale(1.6); }
+  100% { opacity: 0;   transform: translate(-50%, -50%) scale(1.9); }
+}
+
+/* Expanding rune rings */
+.drv-celebrate-ring {
+  position: absolute; left: 50%; top: 50%;
+  width: 130px; height: 130px; border-radius: 50%;
+  border: 2px solid var(--drv-accent);
+  opacity: 0; transform: translate(-50%, -50%) scale(.2);
+  animation: drv-cel-ring 1.1s cubic-bezier(.16, 1, .3, 1) forwards;
+}
+.drv-celebrate-ring.r2 { animation-delay: .12s; border-color: var(--drv-accent-bright); }
+.drv-celebrate-ring.r3 { animation-delay: .24s; }
+@keyframes drv-cel-ring {
+  0%   { opacity: 0;  transform: translate(-50%, -50%) scale(.2); }
+  18%  { opacity: .8; }
+  100% { opacity: 0;  transform: translate(-50%, -50%) scale(3); }
+}
+
+/* Rising embers — per-ember trajectory set inline via --tx/--ty/--d. */
+.drv-celebrate-ember {
+  position: absolute; left: 50%; top: 50%; border-radius: 50%;
+  opacity: 0; transform: translate(-50%, -50%) scale(.4);
+  animation: drv-cel-ember 1.15s ease-out var(--d, 0ms) forwards;
+}
+@keyframes drv-cel-ember {
+  0%   { opacity: 0; transform: translate(-50%, -50%) scale(.4); }
+  12%  { opacity: 1; }
+  78%  { opacity: .85; }
+  100% { opacity: 0; transform: translate(calc(-50% + var(--tx)), calc(-50% + var(--ty))) scale(1.1); }
+}
+
+/* Breathing glow behind the sigil */
+.drv-celebrate-glow {
+  position: absolute; left: 50%; top: 50%;
+  width: 220px; height: 220px; border-radius: 50%;
+  background: radial-gradient(circle, rgba(200, 151, 58, .55), rgba(200, 151, 58, 0) 68%);
+  opacity: 0; transform: translate(-50%, -50%) scale(1);
+  animation: drv-cel-glow-in .5s ease-out forwards,
+             drv-cel-glow-pulse 1.8s ease-in-out .5s infinite;
+}
+@keyframes drv-cel-glow-in { to { opacity: 1; } }
+@keyframes drv-cel-glow-pulse {
+  0%, 100% { transform: translate(-50%, -50%) scale(1);    opacity: .5; }
+  50%      { transform: translate(-50%, -50%) scale(1.18); opacity: .85; }
+}
+
+/* Rotating rune ring + tick marks */
+.drv-celebrate-rune {
+  position: absolute; left: 50%; top: 50%;
+  width: 168px; height: 168px; border-radius: 50%;
+  border: 1px solid rgba(200, 151, 58, .5);
+  opacity: 0; transform: translate(-50%, -50%) scale(.3);
+  animation: drv-cel-pop .6s cubic-bezier(.34, 1.56, .64, 1) forwards,
+             drv-cel-spin 9s linear .6s infinite;
+}
+.drv-celebrate-tick {
+  position: absolute; left: 50%; top: 6px;
+  width: 3px; height: 12px; border-radius: 2px;
+  background: var(--drv-accent-bright);
+  transform-origin: 50% 78px; /* pivot about the ring centre */
+}
+@keyframes drv-cel-spin { to { transform: translate(-50%, -50%) rotate(360deg); } }
+
+/* Emblem core */
+.drv-celebrate-sigil {
+  position: absolute; left: 50%; top: 50%;
+  width: 132px; height: 132px; border-radius: 50%;
+  background: var(--drv-surface);
+  border: 2px solid var(--drv-accent);
+  box-shadow: 0 0 26px rgba(200, 151, 58, .85), inset 0 0 18px rgba(200, 151, 58, .25);
+  display: flex; align-items: center; justify-content: center;
+  opacity: 0; transform: translate(-50%, -50%) scale(.3);
+  animation: drv-cel-pop .6s cubic-bezier(.34, 1.56, .64, 1) forwards;
+}
+@keyframes drv-cel-pop {
+  0%   { opacity: 0; transform: translate(-50%, -50%) scale(.3); }
+  60%  { opacity: 1; }
+  100% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+.drv-celebrate-dash {
+  position: absolute; inset: 11px; border-radius: 50%;
+  border: 1px dashed rgba(245, 217, 139, .45);
+  animation: drv-cel-spin-rev 9s linear infinite;
+}
+@keyframes drv-cel-spin-rev { to { transform: rotate(-360deg); } }
+.drv-celebrate-check {
+  font-family: var(--drv-font-display);
+  font-size: 62px; line-height: 1; font-weight: 700;
+  color: var(--drv-accent-bright);
+  text-shadow: 0 0 16px rgba(200, 151, 58, .9);
+}
+
+/* Banner */
+.drv-celebrate-banner {
+  position: absolute; left: 0; right: 0; top: calc(50% + 104px);
+  text-align: center; padding: 0 28px; pointer-events: none;
+}
+.drv-celebrate-title {
+  font-family: var(--drv-font-ornate);
+  font-size: clamp(1.4rem, 7vw, 2rem);
+  font-weight: 700; letter-spacing: .12em;
+  color: var(--drv-text-heading);
+  text-shadow: 0 0 18px rgba(200, 151, 58, .85);
+  opacity: 0; transform: translateY(26px);
+  animation: drv-cel-rise .52s cubic-bezier(.34, 1.56, .64, 1) .17s forwards;
+}
+.drv-celebrate-divider {
+  height: 2px; width: 220px; max-width: 70%; margin: 12px auto;
+  background: var(--drv-accent);
+  opacity: 0; transform: scaleX(0);
+  animation: drv-cel-divider .52s ease-out .17s forwards;
+}
+@keyframes drv-cel-divider { to { opacity: .85; transform: scaleX(1); } }
+.drv-celebrate-reward {
+  font-family: var(--drv-font-display);
+  font-size: .8rem; letter-spacing: .35em;
+  color: var(--drv-text);
+  opacity: 0; transform: translateY(26px);
+  animation: drv-cel-rise .52s cubic-bezier(.34, 1.56, .64, 1) .17s forwards;
+}
+.drv-celebrate-ref {
+  margin-top: 10px;
+  font-family: var(--drv-font-body);
+  font-size: .8rem; letter-spacing: .08em;
+  color: var(--drv-text-muted);
+  opacity: 0; animation: drv-cel-fade .4s ease-out .35s forwards;
+}
+@keyframes drv-cel-rise { to { opacity: 1; transform: translateY(0); } }
+@keyframes drv-cel-fade { to { opacity: 1; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .drv-celebrate-rays, .drv-celebrate-flash, .drv-celebrate-ember, .drv-celebrate-ring {
+    display: none;
+  }
+  .drv-celebrate-glow, .drv-celebrate-rune, .drv-celebrate-sigil {
+    animation: none !important; opacity: 1 !important;
+    transform: translate(-50%, -50%) !important;
+  }
+  .drv-celebrate-dash { animation: none !important; }
+  .drv-celebrate-title, .drv-celebrate-divider, .drv-celebrate-reward, .drv-celebrate-ref {
+    animation: none !important; opacity: 1 !important; transform: none !important;
+  }
+}

--- a/backend/frontend/assets/driver.js
+++ b/backend/frontend/assets/driver.js
@@ -827,6 +827,82 @@
     await updateOrderStatus(orderId, "Delivered");
   }
 
+  // ── Delivery celebration (MMO level-up flourish) ────────────────
+
+  // Plays a one-shot dark-fantasy flourish when a stop is delivered: a
+  // sunburst, expanding rune rings, rising embers, and a glowing sigil with a
+  // "DELIVERY COMPLETE" banner. Auto-dismisses (~2.7s) or on tap. CSS in
+  // driver-mobile.css does the animating; this just builds + tears down the DOM.
+  function showDeliveryCelebration(reference) {
+    var prior = document.querySelector(".drv-celebrate");
+    if (prior && prior.parentNode) prior.parentNode.removeChild(prior);
+
+    var EMBERS = 16;
+    var TICKS = 8;
+
+    var embers = "";
+    for (var i = 0; i < EMBERS; i++) {
+      var ang = (Math.PI * 2 * i) / EMBERS + (Math.random() - 0.5) * 0.6;
+      var dist = 120 + Math.random() * 170;
+      var tx = Math.round(Math.cos(ang) * dist);
+      var ty = Math.round(Math.sin(ang) * dist - 60); // bias upward, like sparks
+      var size = (3 + Math.random() * 5).toFixed(1);
+      var delay = Math.round(Math.random() * 220);
+      var color = Math.random() > 0.5 ? "#E05A3B" : "var(--drv-accent-bright)";
+      embers +=
+        '<span class="drv-celebrate-ember" style="width:' + size + "px;height:" + size +
+        "px;background:" + color + ";--tx:" + tx + "px;--ty:" + ty + "px;--d:" + delay + 'ms;"></span>';
+    }
+
+    var ticks = "";
+    for (var t = 0; t < TICKS; t++) {
+      ticks +=
+        '<span class="drv-celebrate-tick" style="transform:translateX(-50%) rotate(' +
+        (t * (360 / TICKS)) + 'deg);"></span>';
+    }
+
+    var refHtml = reference
+      ? '<div class="drv-celebrate-ref">' + C.escapeHtml(reference) + "</div>"
+      : "";
+
+    var overlay = document.createElement("div");
+    overlay.className = "drv-celebrate";
+    overlay.setAttribute("role", "alert");
+    overlay.setAttribute("aria-label", "Delivery complete");
+    overlay.innerHTML =
+      '<div class="drv-celebrate-backdrop"></div>' +
+      '<div class="drv-celebrate-rays"></div>' +
+      '<div class="drv-celebrate-flash"></div>' +
+      '<div class="drv-celebrate-ring r1"></div>' +
+      '<div class="drv-celebrate-ring r2"></div>' +
+      '<div class="drv-celebrate-ring r3"></div>' +
+      embers +
+      '<div class="drv-celebrate-glow"></div>' +
+      '<div class="drv-celebrate-rune">' + ticks + "</div>" +
+      '<div class="drv-celebrate-sigil"><span class="drv-celebrate-dash"></span>' +
+      '<span class="drv-celebrate-check">✓</span></div>' +
+      '<div class="drv-celebrate-banner">' +
+      '<div class="drv-celebrate-title">DELIVERY COMPLETE</div>' +
+      '<div class="drv-celebrate-divider"></div>' +
+      '<div class="drv-celebrate-reward">✦&nbsp;&nbsp;STOP CLEARED&nbsp;&nbsp;✦</div>' +
+      refHtml +
+      "</div>";
+
+    var removed = false;
+    function teardown() {
+      if (removed) return;
+      removed = true;
+      overlay.classList.add("is-leaving");
+      setTimeout(function () {
+        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+      }, 380);
+    }
+    overlay.addEventListener("click", teardown);
+    setTimeout(teardown, 2700);
+
+    document.body.appendChild(overlay);
+  }
+
   // ── Profile ────────────────────────────────────────────────────
 
   var currentProfile = null;
@@ -1096,6 +1172,8 @@
           throw podErr;
         }
         C.showMessage(el.ordersMessage, "POD submitted & delivered.", "success");
+        var deliveredOrder = currentOrders.find(function (o) { return o.id === orderId; });
+        showDeliveryCelebration(deliveredOrder && deliveredOrder.reference_id ? "REF " + deliveredOrder.reference_id : "");
         await refreshInbox();
         closeDetailPanel();
       }

--- a/backend/frontend/driver-sw.js
+++ b/backend/frontend/driver-sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "discra-driver-v20260529a";
+const CACHE_NAME = "discra-driver-v20260529b";
 const PRECACHE_URLS = [
   "driver",
-  "assets/driver-mobile.css?v=20260524a",
+  "assets/driver-mobile.css?v=20260529b",
   "assets/common.js?v=20260524a",
-  "assets/driver.js?v=20260524a",
+  "assets/driver.js?v=20260529b",
   "assets/driver-manifest.json",
 ];
 

--- a/backend/frontend/driver.html
+++ b/backend/frontend/driver.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <link rel="manifest" href="assets/driver-manifest.json">
   <meta name="theme-color" content="#0b1117">
-  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260524a">
+  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260529b">
 </head>
 <body>
 
@@ -163,6 +163,6 @@
 
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
   <script src="assets/common.js?v=20260524a"></script>
-  <script src="assets/driver.js?v=20260524a"></script>
+  <script src="assets/driver.js?v=20260529b"></script>
 </body>
 </html>


### PR DESCRIPTION
Web counterpart to [#178](https://github.com/cody-carmichael/discra/pull/178) (mobile). Brings the delivery celebration to the **web driver PWA** so both driver clients get the flourish.

## What

When a driver submits a POD and the stop flips to **Delivered**, the web app now plays the same MMO-style **level-up flourish**, themed to the driver PWA's dark-fantasy palette (Cinzel / Cinzel Decorative, gold/ember on void).

## Details

- **CSS** (`driver-mobile.css`): keyframe-driven overlay — a void backdrop, a `repeating-conic-gradient` **sunburst**, expanding **rune rings**, rising **embers** (gold + ember-orange `#E05A3B`), a breathing **glow**, a rotating **rune ring** with tick marks, and a glowing **sigil** with a ✓.
- **JS** (`driver.js`): `showDeliveryCelebration(reference)` builds the overlay (per-ember random trajectories via inline `--tx/--ty/--d` custom props), appends it to `body`, and tears it down on tap or after ~2.7s. Triggered on the `submit-pod` success path; the banner shows `REF <reference_id>`.
- Uses the existing `--drv-*` design tokens; no new assets/deps.
- Respects `prefers-reduced-motion` (drops the heavy fx, keeps a quiet sigil + banner).
- Bumped the `driver-sw` cache name and `?v=` asset versions to force a client refresh (per the repo's cache-busting convention).

## Verification

Served the frontend and rendered the overlay against the real stylesheet in-browser (no console errors). Confirmed both the opening burst (conic-gradient sunburst + rune rings + embers) and the hold state (glowing sigil + Cinzel Decorative banner + divider + "STOP CLEARED" + reference). The live end-to-end trigger needs auth + backend + camera, so the visual was verified via the real DOM template + CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)