### PR TITLE
fix(security): Step 3.4 hardening batch — headers, CORS, throttling, SES IAM, PII logs (S-1..S-5)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -189,6 +189,31 @@ def _cookie_secure(request: Request) -> bool:
     return request.url.scheme == "https"
 
 
+# Baseline HTTP security headers applied to every response (S-1). `frame-ancestors
+# 'none'` + `X-Frame-Options: DENY` block clickjacking of the admin/driver consoles;
+# `nosniff` blocks MIME sniffing; `Referrer-Policy` avoids leaking full URLs (e.g.
+# signed onboarding review links) cross-origin. CSP is deliberately limited to
+# framing/base/object hardening so it does not break inline scripts or the map/font
+# CDNs the consoles load — a full script-src/style-src policy is a separate pass.
+_SECURITY_HEADERS = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Content-Security-Policy": "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+}
+
+
+def _apply_security_headers(response: Response, request: Request) -> None:
+    for header, value in _SECURITY_HEADERS.items():
+        response.headers.setdefault(header, value)
+    # Only advertise HSTS over HTTPS (mirrors the secure-cookie determination) so we
+    # never send it on the local http dev server.
+    if _cookie_secure(request):
+        response.headers.setdefault(
+            "Strict-Transport-Security", "max-age=31536000; includeSubDomains"
+        )
+
+
 def _normalize_hosted_domain(value: str) -> str:
     return value.replace("https://", "").replace("http://", "").rstrip("/")
 
@@ -277,6 +302,7 @@ def create_app() -> FastAPI:
         response = await call_next(request)
         elapsed_ms = (time.perf_counter() - started) * 1000
         response.headers["x-request-id"] = request_id
