### PR TITLE
fix(security): Step 3.4 remediation — throttling, IAM scoping, PII logs, encryption, backups, config guard (S-3..S-9)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -225,6 +225,45 @@ def _cors_allowed_origins() -> list[str]:
     return [origin.strip() for origin in raw.split(",") if origin.strip()]
 
 
+def _is_deployed_runtime() -> bool:
+    """True when running in a deployed environment: the Lambda runtime sets
+    AWS_LAMBDA_FUNCTION_NAME; REQUIRE_SECURE_CONFIG=true opts other deploy
+    targets into the same guard."""
+    if os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
+        return True
+    return _as_bool(os.environ.get("REQUIRE_SECURE_CONFIG"), default=False)
+
+
+def _assert_safe_deployed_config() -> None:
+    """Fail fast at startup if a dev escape hatch is unsafely set in a deployed
+    environment (S-8, belt-and-suspenders over the safe template defaults).
+
+    Hard failures — never legitimate when deployed:
+      * JWT_VERIFY_SIGNATURE=false (accepts unsigned/forged JWTs)
+      * ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET=true (unsigned webhooks)
+
+    ENABLE_UI_DEV_AUTH only warns: it is a supported QA path on the dev stack
+    (per docs/qa-plan.md) and is already secret-gated at request time.
+    """
+    if not _is_deployed_runtime():
+        return
+    if not _as_bool(os.environ.get("JWT_VERIFY_SIGNATURE"), default=True):
+        raise RuntimeError(
+            "Unsafe deployed config: JWT_VERIFY_SIGNATURE is disabled. "
+            "Refusing to start with JWT signature verification off."
+        )
+    if _as_bool(os.environ.get("ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET"), default=False):
+        raise RuntimeError(
+            "Unsafe deployed config: ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET is enabled. "
+            "Refusing to start with unsigned Stripe webhooks."
+        )
+    if _as_bool(os.environ.get("ENABLE_UI_DEV_AUTH"), default=False):
+        logger.warning(
+            "ENABLE_UI_DEV_AUTH is enabled in a deployed environment — "
+            "credential-free role sign-in is active (QA/dev stacks only)."
+        )
+
+
 def _normalize_hosted_domain(value: str) -> str:
     return value.replace("https://", "").replace("http://", "").rstrip("/")
 
