### PR TITLE
fix(billing): invitation lifecycle + seat-accounting hardening (Step 2.2)

### DIFF
--- a/backend/billing_service.py
+++ b/backend/billing_service.py
@@ -342,9 +342,18 @@ def ensure_seat_limit_for_invitation(role: SeatRole, subscription: SeatSubscript
             raise SeatLimitExceededError("Dispatcher seat limit reached")
         return
 
-    reserved = usage.driver_active + usage.driver_pending
-    if reserved >= subscription.driver_seat_limit:
-        raise SeatLimitExceededError("Driver seat limit reached")
+    if role == SeatRole.DRIVER:
+        reserved = usage.driver_active + usage.driver_pending
+        if reserved >= subscription.driver_seat_limit:
+            raise SeatLimitExceededError("Driver seat limit reached")
+        return
+
+    # Admin (and any future non-seat role) is not metered against the
+    # Dispatcher/Driver seat pools — admins are org owners, not billable seats.
+    # This previously fell through to the Driver branch and was wrongly blocked
+    # by the driver seat limit (a fresh org with 0 driver seats could not invite
+    # a co-admin).
+    return
 
 
 def ensure_seat_limit_for_activation(role: SeatRole, subscription: SeatSubscriptionRecord, usage: SeatUsage):
@@ -353,8 +362,13 @@ def ensure_seat_limit_for_activation(role: SeatRole, subscription: SeatSubscript
             raise SeatLimitExceededError("Dispatcher seat limit reached for activation")
         return
 
-    if usage.driver_active >= subscription.driver_seat_limit:
-        raise SeatLimitExceededError("Driver seat limit reached for activation")
+    if role == SeatRole.DRIVER:
+        if usage.driver_active >= subscription.driver_seat_limit:
+            raise SeatLimitExceededError("Driver seat limit reached for activation")
+        return
+
+    # Admin / non-seat roles: no seat to consume (mirrors the invitation path).
+    return
 
 
 def new_invitation(org_id: str, user_id: str, email: Optional[str], role: SeatRole) -> BillingInvitationRecord:

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -539,6 +539,168 @@ def test_invitation_requires_email_or_user_id():
     assert invite.status_code == 422
 
 
+# --- Invitation lifecycle: duplicate / revoked / re-activate / seat accounting / escalation (Step 2.2) ---
+
+
+def test_duplicate_pending_invitation_is_rejected():
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    client.post(
+        "/billing/seats",
+        json={"dispatcher_seat_limit": 3, "driver_seat_limit": 3},
+        headers=_auth_header(admin_token),
+    )
+
+    payload = {"user_id": "dup-user", "email": "dup@example.com", "role": "Dispatcher"}
+    first = client.post("/billing/invitations", json=payload, headers=_auth_header(admin_token))
+    assert first.status_code == 200
+
+    second = client.post("/billing/invitations", json=payload, headers=_auth_header(admin_token))
+    assert second.status_code == 409
+    assert "already exists" in second.json()["detail"].lower()
+
+
+def test_cancelled_invitation_cannot_be_activated():
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    client.post(
+        "/billing/seats",
+        json={"dispatcher_seat_limit": 2, "driver_seat_limit": 2},
+        headers=_auth_header(admin_token),
+    )
+
+    invite = client.post(
+        "/billing/invitations",
+        json={"user_id": "rev-user", "email": "rev@example.com", "role": "Driver"},
+        headers=_auth_header(admin_token),
+    )
+    invitation_id = invite.json()["invitation_id"]
+    assert client.post(f"/billing/invitations/{invitation_id}/cancel", headers=_auth_header(admin_token)).status_code == 200
+
+    activate = client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token))
+    assert activate.status_code == 409
+    assert "not pending" in activate.json()["detail"].lower()
+
+
+def test_accepted_invitation_cannot_be_reactivated():
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    client.post(
+        "/billing/seats",
+        json={"dispatcher_seat_limit": 2, "driver_seat_limit": 2},
+        headers=_auth_header(admin_token),
+    )
+
+    invite = client.post(
+        "/billing/invitations",
+        json={"user_id": "twice-user", "email": "twice@example.com", "role": "Driver"},
+        headers=_auth_header(admin_token),
+    )
+    invitation_id = invite.json()["invitation_id"]
+
+    assert client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token)).status_code == 200
+    second = client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token))
+    assert second.status_code == 409
+    assert "not pending" in second.json()["detail"].lower()
+
+
+def test_cancel_non_pending_invitation_is_rejected():
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    client.post(
+        "/billing/seats",
+        json={"dispatcher_seat_limit": 2, "driver_seat_limit": 2},
+        headers=_auth_header(admin_token),
+    )
+
+    invite = client.post(
+        "/billing/invitations",
+        json={"user_id": "cancel-twice", "email": "ct@example.com", "role": "Driver"},
+        headers=_auth_header(admin_token),
+    )
+    invitation_id = invite.json()["invitation_id"]
+
+    assert client.post(f"/billing/invitations/{invitation_id}/cancel", headers=_auth_header(admin_token)).status_code == 200
+    second = client.post(f"/billing/invitations/{invitation_id}/cancel", headers=_auth_header(admin_token))
+    assert second.status_code == 409
+    assert "only pending" in second.json()["detail"].lower()
+
+
+def test_activation_moves_seat_from_pending_to_used():
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    client.post(
+        "/billing/seats",
+        json={"dispatcher_seat_limit": 2, "driver_seat_limit": 2},
+        headers=_auth_header(admin_token),
+    )
+
+    invite = client.post(
+        "/billing/invitations",
+        json={"user_id": "seat-user", "email": "seat@example.com", "role": "Driver"},
+        headers=_auth_header(admin_token),
+    )
+    invitation_id = invite.json()["invitation_id"]
+
+    before = client.get("/billing/summary", headers=_auth_header(admin_token)).json()["driver_seats"]
+    assert (before["used"], before["pending"], before["available"]) == (0, 1, 1)
+
+    assert client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token)).status_code == 200
+
+    after = client.get("/billing/summary", headers=_auth_header(admin_token)).json()["driver_seats"]
+    assert (after["used"], after["pending"], after["available"]) == (1, 0, 1)
+
+
+def test_admin_invitation_is_not_limited_by_seat_pools():
+    """R-2 regression: an Admin invitation must not be metered against the Driver
+    seat pool. A fresh org has 0 seats; inviting a co-admin must still succeed
+    (previously role=Admin fell into the Driver branch and 409'd)."""
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    invite = client.post(
+        "/billing/invitations",
+        json={"user_id": "co-admin", "email": "co-admin@example.com", "role": "Admin"},
+        headers=_auth_header(admin_token),
+    )
+    assert invite.status_code == 200, invite.text
+    invitation_id = invite.json()["invitation_id"]
+
+    activate = client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token))
+    assert activate.status_code == 200, activate.text
+    assert "Admin" in activate.json()["roles"]
+
+
+def test_invited_role_is_server_controlled():
+    """The activated role is exactly what the admin specified — an invited Driver
+    is granted Driver only, never Admin/Dispatcher (no privilege escalation)."""
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    client.post(
+        "/billing/seats",
+        json={"dispatcher_seat_limit": 2, "driver_seat_limit": 2},
+        headers=_auth_header(admin_token),
+    )
+
+    invite = client.post(
+        "/billing/invitations",
+        json={"user_id": "plain-driver", "email": "pd@example.com", "role": "Driver"},
+        headers=_auth_header(admin_token),
+    )
+    invitation_id = invite.json()["invitation_id"]
+    activate = client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token))
+    assert activate.status_code == 200
+    roles = activate.json()["roles"]
+    assert "Driver" in roles
+    assert "Admin" not in roles
+    assert "Dispatcher" not in roles
+
+
+def test_non_admin_cannot_create_admin_invitation():
+    """Invitation creation is Admin-only, so a Dispatcher/Driver cannot mint an
+    invitation of any role — including an Admin one. No self-escalation path."""
+    for role in ("Dispatcher", "Driver"):
+        token = make_token(f"{role.lower()}-esc", "org-1", [role])
+        resp = client.post(
+            "/billing/invitations",
+            json={"email": "escalate@example.com", "role": "Admin"},
+            headers=_auth_header(token),
+        )
+        assert resp.status_code == 403, f"{role} -> {resp.status_code}"
+
+
 # --- RBAC: every billing endpoint is Admin-only ---
 
 BILLING_ENDPOINTS = [


### PR DESCRIPTION
## Phase 2 — RBAC & user invitations, Step 2.2: Invitation → sign-on flow

Traced and hardened the full user-invitation lifecycle across **both** paths.

### Two paths
- **Tenant-admin onboarding** (`onboarding_service.py` / `onboarding.py` / `register.js`): a new user signs in via Cognito Hosted UI → submits a registration → an **allowlisted approver** approves a signed, TTL'd review link → org created + user granted `Admin` **in both the identity store and the Cognito group**. Already well covered by `test_onboarding.py`; verified, no changes needed.
- **Seat invitations** (`billing.py` create/activate/cancel): an **Admin** invites a teammate by email/role → `PENDING` (reserves a seat) → activate → role written + seat moves pending→used → `ACCEPTED`. Create/activate/cancel are Admin-only.

### Fix — R-2 (Sev3): Admin invite mis-metered against driver seats
`ensure_seat_limit_for_invitation`/`_activation` routed any non-Dispatcher role (i.e. `Admin`) into the **driver** seat branch. The admin console invite form does offer `Admin` (`admin.html:555`), so inviting a co-admin in a fresh org (0 seats) returned `409 "Driver seat limit reached"`. The checks now branch explicitly; Admin / non-seat roles aren't metered against the Dispatcher/Driver pools.

### Tests — 8 new in `test_billing.py`
duplicate→409, cancelled-can't-activate→409, accepted-can't-reactivate→409, cancel-non-pending→409, pending→used seat accounting, R-2 regression, **server-controlled role** (a Driver invite never yields Admin), and **non-admin-can't-mint-an-invitation** (no self-escalation). **Backend suite: 253 passed.**

### Known gap logged, not blind-fixed — I-1 (Sev2)
Seat-invitation **activation grants the app-side role + seat but not the invitee's Cognito group** (RBAC reads roles from the JWT's `cognito:groups`; there's no PostConfirmation/PreToken trigger). So an invited Dispatcher/Driver has the seat + record but no working role until the group is set out-of-band. Not fixed here because the invitee may be email-first (no Cognito user yet), making the signup↔activation ordering a design decision with production-auth impact and no local Cognito to verify. Recommended follow-up: reuse `ensure_admin_access(..., role_name=invitation.role)` once the invitee's Cognito user exists. Pilot workaround: assign the group in the Cognito console. (Onboarding/flow A already sets the group.)

### Notes
- No-self-escalation to Admin is structurally guaranteed: invitation create/activate are Admin-only (locked by the Step 2.1 RBAC matrix + an explicit test here) and the granted role is server-controlled.
- Seat invitations have no TTL by design (admin-managed; cancel to revoke); the TTL/replay case is the onboarding review token (already tested).
- The register-flow Playwright spec stays in the local QA suite (Hosted-UI gated, like the onboarding e2e).

Independent of [#184](https://github.com/cody-carmichael/discra/pull/184) (Step 2.1); both branch off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)