+        _apply_security_headers(response, request)
         logger.info(
             _json_log(
                 {

--- a/backend/app.py
+++ b/backend/app.py
@@ -214,6 +214,17 @@ def _apply_security_headers(response: Response, request: Request) -> None:
         )
 
 
+def _cors_allowed_origins() -> list[str]:
+    """Allowed CORS origins (S-2). Driven by the CorsAllowedOrigins stack parameter
+    via the CORS_ALLOWED_ORIGINS env var. The web consoles call the API same-origin,
+    so this list only governs genuine cross-origin browsers — default to local-dev
+    origins with NO wildcard. An explicit `*` is still honored as an opt-in."""
+    raw = (os.environ.get("CORS_ALLOWED_ORIGINS") or "").strip()
+    if not raw:
+        return ["http://localhost:8000", "http://127.0.0.1:8000"]
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
 def _normalize_hosted_domain(value: str) -> str:
     return value.replace("https://", "").replace("http://", "").rstrip("/")
 
@@ -284,10 +295,10 @@ def create_app() -> FastAPI:
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=_cors_allowed_origins(),
         allow_credentials=False,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["content-type", "authorization", "x-admin-token", "x-correlation-id"],
     )
 
     @app.middleware("http")

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,75 @@
+"""CORS origin allowlist (security backlog S-2).
+
+The web consoles call the API same-origin, so this list only governs genuine
+cross-origin browsers. Default is local-dev origins with NO wildcard; the
+deployed origin(s) come from the CorsAllowedOrigins stack parameter via
+CORS_ALLOWED_ORIGINS. Locks: no wildcard by default, unknown origins blocked,
+configured origins honored, explicit "*" still available as an opt-in.
+"""
+
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from backend.app import create_app
+
+EVIL = "https://evil.example.com"
+
+
+def _client(monkeypatch, origins_env=None):
+    if origins_env is None:
+        monkeypatch.delenv("CORS_ALLOWED_ORIGINS", raising=False)
+    else:
+        monkeypatch.setenv("CORS_ALLOWED_ORIGINS", origins_env)
+    return TestClient(create_app())
+
+
+def _acao(resp):
+    return resp.headers.get("access-control-allow-origin")
+
+
+def test_default_cors_has_no_wildcard_and_blocks_unknown_origin(monkeypatch):
+    client = _client(monkeypatch)
+    resp = client.get("/health", headers={"Origin": EVIL})
+    assert resp.status_code == 200
+    assert _acao(resp) != "*"
+    assert _acao(resp) != EVIL  # unknown origin must not be reflected
+
+
+def test_default_cors_allows_localhost_dev_origin(monkeypatch):
+    client = _client(monkeypatch)
+    resp = client.get("/health", headers={"Origin": "http://127.0.0.1:8000"})
+    assert resp.status_code == 200
+    assert _acao(resp) == "http://127.0.0.1:8000"
+
+
+def test_configured_origins_allow_and_block(monkeypatch):
+    client = _client(monkeypatch, "https://app.example.com")
+    allowed = client.get("/health", headers={"Origin": "https://app.example.com"})
+    assert _acao(allowed) == "https://app.example.com"
+    blocked = client.get("/health", headers={"Origin": EVIL})
+    assert _acao(blocked) != EVIL
+    assert _acao(blocked) != "*"
+
+
+def test_preflight_from_unknown_origin_is_not_allowed(monkeypatch):
+    client = _client(monkeypatch, "https://app.example.com")
+    resp = client.options(
+        "/orders/",
+        headers={
+            "Origin": EVIL,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+    assert _acao(resp) != EVIL
+    assert _acao(resp) != "*"
+
+
+def test_explicit_wildcard_opt_in_is_honored(monkeypatch):
+    client = _client(monkeypatch, "*")
+    resp = client.get("/health", headers={"Origin": EVIL})
+    assert _acao(resp) == "*"

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,0 +1,77 @@
+"""HTTP security headers are present on every response (security backlog S-1).
+
+Locks the clickjacking / MIME-sniffing / referrer-leak protections added in
+`app.py` so they can't silently regress. HSTS is only advertised over HTTPS.
+"""
+
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from backend.app import app
+
+client = TestClient(app)
+
+_BASELINE = {
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "DENY",
+    "referrer-policy": "strict-origin-when-cross-origin",
+}
+
+
+def _assert_baseline(headers):
+    for name, expected in _BASELINE.items():
+        assert headers.get(name) == expected, f"{name} expected {expected!r}, got {headers.get(name)!r}"
+    csp = headers.get("content-security-policy", "")
+    assert "frame-ancestors 'none'" in csp, f"CSP missing frame-ancestors: {csp!r}"
+
+
+def test_security_headers_on_ui_html():
+    resp = client.get("/ui/admin")
+    assert resp.status_code == 200
+    _assert_baseline(resp.headers)
+
+
+def test_security_headers_on_driver_ui():
+    resp = client.get("/backend/ui/driver")
+    assert resp.status_code == 200
+    _assert_baseline(resp.headers)
+
+
+def test_security_headers_on_static_asset():
+    # StaticFiles mounts are wrapped by the middleware too.
+    resp = client.get("/ui/assets/admin.js")
+    assert resp.status_code == 200
+    _assert_baseline(resp.headers)
+
+
+def test_security_headers_on_api_json():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    _assert_baseline(resp.headers)
+
+
+def test_security_headers_on_error_response():
+    # 404s flow through the middleware and must still carry the headers.
+    resp = client.get("/no-such-route-xyz")
+    assert resp.status_code == 404
+    _assert_baseline(resp.headers)
+
+
+def test_hsts_absent_over_plain_http(monkeypatch):
+    monkeypatch.delenv("FORCE_SECURE_COOKIES", raising=False)
+    resp = client.get("/health")  # TestClient default scheme is http
+    assert resp.status_code == 200
+    assert "strict-transport-security" not in {k.lower() for k in resp.headers.keys()}
+
+
+def test_hsts_present_when_secure(monkeypatch):
+    monkeypatch.setenv("FORCE_SECURE_COOKIES", "true")
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    hsts = resp.headers.get("strict-transport-security")
+    assert hsts is not None and "max-age=" in hsts

--- a/template.yaml
+++ b/template.yaml
@@ -19,6 +19,13 @@ Parameters:
     Type: String
     Default: exampleclientid
     Description: Cognito App Client ID (JWT audience)
+  CorsAllowedOrigins:
+    Type: CommaDelimitedList
+    Default: "http://localhost:8000,http://127.0.0.1:8000"
+    Description: >-
+      Allowed CORS origins for the HTTP API and the app CORS middleware. Defaults
+      to local dev origins; set to your deployed app HTTPS origin(s) in prod. Do
+      not use "*". Drives both API Gateway CorsConfiguration and CORS_ALLOWED_ORIGINS.
   OrsApiKey:
     Type: String
     Default: ""
@@ -193,8 +200,7 @@ Resources:
     Properties:
       StageName: dev
       CorsConfiguration:
-        AllowOrigins:
-          - "*"
+        AllowOrigins: !Ref CorsAllowedOrigins
         AllowMethods:
           - GET
           - POST
@@ -564,6 +570,7 @@ Resources:
           COGNITO_ISSUER: !Sub "https://cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPoolId}"
           COGNITO_AUDIENCE: !Ref CognitoAppClientId
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          CORS_ALLOWED_ORIGINS: !Join [",", !Ref CorsAllowedOrigins]
           JWT_VERIFY_SIGNATURE: "true"
           ORGANIZATIONS_TABLE: !Ref OrganizationsTable
           USERS_TABLE: !Ref UsersTable


### PR DESCRIPTION
## Step 3.4 security remediation batch (from the Step 3.1 review)

Five findings, each a small independent commit. App-side fixes are locally verified; `template.yaml` changes are CI-SAM-build-gated (no local `sam`).

| # | Sev | Fix | Where | Test |
|---|-----|-----|-------|------|
| **S-1** | Sev2 | Security headers on every response (nosniff, `X-Frame-Options: DENY`, Referrer-Policy, CSP `frame-ancestors 'none'`, HSTS over HTTPS) | `app.py` | `test_security_headers.py` (7) |
| **S-2** | Sev3 | CORS origin allowlist via `CorsAllowedOrigins` param (no wildcard) driving API GW **and** app middleware | `app.py` + `template.yaml` | `test_cors.py` (5) |
| **S-3** | Sev3 | API Gateway stage `DefaultRouteSettings` throttling (tunable, 100/200) | `template.yaml` | infra (deploy-verify) |
| **S-4** | Sev3 | SES IAM scoped to the onboarding sender's email+domain identity ARNs (was `Resource: "*"`); omitted when SES unconfigured | `template.yaml` | infra (deploy-verify) |
| **S-5** | Sev3 | Redact PII from email-classifier logs — mask sender local-part (keep domain), log subject length only | `email_classifier.py` | `test_email_log_redaction.py` (4) |

### Notes
- **S-3b** (per-IP WAF) deferred to pilot cutover by decision — needs CloudFront (HTTP API v2 can't attach WAF); cost ~$10/mo confirmed reasonable. Stage throttling (S-3) is the interim control.
- CSP `script-src`/`style-src` tightening deferred (needs inline-script + CDN audit).

### Verification
- **Full backend suite: 261 passed.** Live curl for headers + CORS. Template structurally validated (params, `DefaultRouteSettings`, `Conditions`, scoped ARNs).
- The three `template.yaml` changes (CORS, throttling, SES) can't be deploy-verified locally — **CI SAM build is the gate**.

Phase 3 Step 3.4; **S-6…S-9** (all Sev4) remain. Independent of #184/#185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)