### PR TITLE
fix(mobile): handle token expiry and guard mutating actions from double-submit

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -19,7 +19,7 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { apiRequest, decodeJwtPayload, extractTokenGroups, extractUsername, normalizeApiBase } from "./lib";
+import { apiRequest, decodeJwtPayload, extractTokenGroups, extractUsername, getTokenExp, isTokenExpired, normalizeApiBase } from "./lib";
 import AdminScreen from "./screens/AdminScreen";
 import DriverScreen from "./screens/DriverScreen";
 
@@ -141,6 +141,36 @@ export default function App() {
     // workspace is already selected (restored from storage; defaults to "driver").
   }, [token, isDriver, isAdmin]);
 
+  // Token-expiry watchdog. id_tokens expire (~1h) with no refresh token kept,
+  // so a session left open mid-shift would otherwise fail every API call with
+  // an opaque toast. Detect expiry and drop the user back to a sign-in screen
+  // with a clear message, both immediately and on a poll for in-session expiry.
+  useEffect(() => {
+    if (!looksLikeJwt(token)) return;
+    const expireNow = () => {
+      setToken("");
+      setLoginMsg("Your session expired. Please sign in again.");
+    };
+    if (isTokenExpired(token)) {
+      expireNow();
+      return;
+    }
+    const exp = getTokenExp(token);
+    const id = setInterval(() => {
+      if (isTokenExpired(token)) expireNow();
+    }, 30_000);
+    // If we know the exact expiry, also schedule a precise wake-up for it.
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    if (exp != null) {
+      const msUntil = exp * 1000 - Date.now();
+      if (msUntil > 0 && msUntil < 0x7fffffff) timeoutId = setTimeout(expireNow, msUntil);
+    }
+    return () => {
+      clearInterval(id);
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [token]);
+
   // ── Storage ────────────────────────────────────────────────────────────────
 
   useEffect(() => {
@@ -154,7 +184,16 @@ export default function App() {
           cognitoDomain?: string;
           workspace?: Workspace;
         };
-        if (parsed.token && looksLikeJwt(parsed.token)) setToken(parsed.token);
+        // Restore a stored token only if it's structurally valid AND not already
+        // expired — a stale token would otherwise drop the user into the
+        // authenticated UI where every API call 401s with no clear recovery.
+        if (parsed.token && looksLikeJwt(parsed.token)) {
+          if (isTokenExpired(parsed.token)) {
+            setLoginMsg("Your session expired. Please sign in again.");
+          } else {
+            setToken(parsed.token);
+          }
+        }
         if (parsed.apiBase && Platform.OS !== "web") setApiBase(parsed.apiBase);
         if (parsed.cognitoDomain) setCognitoDomain(normalizeDomain(parsed.cognitoDomain));
         if (parsed.workspace === "admin" || parsed.workspace === "driver") setWorkspace(parsed.workspace);
@@ -325,7 +364,7 @@ export default function App() {
 
   // ─── Authenticated: route to workspace ───────────────────────────────────
 
-  if (looksLikeJwt(token)) {
+  if (looksLikeJwt(token) && !isTokenExpired(token)) {
     // If token is valid but groups are empty (shouldn't happen normally), show sign-out
     const canAdmin = isAdmin;
     const canDriver = isDriver;
@@ -445,6 +484,7 @@ export default function App() {
 
           <Text style={styles.label}>Username</Text>
           <TextInput
+            testID="login-username"
             style={styles.input}
             value={loginUser}
             onChangeText={setLoginUser}
@@ -456,6 +496,7 @@ export default function App() {
           />
           <Text style={styles.label}>Password</Text>
           <TextInput
+            testID="login-password"
             style={styles.input}
             value={loginPass}
             onChangeText={setLoginPass}
@@ -471,6 +512,7 @@ export default function App() {
           {loginMsg ? <Text style={styles.errorText}>{loginMsg}</Text> : null}
 
           <Pressable
+            testID="login-submit"
             style={[styles.btn, styles.btnPrimary, styles.loginBtn, loginLoading && { opacity: 0.6 }]}
             onPress={() => signIn().catch(() => undefined)}
             disabled={loginLoading}

--- a/mobile/lib.ts
+++ b/mobile/lib.ts
@@ -210,6 +210,25 @@ export function extractTokenGroups(token: string): string[] {
   return [];
 }
 
+/** The JWT `exp` claim (epoch seconds), or null if absent/undecodable. */
+export function getTokenExp(token: string): number | null {
+  const payload = decodeJwtPayload(token);
+  const exp = payload ? payload.exp : undefined;
+  return typeof exp === "number" && Number.isFinite(exp) ? exp : null;
+}
+
+/**
+ * True only when the token has a decodable `exp` claim that is at/after now
+ * (optionally minus a skew, to expire slightly early and avoid a request racing
+ * the boundary). Fail-open: a token with no decodable `exp` is treated as NOT
+ * expired, so this can never sign out a token we simply cannot parse.
+ */
+export function isTokenExpired(token: string, skewSeconds = 0, nowMs: number = Date.now()): boolean {
+  const exp = getTokenExp(token);
+  if (exp == null) return false;
+  return nowMs >= (exp - skewSeconds) * 1000;
+}
+
 /**
  * Derive a human-readable display name from a driver_id.
  * - `sim-alex-rivera-78c98b` → "Alex Rivera"

--- a/mobile/screens/AdminScreen.tsx
+++ b/mobile/screens/AdminScreen.tsx
@@ -924,6 +924,7 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
                   onAssign={assignOrder}
                   onUnassign={unassignOrder}
                   onCreateNew={() => { setCreateForm(BLANK_FORM); setCreateMsg(""); setCreateVisible(true); }}
+                  busy={loading}
                 />
               ) : ordersSubTab === "inflight" ? (
                 <>
@@ -1637,9 +1638,10 @@ type OrdersTabProps = {
   onAssign: (id: string) => void;
   onUnassign: (id: string) => void;
   onCreateNew: () => void;
+  busy: boolean;
 };
 
-function OrdersTab({ orders, searchQuery, setSearchQuery, onEdit, onUpdateStatus, onAssign, onUnassign, onCreateNew }: OrdersTabProps) {
+function OrdersTab({ orders, searchQuery, setSearchQuery, onEdit, onUpdateStatus, onAssign, onUnassign, onCreateNew, busy }: OrdersTabProps) {
   return (
     <>
       <View style={styles.row}>
@@ -1675,7 +1677,8 @@ function OrdersTab({ orders, searchQuery, setSearchQuery, onEdit, onUpdateStatus
             {ADMIN_STATUS.map((s) => (
               <Pressable
                 key={s}
-                style={[styles.statusBtn, order.status === s && styles.statusBtnActive]}
+                style={[styles.statusBtn, order.status === s && styles.statusBtnActive, busy && styles.btnDisabled]}
+                disabled={busy}
                 onPress={() => onUpdateStatus(order.id, s)}
               >
                 <Text style={styles.statusBtnText}>{s}</Text>
@@ -1684,11 +1687,11 @@ function OrdersTab({ orders, searchQuery, setSearchQuery, onEdit, onUpdateStatus
           </View>
           <View style={styles.row}>
             {!order.assigned_to ? (
-              <Pressable style={[styles.btn, styles.btnPrimary]} onPress={() => onAssign(order.id)}>
+              <Pressable style={[styles.btn, styles.btnPrimary, busy && styles.btnDisabled]} disabled={busy} onPress={() => onAssign(order.id)}>
                 <Text style={styles.btnText}>Assign</Text>
               </Pressable>
             ) : (
-              <Pressable style={[styles.btn, styles.btnGhost]} onPress={() => onUnassign(order.id)}>
+              <Pressable style={[styles.btn, styles.btnGhost, busy && styles.btnDisabled]} disabled={busy} onPress={() => onUnassign(order.id)}>
                 <Text style={styles.btnGhostText}>Unassign</Text>
               </Pressable>
             )}
@@ -2001,6 +2004,7 @@ const styles = StyleSheet.create({
   },
   statusBtnActive: { backgroundColor: "#2A1E10", borderColor: "#C8973A" },
   statusBtnText: { color: "#EDE0C4", fontSize: 11, fontWeight: "600" },
+  btnDisabled: { opacity: 0.5 },
 
   // Orders sub-tabs
   tabContent: { flex: 1 },

--- a/mobile/screens/DriverScreen.tsx
+++ b/mobile/screens/DriverScreen.tsx
@@ -106,6 +106,9 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
   // Level-up flourish shown after a POD is submitted and the stop is delivered.
   const [celebration, setCelebration] = useState<{ reference: string } | null>(null);
   const [loading, setLoading] = useState(false);
+  // Guards the status-action buttons against double-tap: a second tap before the
+  // POST resolves would fire a duplicate /orders/{id}/status request.
+  const [statusUpdating, setStatusUpdating] = useState(false);
   const [locationActive, setLocationActive] = useState(false);
   const locationTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mapRef = useRef<MapView | null>(null);
@@ -268,6 +271,9 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
 
   // ── Update order status ────────────────────────────────────────────────────
   async function updateStatus(orderId: string, status: string) {
+    // Drop a concurrent tap while a status change is already in flight.
+    if (statusUpdating) return;
+    setStatusUpdating(true);
     setLoading(true);
     try {
       await apiRequest(apiBase, `/orders/${orderId}/status`, {
@@ -281,6 +287,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
       setStatusMsg(e instanceof Error ? e.message : "Status update failed.");
     } finally {
       setLoading(false);
+      setStatusUpdating(false);
     }
   }
 
@@ -786,6 +793,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                 return (
                   <Pressable
                     key={order.id}
+                    testID={`stop-card-${idx}`}
                     style={[styles.stopCard, selectedOrder?.id === order.id && styles.stopCardSelected]}
                     onPress={() => selectOrder(order)}
                   >
@@ -806,7 +814,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                 );
               })}
               <View style={styles.sheetActions}>
-                <Pressable style={[styles.btn, styles.btnPrimary]} onPress={() => loadInbox().catch(() => undefined)}>
+                <Pressable testID="inbox-refresh-btn" style={[styles.btn, styles.btnPrimary]} onPress={() => loadInbox().catch(() => undefined)}>
                   <Text style={styles.btnText}>Refresh</Text>
                 </Pressable>
                 <Pressable style={[styles.btn, styles.btnGhost]} onPress={onSignOut}>
@@ -838,7 +846,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                 <Text style={styles.detailTitle} numberOfLines={1}>
                   {selectedOrder?.customer_name ?? "Order"}
                 </Text>
-                <Pressable onPress={() => { setDetailVisible(false); setSelectedOrder(null); }}>
+                <Pressable testID="detail-close-btn" onPress={() => { setDetailVisible(false); setSelectedOrder(null); }}>
                   <Text style={styles.detailClose}>✕</Text>
                 </Pressable>
               </View>
@@ -890,12 +898,15 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                     {DRIVER_STATUS.map((s) => (
                       <Pressable
                         key={s}
+                        testID={`status-action-${s}`}
                         style={[
                           styles.actionBtn,
                           selectedOrder.status === s && styles.actionBtnActive,
                           s === "Failed" && styles.actionBtnDanger,
                           s === "Delivered" && styles.actionBtnGreen,
+                          statusUpdating && styles.actionBtnDisabled,
                         ]}
+                        disabled={statusUpdating}
                         onPress={() => updateStatus(selectedOrder.id, s).catch(() => undefined)}
                       >
                         <Text style={styles.actionBtnText}>{s}</Text>
@@ -910,10 +921,10 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
 
                   {/* Photo */}
                   {pod.photoUri ? (
-                    <Image source={{ uri: pod.photoUri }} style={styles.podPhoto} />
+                    <Image testID="pod-photo-preview" source={{ uri: pod.photoUri }} style={styles.podPhoto} />
                   ) : null}
                   <View style={styles.row}>
-                    <Pressable style={[styles.btn, styles.btnPrimary]} onPress={() => capturePodPhoto(selectedOrder.id).catch(() => undefined)}>
+                    <Pressable testID="pod-photo-btn" style={[styles.btn, styles.btnPrimary]} onPress={() => capturePodPhoto(selectedOrder.id).catch(() => undefined)}>
                       <Text style={styles.btnText}>📷 {pod.photoUri ? "Retake" : "Photo"}</Text>
                     </Pressable>
                     {pod.photoUri ? (
@@ -925,7 +936,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
 
                   {/* Signature */}
                   <View style={styles.row}>
-                    <Pressable style={[styles.btn, styles.btnPrimary]} onPress={() => setSignatureOrderId(selectedOrder.id)}>
+                    <Pressable testID="pod-signature-btn" style={[styles.btn, styles.btnPrimary]} onPress={() => setSignatureOrderId(selectedOrder.id)}>
                       <Text style={styles.btnText}>✍️ {pod.signatureData ? "Re-sign" : "Signature"}</Text>
                     </Pressable>
                     {pod.signatureData ? (
@@ -934,10 +945,11 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                       </Pressable>
                     ) : null}
                   </View>
-                  {pod.signatureData ? <Text style={styles.podCaptured}>✓ Signature captured</Text> : null}
+                  {pod.signatureData ? <Text testID="pod-signature-captured" style={styles.podCaptured}>✓ Signature captured</Text> : null}
 
                   {/* Notes */}
                   <TextInput
+                    testID="pod-notes-input"
                     style={styles.input}
                     value={pod.notes}
                     onChangeText={(v) => setPodField(selectedOrder.id, "notes", v)}
@@ -948,6 +960,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
 
                   {/* Submit */}
                   <Pressable
+                    testID="pod-submit-btn"
                     style={[styles.btn, styles.btnGreen, { width: "100%" }]}
                     onPress={() => submitPod(selectedOrder).catch((e) => setStatusMsg(e instanceof Error ? e.message : "Submit failed."))}
                     disabled={pod.submitting}
@@ -1512,6 +1525,9 @@ const styles = StyleSheet.create({
   },
   actionBtnGreen: {
     borderColor: "#1A5C3A",
+  },
+  actionBtnDisabled: {
+    opacity: 0.5,
   },
   actionBtnText: {
     color: "#EDE0C4",


### PR DESCRIPTION
## Summary

Deep mobile sweep (alpha playbook Step 1.5) of `mobile/` — App.tsx, screens/AdminScreen.tsx, screens/DriverScreen.tsx, lib.ts. Fixes the two Sev2 issues found by static + manual review.

**1. Token expiry was never handled (Sev2).** `looksLikeJwt()` only checked structure, and no refresh token is kept — so an `id_token` that expired mid-shift left the user inside the authenticated UI where every request 401s as an opaque toast (inbox load, location share, POD submit all silently fail) with no path back to sign-in.

- `lib.ts` gains `isTokenExpired()` / `getTokenExp()` — decode the `exp` claim, **fail-open** when it's absent/undecodable so a token we can't parse is never force-signed-out.
- `App.tsx` now gates the authenticated render on non-expiry, refuses to restore an expired stored token (showing "Your session expired. Please sign in again."), and runs a watchdog (30s interval + a precise `exp` timeout) that auto-signs-out on mid-session expiry.

**2. Mutating buttons could double-submit (Sev2).** The driver status-action buttons and the admin order-card status / assign / unassign buttons fired concurrent `POST`s on rapid taps. (POD submit, profile save, and create/edit/invite were already guarded.)

- Driver `updateStatus` sets a `statusUpdating` flag that disables the status buttons while a request is in flight.
- Admin `OrdersTab` takes a `busy` prop and disables its status/assign/unassign buttons during a mutation.

## Verification

- Mobile `tsc --noEmit`: **green**.
- Device/emulator verification of the matching Maestro assertions (`session-expiry.yaml`; a status double-submit assertion in `driver-pod-smoke.yaml`) is **still pending an emulator** — tracked as A-7. The fixes are static-typed-clean but not yet exercised on a device.

## Reviewer notes

- Scope is intentionally limited to the four product-source files. The Maestro flows, the QA ledger, and the Playwright suite are kept out of the repo by project convention.
- A separate Sev3 (the mobile README still advertises a "Sync Queue"/offline queue that does not exist in the code) is **not** included here — it will come as a standalone docs-only PR. A real offline mutation queue is logged as a Phase-4 feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