@@ -288,6 +327,7 @@ def _exchange_hosted_code_for_token(
 
 
 def create_app() -> FastAPI:
+    _assert_safe_deployed_config()
     app = FastAPI(
         title="Discra Backend",
         version=os.environ.get("VERSION", "dev"),

--- a/backend/email_classifier.py
+++ b/backend/email_classifier.py
@@ -18,6 +18,25 @@ from typing import Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
+def _redact_email(value: str) -> str:
+    """Mask the local-part of an email for logging, keeping the (org-level) domain
+    for classification debugging (S-5). 'john.doe@acme.com' -> '***@acme.com';
+    a value without '@' -> '***'; empty -> ''."""
+    value = (value or "").strip()
+    if not value:
+        return ""
+    if "@" not in value:
+        return "***"
+    _, _, domain = value.partition("@")
+    return f"***@{domain}" if domain else "***"
+
+
+def _redact_text(value: str) -> str:
+    """Never log free-text headers (subjects can carry customer PII) — log only a
+    length indicator so the line stays useful for ops without exposing content."""
+    return f"<{len(value or '')} chars>"
+
+
 class SkipReason(str, Enum):
     NO_SENDER_MATCH = "no_sender_match"
     NO_SUBJECT_MATCH = "no_subject_match"
@@ -132,7 +151,7 @@ def classify_email(
     # subject_pattern are tried before empty-subject catch-alls so a catch-all
     # can't shadow more specific parsers regardless of saved order.
     if not custom_rules:
-        logger.debug("Unknown sender: %s (no rules configured)", original_sender)
+        logger.debug("Unknown sender: %s (no rules configured)", _redact_email(original_sender))
         return ClassificationResult(
             is_order=False,
             skip_reason=SkipReason.NO_SENDER_MATCH,
@@ -161,7 +180,7 @@ def classify_email(
             logger.info(
                 "Rule '%s' matched sender %s",
                 rule.get("name", ""),
-                original_sender,
+                _redact_email(original_sender),
             )
             return ClassificationResult(
                 is_order=True,
@@ -171,9 +190,9 @@ def classify_email(
             )
     if sender_matched:
         logger.info(
-            "Rules matched sender %s but no subject_pattern accepted %r",
-            original_sender,
-            original_subject,
+            "Rules matched sender %s but no subject_pattern accepted %s",
+            _redact_email(original_sender),
+            _redact_text(original_subject),
         )
         return ClassificationResult(
             is_order=False,
@@ -182,7 +201,7 @@ def classify_email(
             original_subject=original_subject,
         )
 
-    logger.debug("Unknown sender: %s (subject: %s)", original_sender, original_subject)
+    logger.debug("Unknown sender: %s (subject: %s)", _redact_email(original_sender), _redact_text(original_subject))
     return ClassificationResult(
         is_order=False,
         skip_reason=SkipReason.NO_SENDER_MATCH,

--- a/backend/tests/test_deployed_config_guard.py
+++ b/backend/tests/test_deployed_config_guard.py
@@ -1,0 +1,70 @@
+"""Deployed-config startup guard (security backlog S-8).
+
+In a deployed runtime (Lambda sets AWS_LAMBDA_FUNCTION_NAME, or
+REQUIRE_SECURE_CONFIG=true), create_app() must refuse to start with a dev
+escape hatch unsafely set. Local dev (no marker) is never affected.
+"""
+
+import logging
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from backend.app import create_app
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in (
+        "AWS_LAMBDA_FUNCTION_NAME",
+        "REQUIRE_SECURE_CONFIG",
+        "JWT_VERIFY_SIGNATURE",
+        "ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET",
+        "ENABLE_UI_DEV_AUTH",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_lambda_refuses_disabled_jwt_verification(monkeypatch):
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "discra-backend")
+    monkeypatch.setenv("JWT_VERIFY_SIGNATURE", "false")
+    with pytest.raises(RuntimeError, match="JWT_VERIFY_SIGNATURE"):
+        create_app()
+
+
+def test_lambda_refuses_unsigned_stripe_webhooks(monkeypatch):
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "discra-backend")
+    monkeypatch.setenv("ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET", "true")
+    with pytest.raises(RuntimeError, match="STRIPE_WEBHOOK"):
+        create_app()
+
+
+def test_require_secure_config_opt_in_guards_non_lambda(monkeypatch):
+    monkeypatch.setenv("REQUIRE_SECURE_CONFIG", "true")
+    monkeypatch.setenv("JWT_VERIFY_SIGNATURE", "false")
+    with pytest.raises(RuntimeError, match="JWT_VERIFY_SIGNATURE"):
+        create_app()
+
+
+def test_lambda_starts_with_safe_config(monkeypatch):
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "discra-backend")
+    monkeypatch.setenv("JWT_VERIFY_SIGNATURE", "true")
+    assert create_app() is not None
+
+
+def test_local_dev_is_unaffected_by_unsafe_flags(monkeypatch):
+    # No deployed marker: the pytest suite itself runs with verification off.
+    monkeypatch.setenv("JWT_VERIFY_SIGNATURE", "false")
+    monkeypatch.setenv("ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET", "true")
+    assert create_app() is not None
+
+
+def test_dev_auth_in_lambda_warns_but_starts(monkeypatch, caplog):
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "discra-backend")
+    monkeypatch.setenv("ENABLE_UI_DEV_AUTH", "true")
+    with caplog.at_level(logging.WARNING):
+        assert create_app() is not None
+    assert any("ENABLE_UI_DEV_AUTH" in rec.getMessage() for rec in caplog.records)

--- a/backend/tests/test_email_log_redaction.py
+++ b/backend/tests/test_email_log_redaction.py
@@ -1,0 +1,60 @@
+"""Email classification never logs PII in the clear (security backlog S-5).
+
+Sender local-parts and subject content must not reach the logs; only the
+org-level domain and a subject length indicator may. Covers all four log sites
+in email_classifier (no-rules, full match, sender-match-no-subject, unknown).
+"""
+
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from backend.email_classifier import classify_email
+
+SENDER = "john.doe@acme-logistics.com"
+SUBJECT = "Order 5567 for Jane Patient at 12 Private Road"
+PII_FRAGMENTS = ("john.doe", "Jane Patient", "Private Road")
+
+
+def _logs(caplog) -> str:
+    return "\n".join(rec.getMessage() for rec in caplog.records)
+
+
+def _assert_no_pii(caplog):
+    blob = _logs(caplog)
+    assert blob, "expected at least one log record"
+    for fragment in PII_FRAGMENTS:
+        assert fragment not in blob, f"PII {fragment!r} leaked into logs: {blob!r}"
+    # The redacted, org-level domain is still logged (useful, non-personal).
+    assert "***@acme-logistics.com" in blob
+
+
+def test_no_rules_redacts_sender(caplog):
+    caplog.set_level(logging.DEBUG)
+    classify_email(subject=SUBJECT, sender=SENDER, custom_rules=None)
+    _assert_no_pii(caplog)
+
+
+def test_unknown_sender_redacts_sender_and_subject(caplog):
+    caplog.set_level(logging.DEBUG)
+    rules = [{"name": "Other", "sender_pattern": "other-co.com", "subject_pattern": "", "parser_type": "email-ai", "enabled": True}]
+    classify_email(subject=SUBJECT, sender=SENDER, custom_rules=rules)
+    _assert_no_pii(caplog)
+
+
+def test_sender_match_no_subject_redacts_subject(caplog):
+    caplog.set_level(logging.INFO)
+    rules = [{"name": "Acme", "sender_pattern": "acme-logistics.com", "subject_pattern": "NONMATCHING-XYZ", "parser_type": "email-ai", "enabled": True}]
+    result = classify_email(subject=SUBJECT, sender=SENDER, custom_rules=rules)
+    assert result.is_order is False
+    _assert_no_pii(caplog)
+
+
+def test_full_match_redacts_sender(caplog):
+    caplog.set_level(logging.INFO)
+    rules = [{"name": "Acme", "sender_pattern": "acme-logistics.com", "subject_pattern": "order", "parser_type": "email-ai", "enabled": True}]
+    result = classify_email(subject=SUBJECT, sender=SENDER, custom_rules=rules)
+    assert result.is_order is True
+    _assert_no_pii(caplog)

--- a/template.yaml
+++ b/template.yaml
@@ -26,6 +26,20 @@ Parameters:
       Allowed CORS origins for the HTTP API and the app CORS middleware. Defaults
       to local dev origins; set to your deployed app HTTPS origin(s) in prod. Do
       not use "*". Drives both API Gateway CorsConfiguration and CORS_ALLOWED_ORIGINS.
+  ApiThrottleRateLimit:
+    Type: Number
+    Default: 100
+    Description: >-
+      API Gateway stage steady-state request rate limit (requests/sec, aggregate
+      per route) — caps DoS / cost-runaway on every route incl. auth + webhooks.
+      Tune to pilot load. NOTE: aggregate throttling, not per-IP; per-IP abuse
+      limiting needs AWS WAF, which on an HTTP API requires CloudFront in front.
+  ApiThrottleBurstLimit:
+    Type: Number
+    Default: 200
+    Description: >-
+      API Gateway stage burst limit (max concurrent request spike, aggregate per
+      route). Should be >= ApiThrottleRateLimit.
   OrsApiKey:
     Type: String
     Default: ""
@@ -199,6 +213,13 @@ Resources:
     Type: AWS::Serverless::HttpApi
     Properties:
       StageName: dev
+      # Stage-wide request throttling (S-3): baseline DoS / cost-runaway protection
+      # applied to every route, including the auth/onboarding endpoints served via
+      # the /backend/{proxy+} routes and the webhook routes. Aggregate (per-route),
+      # not per-IP — per-IP abuse limiting is a WAF follow-up (needs CloudFront).
+      DefaultRouteSettings:
+        ThrottlingBurstLimit: !Ref ApiThrottleBurstLimit
+        ThrottlingRateLimit: !Ref ApiThrottleRateLimit
       CorsConfiguration:
         AllowOrigins: !Ref CorsAllowedOrigins
         AllowMethods:

--- a/template.yaml
+++ b/template.yaml
@@ -194,6 +194,12 @@ Parameters:
     NoEcho: true
     Description: Google OAuth client secret for Gmail API access
 
+Conditions:
+  # SES sending is only used by the onboarding notifier when a from-email is set;
+  # otherwise it logs only. Gate the ses:SendEmail grant on that so the role has no
+  # SES permission at all when unconfigured (S-4 least privilege).
+  HasSesFromEmail: !Not [!Equals [!Ref OnboardingSesFromEmail, ""]]
+
 Globals:
   Function:
     MemorySize: 512
@@ -698,12 +704,22 @@ Resources:
               - cognito-idp:AdminAddUserToGroup
               - cognito-idp:AdminUpdateUserAttributes
             Resource: !Sub "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPoolId}"
-        - Statement:
-            Effect: Allow
-            Action:
-              - ses:SendEmail
-              - ses:SendRawEmail
-            Resource: "*"
+        # S-4: scope SES to the configured onboarding sender's identity (and its
+        # domain identity, covering both SES verification styles) instead of "*".
+        # Omitted entirely when no from-email is configured.
+        - !If
+          - HasSesFromEmail
+          - Statement:
+              Effect: Allow
+              Action:
+                - ses:SendEmail
+                - ses:SendRawEmail
+              Resource:
+                - !Sub "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${OnboardingSesFromEmail}"
+                - !Sub
+                  - "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${Domain}"
+                  - Domain: !Select [1, !Split ["@", !Ref OnboardingSesFromEmail]]
+          - !Ref AWS::NoValue
         - Statement:
             Effect: Allow
             Action:

--- a/template.yaml
+++ b/template.yaml
@@ -199,6 +199,11 @@ Conditions:
   # otherwise it logs only. Gate the ses:SendEmail grant on that so the role has no
   # SES permission at all when unconfigured (S-4 least privilege).
   HasSesFromEmail: !Not [!Equals [!Ref OnboardingSesFromEmail, ""]]
+  # Amazon Location is optional (code falls back to haversine/in-memory when the
+  # names are unset). Gate each geo grant on its resource being configured so the
+  # role carries no geo permission otherwise (S-6 least privilege).
+  HasLocationRouteCalculator: !Not [!Equals [!Ref LocationRouteCalculatorName, ""]]
+  HasLocationPlaceIndex: !Not [!Equals [!Ref LocationPlaceIndexName, ""]]
 
 Globals:
   Function:
@@ -255,6 +260,12 @@ Resources:
     Properties:
       TableName: !Sub "discra-organizations-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
+      # S-9: point-in-time recovery for persistent business data (backup/restore).
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -272,6 +283,12 @@ Resources:
     Properties:
       TableName: !Sub "discra-users-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
+      # S-9: point-in-time recovery for persistent business data (backup/restore).
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -300,6 +317,12 @@ Resources:
     Properties:
       TableName: !Sub "discra-orders-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
+      # S-9: point-in-time recovery for persistent business data (backup/restore).
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -332,6 +355,12 @@ Resources:
     Properties:
       TableName: !Sub "discra-pod-artifacts-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
+      # S-9: point-in-time recovery for persistent business data (backup/restore).
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -353,6 +382,9 @@ Resources:
     Properties:
       TableName: !Sub "discra-driver-locations-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -377,6 +409,9 @@ Resources:
     Properties:
       TableName: !Sub "discra-push-subscriptions-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -401,6 +436,12 @@ Resources:
     Properties:
       TableName: !Sub "discra-seat-subscriptions-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
+      # S-9: point-in-time recovery for persistent business data (backup/restore).
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -418,6 +459,12 @@ Resources:
     Properties:
       TableName: !Sub "discra-seat-invitations-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
+      # S-9: point-in-time recovery for persistent business data (backup/restore).
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -439,6 +486,12 @@ Resources:
     Properties:
       TableName: !Sub "discra-audit-logs-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
+      # S-9: point-in-time recovery for persistent business data (backup/restore).
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -460,6 +513,12 @@ Resources:
     Properties:
       TableName: !Sub "discra-onboarding-registrations-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
+      # S-9: point-in-time recovery for persistent business data (backup/restore).
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: registration_id
           AttributeType: S
@@ -490,6 +549,12 @@ Resources:
     Properties:
       TableName: !Sub "discra-email-config-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
+      # S-9: point-in-time recovery for persistent business data (backup/restore).
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -507,6 +572,9 @@ Resources:
     Properties:
       TableName: !Sub "discra-skipped-emails-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
       AttributeDefinitions:
         - AttributeName: org_id
           AttributeType: S
@@ -531,6 +599,9 @@ Resources:
     Properties:
       TableName: !Sub "discra-ws-connections-${AWS::StackName}"
       BillingMode: PAY_PER_REQUEST
+      # S-7: SSE-KMS (AWS-managed key) for key-usage auditability (vs AWS-owned default).
+      SSESpecification:
+        SSEEnabled: true
       AttributeDefinitions:
         - AttributeName: connection_id
           AttributeType: S
@@ -563,6 +634,19 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      # S-9: versioning protects POD artifacts (delivery evidence) against
+      # accidental overwrite/delete; the lifecycle rule caps noncurrent-version
+      # storage cost and cleans up abandoned multipart uploads.
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-noncurrent-versions
+            Status: Enabled
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 90
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -692,12 +776,24 @@ Resources:
               - s3:AbortMultipartUpload
               - s3:GetObject
             Resource: !Sub "${PodArtifactsBucket.Arn}/*"
-        - Statement:
-            Effect: Allow
-            Action:
-              - geo:CalculateRouteMatrix
-              - geo:SearchPlaceIndexForText
-            Resource: "*"
+        # S-6: scope Amazon Location to the configured calculator / place index
+        # instead of "*"; each grant is omitted entirely when unconfigured.
+        - !If
+          - HasLocationRouteCalculator
+          - Statement:
+              Effect: Allow
+              Action:
+                - geo:CalculateRouteMatrix
+              Resource: !Sub "arn:aws:geo:${AWS::Region}:${AWS::AccountId}:route-calculator/${LocationRouteCalculatorName}"
+          - !Ref AWS::NoValue
+        - !If
+          - HasLocationPlaceIndex
+          - Statement:
+              Effect: Allow
+              Action:
+                - geo:SearchPlaceIndexForText
+              Resource: !Sub "arn:aws:geo:${AWS::Region}:${AWS::AccountId}:place-index/${LocationPlaceIndexName}"
+          - !Ref AWS::NoValue
         - Statement:
             Effect: Allow
             Action:


### PR DESCRIPTION
## Step 3.4 security remediation (completes the 3.1 backlog)

Follow-on to #186 (S-1 headers + S-2 CORS, merged). This PR carries the rest of the backlog — one commit per finding (S-6/S-7/S-9 batched as one template commit).

| # | Sev | Fix | Where | Verification |
|---|-----|-----|-------|--------------|
| **S-3** | Sev3 | API GW stage `DefaultRouteSettings` throttling (tunable, 100 req/s + 200 burst) on every route incl. auth + webhooks | `template.yaml` | infra — CI SAM gate |
| **S-4** | Sev3 | SES IAM scoped to onboarding sender email+domain identity ARNs, omitted when unconfigured (was `Resource: "*"`) | `template.yaml` | infra — CI SAM gate |
| **S-5** | Sev3 | Email-classifier log redaction: sender local-part masked (domain kept), subject → length only | `email_classifier.py` | `test_email_log_redaction.py` (4) |
| **S-6** | Sev4 | geo IAM split + scoped to route-calculator / place-index ARNs, condition-gated, omitted when unconfigured. **Zero bare IAM `Resource: "*"` left in the template** | `template.yaml` | infra — CI SAM gate |
| **S-7** | Sev4 | `SSEEnabled: true` on all 13 DynamoDB tables (AWS-managed `aws/dynamodb` KMS key → CloudTrail auditability, $0/mo; CMK deferred pending SOC-2 assessment) | `template.yaml` | infra — CI SAM gate |
| **S-8** | Sev4 | Startup guard: deployed runtime (`AWS_LAMBDA_FUNCTION_NAME` / `REQUIRE_SECURE_CONFIG`) refuses to start with `JWT_VERIFY_SIGNATURE=false` or unsigned-Stripe-webhook override; dev-auth warns (supported QA path). Local dev unaffected | `app.py` | `test_deployed_config_guard.py` (6) |
| **S-9** | Sev4 | PITR on the 9 persistent business tables (TTL'd ephemeral tables skipped); POD bucket versioning + lifecycle (noncurrent 90d, multiparts 7d) | `template.yaml` | infra — CI SAM gate |

### Notes
- **S-3b** (per-IP WAF) deferred to pilot cutover by decision — needs CloudFront (HTTP API v2 can't attach WAF); ~$10/mo confirmed reasonable. Stage throttling is the interim control.
- CSP `script-src`/`style-src` tightening remains a follow-up.
- **Deploy note:** S-7/S-9 are in-place-updatable table/bucket properties (no replacement), but this is the largest template change of the batch — worth a dev-stack deploy + smoke before promoting.

### Verification
- **Full backend suite: 397 passed** (incl. 10 new tests).
- Template structurally validated: 13/13 tables SSE, 9 PITR, versioning + lifecycle, 3 gating conditions, **no bare IAM wildcards**. `template.yaml` changes can't be deploy-verified locally (no `sam`) — CI SAM build is the gate.

With this PR, the Step 3.4 remediation backlog is **cleared** (except deferred S-3b). Next: 3.2 SOC-2 / 3.3 GDPR gap analyses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)