### PR TITLE
fix(billing): make real-Stripe paths work and webhook handling idempotent

### DIFF
--- a/backend/billing_service.py
+++ b/backend/billing_service.py
@@ -485,6 +485,17 @@ class DisabledStripeClient(StripeClient):
         raise RuntimeError("Stripe billing portal is not configured")
 
 
+def _stripe_object_to_dict(value: Any) -> Dict[str, Any]:
+    # stripe-python v15 responses are StripeObject instances, not dicts; the
+    # routers and webhook handler consume dict-style payloads.
+    if isinstance(value, dict):
+        return value
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        return to_dict(for_json=True)
+    return value
+
+
 class StripeSdkClient(StripeClient):
     def __init__(
         self,
@@ -503,15 +514,20 @@ class StripeSdkClient(StripeClient):
             stripe.api_key = self._api_key
 
     def parse_webhook_event(self, payload: bytes, signature_header: Optional[str]) -> Dict[str, Any]:
+        payload_text = payload.decode("utf-8") if isinstance(payload, (bytes, bytearray)) else str(payload)
         if self._webhook_secret:
             if not signature_header:
                 raise ValueError("Missing Stripe-Signature header")
-            return stripe.Webhook.construct_event(
-                payload=payload,
-                sig_header=signature_header,
-                secret=self._webhook_secret,
+            # Verify the signature but return the plain JSON dict: stripe-python's
+            # Event/StripeObject no longer supports dict-style .get(), which the
+            # webhook handler relies on.
+            stripe.WebhookSignature.verify_header(
+                payload_text,
+                signature_header,
+                self._webhook_secret,
+                stripe.Webhook.DEFAULT_TOLERANCE,
             )
-        return json.loads(payload.decode("utf-8"))
+        return json.loads(payload_text)
 
     def _item_update(self, items: List[Dict[str, Any]], price_id: str, quantity: int) -> Optional[Dict[str, Any]]:
         if not price_id:
@@ -533,9 +549,11 @@ class StripeSdkClient(StripeClient):
         if not subscription_id:
             raise RuntimeError("Stripe subscription id is required")
 
-        subscription = stripe.Subscription.retrieve(
-            subscription_id,
-            expand=["items.data.price"],
+        subscription = _stripe_object_to_dict(
+            stripe.Subscription.retrieve(
+                subscription_id,
+                expand=["items.data.price"],
+            )
         )
         items = (subscription.get("items", {}) or {}).get("data", [])
         updates = []
@@ -549,10 +567,12 @@ class StripeSdkClient(StripeClient):
         if not updates:
             return subscription
 
-        return stripe.Subscription.modify(
-            subscription_id,
-            items=updates,
-            proration_behavior="create_prorations",
+        return _stripe_object_to_dict(
+            stripe.Subscription.modify(
+                subscription_id,
+                items=updates,
+                proration_behavior="create_prorations",
+            )
         )
 
     def create_checkout_session(
@@ -596,7 +616,7 @@ class StripeSdkClient(StripeClient):
         if customer_id:
             params["customer"] = customer_id
 
-        return stripe.checkout.Session.create(**params)
+        return _stripe_object_to_dict(stripe.checkout.Session.create(**params))
 
     def create_billing_portal_session(
         self,
@@ -607,9 +627,11 @@ class StripeSdkClient(StripeClient):
             raise RuntimeError("STRIPE_SECRET_KEY is required to create billing portal sessions")
         if not customer_id:
             raise RuntimeError("Stripe customer id is required")
-        return stripe.billing_portal.Session.create(
-            customer=customer_id,
-            return_url=return_url,
+        return _stripe_object_to_dict(
+            stripe.billing_portal.Session.create(
+                customer=customer_id,
+                return_url=return_url,
+            )
         )
 
 
@@ -655,6 +677,26 @@ def apply_subscription_webhook(
         return None
 
     current = existing or get_or_default_subscription(org_id, billing_store)
+
+    event_id = str(event.get("id") or "").strip()
+    raw_event_created = event.get("created")
+    event_created = (
+        int(raw_event_created)
+        if isinstance(raw_event_created, (int, float)) and not isinstance(raw_event_created, bool)
+        else None
+    )
+    # Stripe delivers events at-least-once and without ordering guarantees:
+    # drop a redelivery of the event we already applied, and drop any event
+    # older than the one that produced the current state.
+    if event_id and current.last_stripe_event_id == event_id:
+        return None
+    if (
+        event_created is not None
+        and current.last_stripe_event_created is not None
+        and event_created < current.last_stripe_event_created
+    ):
+        return None
+
     dispatcher_limit, driver_limit = _extract_limits_from_subscription_object(
         payload,
         fallback_dispatcher=current.dispatcher_seat_limit,
@@ -669,6 +711,8 @@ def apply_subscription_webhook(
         stripe_subscription_id=stripe_subscription_id or current.stripe_subscription_id,
         dispatcher_seat_limit=dispatcher_limit,
         driver_seat_limit=driver_limit,
+        last_stripe_event_id=event_id or current.last_stripe_event_id,
+        last_stripe_event_created=event_created if event_created is not None else current.last_stripe_event_created,
         created_at=current.created_at,
         updated_at=utc_now(),
     )

--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -277,6 +277,8 @@ def _merge_stripe_subscription_snapshot(
         stripe_subscription_id=subscription_id,
         dispatcher_seat_limit=current.dispatcher_seat_limit,
         driver_seat_limit=current.driver_seat_limit,
+        last_stripe_event_id=current.last_stripe_event_id,
+        last_stripe_event_created=current.last_stripe_event_created,
         created_at=current.created_at,
         updated_at=_utc_now(),
     )
@@ -371,6 +373,8 @@ async def update_billing_seats(
         stripe_subscription_id=subscription.stripe_subscription_id,
         dispatcher_seat_limit=dispatcher_limit,
         driver_seat_limit=driver_limit,
+        last_stripe_event_id=subscription.last_stripe_event_id,
+        last_stripe_event_created=subscription.last_stripe_event_created,
         created_at=subscription.created_at,
         updated_at=_utc_now(),
     )
@@ -475,6 +479,8 @@ async def start_billing_checkout(
             stripe_subscription_id=subscription.stripe_subscription_id,
             dispatcher_seat_limit=dispatcher_limit,
             driver_seat_limit=driver_limit,
+            last_stripe_event_id=subscription.last_stripe_event_id,
+            last_stripe_event_created=subscription.last_stripe_event_created,
             created_at=subscription.created_at,
             updated_at=_utc_now(),
         )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -227,6 +227,11 @@ class SeatSubscriptionRecord(BaseModel):
     stripe_subscription_id: Optional[str] = None
     dispatcher_seat_limit: int = Field(default=0, ge=0)
     driver_seat_limit: int = Field(default=0, ge=0)
+    # Stripe delivers webhook events at-least-once and out of order; the last
+    # applied event id/created pair lets the webhook handler drop duplicates
+    # and stale events instead of overwriting newer seat state.
+    last_stripe_event_id: Optional[str] = None
+    last_stripe_event_created: Optional[int] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -1,7 +1,10 @@
 import base64
+import hashlib
+import hmac
 import json
 import os
 import sys
+import time
 
 import pytest
 from fastapi.testclient import TestClient
@@ -534,3 +537,313 @@ def test_invitation_requires_email_or_user_id():
         headers=_auth_header(admin_token),
     )
     assert invite.status_code == 422
+
+
+# --- RBAC: every billing endpoint is Admin-only ---
+
+BILLING_ENDPOINTS = [
+    ("GET", "/billing/summary", None),
+    ("GET", "/billing/status", None),
+    ("POST", "/billing/seats", {"dispatcher_seat_limit": 1, "driver_seat_limit": 1}),
+    (
+        "POST",
+        "/billing/checkout",
+        {
+            "dispatcher_seat_limit": 1,
+            "driver_seat_limit": 1,
+            "success_url": "https://example.com/ok",
+            "cancel_url": "https://example.com/cancel",
+        },
+    ),
+    ("POST", "/billing/portal", {"return_url": "https://example.com/admin"}),
+    ("POST", "/billing/invitations", {"email": "x@example.com", "role": "Driver"}),
+    ("GET", "/billing/invitations", None),
+    ("POST", "/billing/invitations/some-id/activate", None),
+    ("POST", "/billing/invitations/some-id/cancel", None),
+]
+
+
+@pytest.mark.parametrize("role", ["Dispatcher", "Driver"])
+@pytest.mark.parametrize("method,path,body", BILLING_ENDPOINTS)
+def test_non_admin_roles_get_403_on_billing_endpoints(method, path, body, role):
+    token = make_token(f"{role.lower()}-1", "org-1", [role])
+    response = client.request(method, path, json=body, headers=_auth_header(token))
+    assert response.status_code == 403, f"{role} {method} {path} -> {response.status_code}"
+    assert "insufficient role" in response.json()["detail"].lower()
+
+
+@pytest.mark.parametrize("method,path,body", BILLING_ENDPOINTS)
+def test_unauthenticated_requests_get_401_on_billing_endpoints(method, path, body):
+    response = client.request(method, path, json=body)
+    assert response.status_code == 401, f"anon {method} {path} -> {response.status_code}"
+
+
+# --- Webhook idempotency and ordering ---
+
+def _subscription_event(event_id, created, *, quantity_dispatcher, quantity_driver, event_type="customer.subscription.updated"):
+    return {
+        "id": event_id,
+        "type": event_type,
+        "created": created,
+        "data": {
+            "object": {
+                "id": "sub_123",
+                "customer": "cus_123",
+                "status": "active",
+                "metadata": {"org_id": "org-1", "plan_name": "Pro"},
+                "items": {
+                    "data": [
+                        {"id": "si_dispatch", "quantity": quantity_dispatcher, "price": {"id": "price_dispatcher"}},
+                        {"id": "si_driver", "quantity": quantity_driver, "price": {"id": "price_driver"}},
+                    ]
+                },
+            }
+        },
+    }
+
+
+def _post_unsigned_webhook(event):
+    return client.post(
+        "/webhooks/stripe",
+        data=json.dumps(event),
+        headers={"Content-Type": "application/json"},
+    )
+
+
+def test_webhook_duplicate_event_is_ignored(monkeypatch):
+    monkeypatch.setenv("ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET", "true")
+    monkeypatch.setenv("STRIPE_DISPATCHER_PRICE_ID", "price_dispatcher")
+    monkeypatch.setenv("STRIPE_DRIVER_PRICE_ID", "price_driver")
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+
+    event = _subscription_event("evt_dup", 1_700_000_000, quantity_dispatcher=2, quantity_driver=4)
+    first = _post_unsigned_webhook(event)
+    assert first.status_code == 200
+    assert first.json()["org_id"] == "org-1"
+
+    replay = _post_unsigned_webhook(event)
+    assert replay.status_code == 200
+    assert replay.json()["org_id"] is None  # duplicate delivery applied nothing
+
+    summary = client.get("/billing/summary", headers=_auth_header(admin_token)).json()
+    assert summary["dispatcher_seats"]["total"] == 2
+    assert summary["driver_seats"]["total"] == 4
+
+    audit_events = get_audit_log_store().list_events("org-1", limit=20)
+    applied = [event for event in audit_events if event.action == "billing.subscription.webhook_applied"]
+    assert len(applied) == 1
+
+
+def test_webhook_stale_out_of_order_event_does_not_overwrite_newer_state(monkeypatch):
+    monkeypatch.setenv("ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET", "true")
+    monkeypatch.setenv("STRIPE_DISPATCHER_PRICE_ID", "price_dispatcher")
+    monkeypatch.setenv("STRIPE_DRIVER_PRICE_ID", "price_driver")
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+
+    newer = _subscription_event("evt_new", 1_700_000_100, quantity_dispatcher=5, quantity_driver=10)
+    assert _post_unsigned_webhook(newer).status_code == 200
+
+    stale = _subscription_event("evt_old", 1_700_000_000, quantity_dispatcher=1, quantity_driver=1)
+    response = _post_unsigned_webhook(stale)
+    assert response.status_code == 200
+    assert response.json()["org_id"] is None  # stale event dropped
+
+    summary = client.get("/billing/summary", headers=_auth_header(admin_token)).json()
+    assert summary["dispatcher_seats"]["total"] == 5
+    assert summary["driver_seats"]["total"] == 10
+
+
+def test_manual_seat_update_preserves_webhook_dedup_state(monkeypatch):
+    monkeypatch.setenv("ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET", "true")
+    monkeypatch.setenv("STRIPE_DISPATCHER_PRICE_ID", "price_dispatcher")
+    monkeypatch.setenv("STRIPE_DRIVER_PRICE_ID", "price_driver")
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+
+    event = _subscription_event("evt_1", 1_700_000_100, quantity_dispatcher=5, quantity_driver=10)
+    assert _post_unsigned_webhook(event).status_code == 200
+
+    seats = client.post(
+        "/billing/seats",
+        json={"dispatcher_seat_limit": 6, "driver_seat_limit": 10},
+        headers=_auth_header(admin_token),
+    )
+    assert seats.status_code == 200
+
+    # A replay of the already-applied event must still be dropped after the
+    # manual update rebuilt the subscription record.
+    replay = _post_unsigned_webhook(event)
+    assert replay.status_code == 200
+    assert replay.json()["org_id"] is None
+
+    summary = client.get("/billing/summary", headers=_auth_header(admin_token)).json()
+    assert summary["dispatcher_seats"]["total"] == 6
+
+
+# --- Webhook signature verification (real stripe library) ---
+
+def _stripe_signature_header(payload: str, secret: str, timestamp=None) -> str:
+    ts = int(timestamp if timestamp is not None else time.time())
+    signed = f"{ts}.{payload}"
+    digest = hmac.new(secret.encode("utf-8"), signed.encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"t={ts},v1={digest}"
+
+
+def test_webhook_accepts_correctly_signed_event(monkeypatch):
+    secret = "whsec_test_secret"
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", secret)
+    monkeypatch.setenv("STRIPE_DISPATCHER_PRICE_ID", "price_dispatcher")
+    monkeypatch.setenv("STRIPE_DRIVER_PRICE_ID", "price_driver")
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+
+    payload = json.dumps(_subscription_event("evt_signed", 1_700_000_000, quantity_dispatcher=3, quantity_driver=7))
+    response = client.post(
+        "/webhooks/stripe",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Stripe-Signature": _stripe_signature_header(payload, secret),
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["org_id"] == "org-1"
+
+    summary = client.get("/billing/summary", headers=_auth_header(admin_token)).json()
+    assert summary["dispatcher_seats"]["total"] == 3
+    assert summary["driver_seats"]["total"] == 7
+
+
+def test_webhook_rejects_bad_signature(monkeypatch):
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "whsec_test_secret")
+    payload = json.dumps(_subscription_event("evt_forged", 1_700_000_000, quantity_dispatcher=99, quantity_driver=99))
+
+    response = client.post(
+        "/webhooks/stripe",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Stripe-Signature": _stripe_signature_header(payload, "whsec_wrong_secret"),
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_webhook_rejects_expired_signature_timestamp(monkeypatch):
+    secret = "whsec_test_secret"
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", secret)
+    payload = json.dumps(_subscription_event("evt_replayed", 1_700_000_000, quantity_dispatcher=2, quantity_driver=2))
+
+    stale_ts = int(time.time()) - 3600  # far outside Stripe's default 300s tolerance
+    response = client.post(
+        "/webhooks/stripe",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Stripe-Signature": _stripe_signature_header(payload, secret, timestamp=stale_ts),
+        },
+    )
+    assert response.status_code == 400
+
+
+# --- StripeSdkClient must return plain dicts (stripe-python v15 returns
+# StripeObject, which is NOT a dict and broke checkout/portal/webhooks in
+# every environment with real Stripe configured) ---
+
+def test_stripe_sdk_client_returns_plain_dicts(monkeypatch):
+    import stripe
+    from stripe._stripe_object import StripeObject
+
+    from backend.billing_service import StripeSdkClient
+
+    def fake_session_create(**params):
+        return StripeObject.construct_from(
+            {"id": "cs_live_shape", "object": "checkout.session", "url": "https://checkout.stripe.com/c/pay/x"},
+            None,
+        )
+
+    def fake_portal_create(**params):
+        return StripeObject.construct_from(
+            {"id": "bps_live_shape", "object": "billing_portal.session", "url": "https://billing.stripe.com/p/session/x"},
+            None,
+        )
+
+    def fake_sub_retrieve(subscription_id, **params):
+        return StripeObject.construct_from(
+            {
+                "id": subscription_id,
+                "object": "subscription",
+                "status": "active",
+                "customer": "cus_x",
+                "metadata": {},
+                "items": {"data": []},
+            },
+            None,
+        )
+
+    monkeypatch.setattr(stripe.checkout.Session, "create", staticmethod(fake_session_create))
+    monkeypatch.setattr(stripe.billing_portal.Session, "create", staticmethod(fake_portal_create))
+    monkeypatch.setattr(stripe.Subscription, "retrieve", staticmethod(fake_sub_retrieve))
+
+    sdk = StripeSdkClient(
+        api_key="sk_test_x",
+        webhook_secret="",
+        dispatcher_price_id="price_d",
+        driver_price_id="price_v",
+    )
+
+    session = sdk.create_checkout_session(
+        org_id="org-1",
+        dispatcher_seat_limit=1,
+        driver_seat_limit=1,
+        success_url="https://example.com/ok",
+        cancel_url="https://example.com/cancel",
+    )
+    assert type(session) is dict
+    assert session.get("url") == "https://checkout.stripe.com/c/pay/x"
+
+    portal = sdk.create_billing_portal_session(customer_id="cus_x", return_url="https://example.com")
+    assert type(portal) is dict
+    assert portal.get("url") == "https://billing.stripe.com/p/session/x"
+
+    # no price ids configured -> no updates -> returns the retrieved subscription
+    sdk_no_prices = StripeSdkClient(
+        api_key="sk_test_x",
+        webhook_secret="",
+        dispatcher_price_id="",
+        driver_price_id="",
+    )
+    subscription = sdk_no_prices.update_subscription_quantities(
+        subscription_id="sub_x",
+        dispatcher_seat_limit=1,
+        driver_seat_limit=1,
+    )
+    assert type(subscription) is dict
+    assert subscription.get("status") == "active"
+
+
+# --- Seat over-allocation guards ---
+
+def test_seat_limit_cannot_be_lowered_below_active_plus_pending():
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    assert (
+        client.post(
+            "/billing/seats",
+            json={"dispatcher_seat_limit": 2, "driver_seat_limit": 2},
+            headers=_auth_header(admin_token),
+        ).status_code
+        == 200
+    )
+
+    invite = client.post(
+        "/billing/invitations",
+        json={"email": "d1@example.com", "role": "Driver"},
+        headers=_auth_header(admin_token),
+    )
+    assert invite.status_code == 200
+
+    lowered = client.post(
+        "/billing/seats",
+        json={"driver_seat_limit": 0},
+        headers=_auth_header(admin_token),
+    )
+    assert lowered.status_code == 400
+    assert "cannot be lower" in lowered.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Verifying Stripe billing end-to-end against **real Stripe test mode** surfaced two bugs that the existing (mock-based) tests could not see, both fixed here:

**1. All real-Stripe paths were broken with stripe-python v15 (Sev1).** The SDK returns `StripeObject`, which is not a `dict` — it has no `.get()` and fails `isinstance(x, dict)`. Consequences with a real key/webhook secret configured:
- `POST /billing/checkout` and `POST /billing/portal` → 502 ("did not return a redirect URL") even though Stripe created the session
- `POST /webhooks/stripe` → 500 (`AttributeError: get`) on every **signed** event, i.e. in any production-shaped environment
- the seat-sync snapshot merge after `update_subscription_quantities` was silently skipped

Fix: `StripeSdkClient` now verifies webhook signatures via `stripe.WebhookSignature.verify_header` and returns plain dicts (`to_dict()`) from every method.

**2. Webhook handling was not idempotent or order-safe (Sev2).** Stripe delivers events at-least-once and without ordering guarantees; a replayed or stale `customer.subscription.*` event re-applied and could overwrite newer seat state. `SeatSubscriptionRecord` now tracks the last applied event id/created pair; duplicate and strictly-older events are dropped, and the fields are preserved through router-side record rebuilds (`/billing/seats`, `/billing/checkout` update path, snapshot merge).

## Verification

- Live against Stripe test mode: real Checkout session, real subscription on a test card, the real `customer.subscription.created` event delivered with a valid `Stripe-Signature`, duplicate replay dropped, `/billing/seats` quantity change confirmed on the live Stripe subscription, portal session, invitation lifecycle seat accounting, RBAC — 18/18 checks. (Test customer/subscription cleaned up after.)
- `backend/tests/test_billing.py`: 17 → 51 tests — parametrized RBAC (Dispatcher/Driver → 403, anonymous → 401 on all 9 billing endpoints), webhook signature verification through the real stripe library (valid / forged / expired timestamp), duplicate + stale-event idempotency regressions, a StripeObject→dict regression test, and the seat-lowering guard.
- Full backend suite: **243 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
