### PR TITLE
fix(web): redirect orphaned /ui/signup routes to register (was 500)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -399,17 +399,22 @@ def create_app() -> FastAPI:
     async def dev_backend_ui_login():
         return FileResponse(str(FRONTEND_DIR / "login.html"))
 
+    # There is no standalone signup page: account creation is handled by the
+    # Cognito Hosted UI (register.js builds the hosted `/signup` URL) and the
+    # local onboarding entry point is the register page. These routes used to
+    # serve a `signup.html` that never existed (every hit 500'd); redirect to
+    # the matching register page instead.
     @app.get("/ui/signup", include_in_schema=False)
     async def ui_signup():
-        return FileResponse(str(FRONTEND_DIR / "signup.html"))
+        return RedirectResponse(url="/ui/register", status_code=status.HTTP_307_TEMPORARY_REDIRECT)
 
     @app.get("/backend/ui/signup", include_in_schema=False)
     async def backend_ui_signup():
-        return FileResponse(str(FRONTEND_DIR / "signup.html"))
+        return RedirectResponse(url="/backend/ui/register", status_code=status.HTTP_307_TEMPORARY_REDIRECT)
 
     @app.get("/dev/backend/ui/signup", include_in_schema=False)
     async def dev_backend_ui_signup():
-        return FileResponse(str(FRONTEND_DIR / "signup.html"))
+        return RedirectResponse(url="/dev/backend/ui/register", status_code=status.HTTP_307_TEMPORARY_REDIRECT)
 
     @app.get("/ui/review", include_in_schema=False)
     async def ui_review():

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -661,3 +661,49 @@ def test_en_route_does_not_affect_other_drivers():
 
     a_status = client.get(f"/orders/{order_a}", headers={"Authorization": f"Bearer {admin_token}"}).json()["status"]
     assert a_status == "EnRoute"
+
+
+def test_driver_cannot_access_another_drivers_order(monkeypatch):
+    """Regression for A-2 (cross-driver isolation / IDOR). A driver must only
+    ever see and act on their OWN assigned orders, and no user may read another
+    org's order by id (tenant isolation)."""
+    monkeypatch.setenv("USE_IN_MEMORY_IDENTITY_STORE", "true")
+    admin_token = make_token("admin-a", "org-a", ["Admin"])
+    driver_a_token = make_token("driver-a", "org-a", ["Driver"])
+    driver_b_token = make_token("driver-b", "org-a", ["Driver"])
+    other_org_admin = make_token("admin-x", "org-x", ["Admin"])
+
+    order_id = client.post(
+        "/orders/",
+        json=make_order_payload("Isolation Co", "WH A2", "9 Dest Ave", reference_id="A2-1"),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    ).json()["id"]
+    assert (
+        client.post(
+            f"/orders/{order_id}/assign",
+            json={"driver_id": "driver-a"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        ).status_code
+        == 200
+    )
+
+    # driver-a (the assignee) sees it in their inbox; driver-b does not.
+    inbox_a = client.get("/orders/driver/inbox", headers={"Authorization": f"Bearer {driver_a_token}"}).json()
+    assert [o["id"] for o in inbox_a] == [order_id]
+    inbox_b = client.get("/orders/driver/inbox", headers={"Authorization": f"Bearer {driver_b_token}"}).json()
+    assert all(o["id"] != order_id for o in inbox_b)
+
+    # driver-b cannot read or mutate driver-a's order directly (IDOR).
+    assert client.get(
+        f"/orders/{order_id}", headers={"Authorization": f"Bearer {driver_b_token}"}
+    ).status_code in (403, 404)
+    assert client.post(
+        f"/orders/{order_id}/status",
+        json={"status": "EnRoute"},
+        headers={"Authorization": f"Bearer {driver_b_token}"},
+    ).status_code in (403, 404)
+
+    # A different org cannot read the order at all (tenant isolation).
+    assert client.get(
+        f"/orders/{order_id}", headers={"Authorization": f"Bearer {other_org_admin}"}
+    ).status_code in (403, 404)

--- a/backend/tests/test_ui.py
+++ b/backend/tests/test_ui.py
@@ -43,6 +43,24 @@ def test_ui_pages_are_available():
     assert "driver-logout-hosted-ui" in driver.text
 
 
+def test_ui_signup_redirects_to_register():
+    """`/ui/signup` (and its prefix variants) used to serve a signup.html that
+    never existed → every hit 500'd. They now redirect to the register page.
+    Account creation itself is handled by the Cognito Hosted UI."""
+    for signup_path, register_path in (
+        ("/ui/signup", "/ui/register"),
+        ("/backend/ui/signup", "/backend/ui/register"),
+        ("/dev/backend/ui/signup", "/dev/backend/ui/register"),
+    ):
+        no_follow = client.get(signup_path, follow_redirects=False)
+        assert no_follow.status_code == 307, signup_path
+        assert no_follow.headers["location"] == register_path, signup_path
+
+        followed = client.get(signup_path)
+        assert followed.status_code == 200, signup_path
+        assert "Register Your Tenant" in followed.text, signup_path
+
+
 def test_ui_assets_and_service_worker_are_served():
     common_js = client.get("/ui/assets/common.js")
     login_js = client.get("/ui/assets/login.js")


### PR DESCRIPTION
## Summary

Deep web sweep (alpha playbook Step 1.4). Fixes the one clear functional break it found and locks three previously-open triage items that the sweep re-verified as fixed.

**F-10 (Sev2) — `/ui/signup` returned 500.** The three `/ui/signup` routes (`/ui`, `/backend/ui`, `/dev/backend/ui`) served `FileResponse(signup.html)`, but `signup.html` never existed, so every request 500'd. Account creation is actually handled by the Cognito Hosted UI (`register.js` builds the hosted `/signup` URL) and the local onboarding entry point is the register page — these routes were orphaned. Each now 307-redirects to its matching register page.

## Regression coverage added (backend)

- `test_ui::test_ui_signup_redirects_to_register` — all three `/ui/signup` variants redirect (307) to the register page and the followed response renders it.
- `test_orders::test_driver_cannot_access_another_drivers_order` — cross-driver isolation / IDOR (A-2): a driver cannot see (inbox), GET, or mutate another driver's order, and a different org cannot read it by id.

## Verification

- Drove every `backend/frontend/` page (landing, login, register, review, admin, driver, simulator) live for Admin / Dispatcher / Driver — 0 console errors, 0 unexpected failed requests.
- Re-verified and locked (Playwright, kept in the local E2E suite): **A-3** create-order double-submit fires exactly one `POST /orders/`; **A-4** logout → hard refresh stays signed out and Sign In works on the first click.
- Service workers reviewed (versioned caches, `skipWaiting` + `clients.claim` + old-cache purge, network-first navigation, never cache API/session) — no stale-asset defect.
- Backend suite: **210 passed**.

One Sev3 (admin Email panel shows a raw "Forbidden" string to Dispatchers vs the billing panel's friendly gate) was logged for a later UX-polish pass, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
