### PR TITLE
fix(pod): make POST /pod/metadata idempotent on duplicate submit

### DIFF
--- a/backend/routers/pod.py
+++ b/backend/routers/pod.py
@@ -128,6 +128,18 @@ async def create_pod_metadata(
     _validate_metadata_keys(key_prefix, payload.photo_keys)
     _validate_metadata_keys(key_prefix, payload.signature_keys)
 
+    # Idempotency: a retried or double-submitted POST (network retry, two tabs,
+    # restored detail panel) must not create duplicate POD records. If this
+    # driver already recorded a POD for this order with the same artifact keys,
+    # return the existing record instead of minting a new one. Keys are unique
+    # per upload (uuid4 in build_pod_key), so identical key sets ⇒ same submit.
+    incoming_keys = (frozenset(payload.photo_keys), frozenset(payload.signature_keys))
+    for existing in pod_store.list_by_order_id(user["org_id"], payload.order_id):
+        if existing.driver_id != user["sub"]:
+            continue
+        if (frozenset(existing.photo_keys), frozenset(existing.signature_keys)) == incoming_keys:
+            return existing
+
     metadata = new_pod_metadata(
         org_id=user["org_id"],
         order_id=payload.order_id,

--- a/backend/tests/test_pod.py
+++ b/backend/tests/test_pod.py
@@ -224,3 +224,87 @@ def test_driver_can_store_pod_metadata():
     assert body["driver_id"] == "driver-1"
     assert body["photo_keys"] == [photo_key]
     assert body["location"]["lat"] == 37.782
+
+
+def _presign_one(driver_token: str, order_id: str, artifact_type="photo", content_type="image/jpeg"):
+    resp = client.post(
+        "/pod/presign",
+        json={
+            "order_id": order_id,
+            "artifacts": [
+                {"artifact_type": artifact_type, "content_type": content_type, "file_size_bytes": 20000}
+            ],
+        },
+        headers={"Authorization": f"Bearer {driver_token}"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["uploads"][0]["key"]
+
+
+def test_pod_metadata_is_idempotent_on_duplicate_submit():
+    """Regression (ledger A-1 / Step 1.2): a retried or double-submitted
+    /pod/metadata with the SAME artifact keys must NOT create a second POD
+    record — it returns the existing one. Guards against network retries, two
+    tabs, and a restored detail panel producing duplicate deliveries."""
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    driver_token = make_token("driver-1", "org-1", ["Driver"])
+    order_id = _create_assigned_order(admin_token, "driver-1")
+    photo_key = _presign_one(driver_token, order_id)
+
+    payload = {"order_id": order_id, "photo_keys": [photo_key], "signature_keys": []}
+    first = client.post("/pod/metadata", json=payload, headers={"Authorization": f"Bearer {driver_token}"})
+    second = client.post("/pod/metadata", json=payload, headers={"Authorization": f"Bearer {driver_token}"})
+
+    assert first.status_code == 200 and second.status_code == 200
+    # Same logical record returned both times.
+    assert first.json()["pod_id"] == second.json()["pod_id"]
+
+    # And the viewer shows exactly ONE record for the order.
+    pod_list = client.get(
+        f"/pod/order/{order_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert pod_list.status_code == 200
+    assert len(pod_list.json()) == 1
+
+
+def test_pod_metadata_distinct_captures_create_distinct_records():
+    """A genuinely new capture (different keys) is still recorded separately —
+    idempotency must not collapse legitimately different submissions."""
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    driver_token = make_token("driver-1", "org-1", ["Driver"])
+    order_id = _create_assigned_order(admin_token, "driver-1")
+
+    key_a = _presign_one(driver_token, order_id)
+    key_b = _presign_one(driver_token, order_id)
+    assert key_a != key_b  # uuid4 per upload
+
+    client.post("/pod/metadata", json={"order_id": order_id, "photo_keys": [key_a]},
+                headers={"Authorization": f"Bearer {driver_token}"})
+    client.post("/pod/metadata", json={"order_id": order_id, "photo_keys": [key_b]},
+                headers={"Authorization": f"Bearer {driver_token}"})
+
+    pod_list = client.get(f"/pod/order/{order_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    assert len(pod_list.json()) == 2
+
+
+def test_pod_viewer_returns_photo_and_signature_urls():
+    """The admin POD viewer must surface presigned GET URLs for both the photo
+    and signature so the images actually render (Step 1.2 'image/signature
+    appears'). In-memory store returns deterministic view URLs per key."""
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    driver_token = make_token("driver-1", "org-1", ["Driver"])
+    order_id = _create_assigned_order(admin_token, "driver-1")
+
+    photo_key = _presign_one(driver_token, order_id, "photo", "image/jpeg")
+    sig_key = _presign_one(driver_token, order_id, "signature", "image/png")
+    client.post(
+        "/pod/metadata",
+        json={"order_id": order_id, "photo_keys": [photo_key], "signature_keys": [sig_key]},
+        headers={"Authorization": f"Bearer {driver_token}"},
+    )
+
+    view = client.get(f"/pod/order/{order_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    assert view.status_code == 200
+    record = view.json()[0]
+    assert len(record["photo_urls"]) == 1 and record["photo_urls"][0]
+    assert len(record["signature_urls"]) == 1 and record["signature_urls"][0]


### PR DESCRIPTION
@
## What

Make `POST /backend/pod/metadata` idempotent. If a driver already recorded a POD for an order with the **same photo/signature key set**, the handler now returns the existing record instead of minting a new `pod_id`.

## Why

The web and mobile **Submit** buttons already lock on first click (commit `c485ae3`), which stops casual UI spam. But nothing guarded the **server**, so a duplicate request that actually reached the API — a network retry, two open tabs, or a restored detail panel — created a *second* POD record (i.e. a duplicate delivery).

Reproduced before the fix: two metadata POSTs with the same keys → `record_count = 2`. After: same `pod_id` returned both times → `record_count = 1`.

This was the genuine remaining gap from the known POD bug (ledger A-1 / Phase 1.2). The other two reported symptoms were already resolved on `main`: broken images were an IAM `s3:GetObject` gap (fixed in `c485ae3`), and submit-spam was the UI button-lock.

## How

In `create_pod_metadata`, before creating a record, scan `list_by_order_id` for an existing POD by the same driver with an identical `(photo_keys, signature_keys)` set and return it if found. Upload keys are `uuid4`-unique per presign, so an identical key set means the same logical submission. Backend-agnostic — uses the store interface, so it holds for both the in-memory and DynamoDB stores.

## Tests

`backend/tests/test_pod.py` (+3, 7/7 pass):
- duplicate submit → same `pod_id` and exactly one record in the viewer
- genuinely distinct captures still create distinct records (no over-collapsing)
- viewer returns presigned photo + signature URLs (so images render)

## Reviewer notes

- Scope is intentionally just the server fix + its pytest. Session QA tooling (Playwright/Maestro/ledger) is kept out of this branch.
- Independent of `fix/dev-auth-default-off` — both branch off `main`, not stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@