### PR TITLE
docs(compliance): SOC-2 + GDPR readiness gap analyses (Steps 3.2, 3.3)

### DIFF
--- a/docs/gdpr-readiness.md
+++ b/docs/gdpr-readiness.md
@@ -1,0 +1,76 @@
+# GDPR Readiness — Gap Analysis
+
+**Date:** 2026-06-29 · **Scope:** personal-data handling across backend, web, mobile, and infra.
+Statuses: **Met / Partial / Gap**. Companion: [soc2-readiness.md](soc2-readiness.md).
+
+**Roles:** for tenant business data (their customers' orders, their drivers' locations) Discra
+acts as **processor** on the tenant's instructions; for onboarding/registration and account data
+Discra is the **controller**. A Discra↔tenant DPA does not yet exist (see Build list).
+
+## 1. Data inventory — what PII we hold, and where
+
+| Data | Subjects | Store | Retention today |
+|---|---|---|---|
+| Staff identity: name, email, phone, profile photo, TSA flag | Tenant staff | Cognito; `UsersTable`; S3 `profile-photos/` | Indefinite |
+| Customer order PII: name, pickup/delivery address, phone, email, free-text notes | Tenant's customers | `OrdersTable` (sources: admin console, orders webhook, Gmail ingest, AI parse) | Indefinite |
+| Driver geolocation (lat/lng/heading, timestamped) | Drivers | `DriverLocationsTable` | **TTL'd** (`expires_at_epoch`) ✓ |
+| POD artifacts: delivery photos, **recipient signature images**, capture location, notes | Customers + drivers | S3 `pod/{org}/{order}/{driver}/`; `PodArtifactsTable` | Indefinite (+ 90d noncurrent versions) |
+| Gmail integration: connected mailbox address, **OAuth refresh token** (mailbox credential), rules | Tenant + email senders | `EmailConfigTable` | Until disconnect |
+| Skipped-email log: sender, subject, reason | Email senders | `SkippedEmailsTable` | **TTL'd** ✓ |
+| Invitations / onboarding: invitee email+role; requester email, contact name, tenant, notes | Staff / prospects | `SeatInvitationsTable`; `OnboardingRegistrationsTable` | Indefinite |
+| Audit trail: actor id, roles, action, details (may embed invitee emails) | Staff | `AuditLogsTable` | Indefinite (deliberate) |
+| Push subscriptions: endpoint URL + crypto keys | Drivers/staff | `PushSubscriptionsTable` | **TTL'd** ✓ |
+| Application logs | — | CloudWatch | **PII-redacted** (S-5, #187) ✓; retention unmanaged |
+| Backups | all of the above | DynamoDB PITR (35d rolling) + S3 versions (90d) | rolls off automatically |
+
+At rest all stores are encrypted (SSE-KMS on tables, SSE-S3 + versioning on the bucket — #187);
+access is org-scoped + RBAC/IDOR-tested (#184).
+
+## 2. Sub-processors and data flows
+
+| Vendor | Personal data sent | Notes / action |
+|---|---|---|
+| AWS (us-east-1) | all stored data | standard AWS DPA applies automatically |
+| Stripe | tenant billing contact, org linkage | standard Stripe DPA |
+| Google (Gmail API) | reads the tenant-connected inbox (email content incl. third-party PII); refresh token held by us | scope is read+label; user-consented OAuth. **Action:** confirm scope minimization + record terms |
+| **Anthropic** | **full email content** (subject/body/PDF text, capped ~12k chars; screenshots for detect-format) for AI order parsing | **Action:** execute/record DPA and confirm zero-data-retention API terms |
+| OpenRouteService | route waypoints (lat/lng only — no names/addresses) | low sensitivity; EU-based |
+| Amazon Location | delivery address text (geocoding), coordinates (matrix) | covered by AWS DPA |
+| CARTO | map-tile requests from the browser (IP, viewport) | client-side; note in privacy policy |
+
+**Gap:** no vendor/DPA register existed before this table. This table is now it — link each
+vendor's DPA and review annually.
+
+## 3. Assessment
+
+| # | Requirement | Status | Evidence / gap | Smallest fix |
+|---|---|---|---|---|
+| 1 | Lawful basis & roles | Partial | Processing is on tenant instructions (contract); driver location = employment context; no Discra↔tenant **DPA** exists | DPA template as part of the pilot contract (**build**) |
+| 2 | Transparency / privacy policy | **Gap** | no privacy policy anywhere (web, mobile, onboarding) | publish policy page; link from login/register + app settings (**build**) |
+| 3 | Consent/notice for driver location tracking | **Gap** | driver PWA + mobile app send location with no notice or in-app disclosure | one-time in-app notice ("location shared with dispatcher while on shift") + doc; consent screen on mobile (**build**) |
+| 4 | Data minimization | Partial | good: TTLs on location/push/skipped-email; POD size caps; log redaction (S-5). Weak: full email bodies sent to AI parsing; indefinite orders/POD | scope AI parse to matched-rule emails only (already the case for the poller — verify elevate path); retention below |
+| 5 | Retention & deletion policy | **Gap** | no policy or job for orders / POD / invitations / onboarding records | define policy (e.g. orders+POD N months post-delivery, configurable per tenant) + a scheduled purge job (**build**) |
+| 6 | Right of access (export) | **Gap** | no per-person export; data is org-scoped, not person-scoped | admin "export person data" action: given email/driver-id, export matching rows (users, orders-by-customer-contact, PODs, invitations, audit refs) (**build**) |
+| 7 | Right to erasure | **Gap** | no per-person delete; spans UsersTable + Cognito + S3 photos + order PII fields + POD artifacts; PITR/S3 versions age out (35d/90d) — document that caveat | admin "erase person" action (delete or field-level anonymize orders); document backup roll-off (**build**) |
+| 8 | Security of processing (art. 32) | Met | encryption at rest/in transit, RBAC+IDOR tested, tenant isolation, secrets not logged, headers/CORS/throttling — see SOC-2 doc §1–3 | — |
+| 9 | Breach notification readiness | **Gap** | no runbook; as processor we must notify tenant controllers without undue delay (their 72h clock) | shared IR runbook w/ breach decision point ([soc2-readiness.md](soc2-readiness.md) §6) |
+| 10 | International transfers | Met (n/a) | hosting + subprocessors in US; pilot tenant US-based; revisit if EU data subjects appear | note in privacy policy |
+
+## 4. What must be BUILT (feeds Phase 4/6 backlogs)
+
+| Build item | GDPR hook | Effort | Priority |
+|---|---|---|---|
+| Privacy policy page (web + mobile links) | Art. 13 | S | **High — before pilot users** |
+| Driver location notice/consent (PWA + Expo) | Art. 13 / employment transparency | S | **High — before pilot drivers** |
+| Discra↔tenant DPA in the pilot agreement | Art. 28 | S (doc) | High |
+| Retention policy + scheduled purge job (orders/POD) | Art. 5(1)(e) | M | Medium — before data accumulates |
+| Person-data export (DSAR) admin action | Art. 15 | M | Medium |
+| Person-data erasure/anonymize admin action | Art. 17 | M | Medium |
+| Breach/IR runbook (shared with SOC-2) | Art. 33/34 | S | High |
+| Anthropic + Google DPA/terms recorded in §2 register | Art. 28 | XS | High (paperwork) |
+
+**Bottom line:** technical/security measures (art. 32) are in good shape after Phases 2–3; the
+gaps are almost entirely **subject-rights plumbing and paperwork** (policy, notices, DPAs,
+retention, DSAR). None require re-architecture — the org-scoped data model makes export/erasure
+tractable — but the two **High** UI items (privacy policy, location notice) should land before
+real pilot users sign in.

--- a/docs/gdpr-readiness.md
+++ b/docs/gdpr-readiness.md
@@ -9,19 +9,19 @@ Discra is the **controller**. A Discra↔tenant DPA does not yet exist (see Buil
 
 ## 1. Data inventory — what PII we hold, and where
 
-| Data | Subjects | Store | Retention today |
-|---|---|---|---|
-| Staff identity: name, email, phone, profile photo, TSA flag | Tenant staff | Cognito; `UsersTable`; S3 `profile-photos/` | Indefinite |
-| Customer order PII: name, pickup/delivery address, phone, email, free-text notes | Tenant's customers | `OrdersTable` (sources: admin console, orders webhook, Gmail ingest, AI parse) | Indefinite |
-| Driver geolocation (lat/lng/heading, timestamped) | Drivers | `DriverLocationsTable` | **TTL'd** (`expires_at_epoch`) ✓ |
-| POD artifacts: delivery photos, **recipient signature images**, capture location, notes | Customers + drivers | S3 `pod/{org}/{order}/{driver}/`; `PodArtifactsTable` | Indefinite (+ 90d noncurrent versions) |
-| Gmail integration: connected mailbox address, **OAuth refresh token** (mailbox credential), rules | Tenant + email senders | `EmailConfigTable` | Until disconnect |
-| Skipped-email log: sender, subject, reason | Email senders | `SkippedEmailsTable` | **TTL'd** ✓ |
-| Invitations / onboarding: invitee email+role; requester email, contact name, tenant, notes | Staff / prospects | `SeatInvitationsTable`; `OnboardingRegistrationsTable` | Indefinite |
-| Audit trail: actor id, roles, action, details (may embed invitee emails) | Staff | `AuditLogsTable` | Indefinite (deliberate) |
-| Push subscriptions: endpoint URL + crypto keys | Drivers/staff | `PushSubscriptionsTable` | **TTL'd** ✓ |
-| Application logs | — | CloudWatch | **PII-redacted** (S-5, #187) ✓; retention unmanaged |
-| Backups | all of the above | DynamoDB PITR (35d rolling) + S3 versions (90d) | rolls off automatically |
+| Data | Subjects | Store | Retention today | Lawful basis (art. 6) |
+|---|---|---|---|---|
+| Staff identity: name, email, phone, profile photo, TSA flag | Tenant staff | Cognito; `UsersTable`; S3 `profile-photos/` | Indefinite | 6(1)(b) contract — account/service provision via the tenant |
+| Customer order PII: name, pickup/delivery address, phone, email, free-text notes | Tenant's customers | `OrdersTable` (sources: admin console, orders webhook, Gmail ingest, AI parse) | Indefinite | Tenant's basis: 6(1)(b) delivery contract / 6(1)(f) fulfillment; Discra processes on instruction (art. 28) |
+| Driver geolocation (lat/lng/heading, timestamped) | Drivers | `DriverLocationsTable` | **TTL'd** (`expires_at_epoch`) ✓ | 6(1)(f) legitimate interest (dispatch ops, employment context) — **not consent** (invalid under employer–employee imbalance); transparency notice required |
+| POD artifacts: delivery photos, **recipient signature images**, capture location, notes | Customers + drivers | S3 `pod/{org}/{order}/{driver}/`; `PodArtifactsTable` | Indefinite (+ 90d noncurrent versions) | 6(1)(b)/(f) proof of delivery. Signature images are ordinary PII here (not art. 9 biometric — no identification processing) |
+| Gmail integration: connected mailbox address, **OAuth refresh token** (mailbox credential), rules | Tenant + email senders | `EmailConfigTable` | Until disconnect | Tenant admin's OAuth authorization + 6(1)(b); third-party sender data: tenant's 6(1)(f) order processing |
+| Skipped-email log: sender, subject, reason | Email senders | `SkippedEmailsTable` | **TTL'd** ✓ | 6(1)(f) ops triage (short-lived) |
+| Invitations / onboarding: invitee email+role; requester email, contact name, tenant, notes | Staff / prospects | `SeatInvitationsTable`; `OnboardingRegistrationsTable` | Indefinite | 6(1)(b) contract / pre-contractual steps at the data subject's request |
+| Audit trail: actor id, roles, action, details (may embed invitee emails) | Staff | `AuditLogsTable` | Indefinite (deliberate) | 6(1)(f) security & accountability (supports art. 32 obligations) |
+| Push subscriptions: endpoint URL + crypto keys | Drivers/staff | `PushSubscriptionsTable` | **TTL'd** ✓ | 6(1)(b) — notifications are a requested service function |
+| Application logs | — | CloudWatch | **PII-redacted** (S-5, #187) ✓; retention unmanaged | 6(1)(f) security/ops (minimized by design) |
+| Backups | all of the above | DynamoDB PITR (35d rolling) + S3 versions (90d) | rolls off automatically | Same basis as the underlying data (availability/integrity) |
 
 At rest all stores are encrypted (SSE-KMS on tables, SSE-S3 + versioning on the bucket — #187);
 access is org-scoped + RBAC/IDOR-tested (#184).
@@ -47,7 +47,7 @@ vendor's DPA and review annually.
 |---|---|---|---|---|
 | 1 | Lawful basis & roles | Partial | Processing is on tenant instructions (contract); driver location = employment context; no Discra↔tenant **DPA** exists | DPA template as part of the pilot contract (**build**) |
 | 2 | Transparency / privacy policy | **Gap** | no privacy policy anywhere (web, mobile, onboarding) | publish policy page; link from login/register + app settings (**build**) |
-| 3 | Consent/notice for driver location tracking | **Gap** | driver PWA + mobile app send location with no notice or in-app disclosure | one-time in-app notice ("location shared with dispatcher while on shift") + doc; consent screen on mobile (**build**) |
+| 3 | Transparency for driver location tracking | **Gap** | driver PWA + mobile app send location with no notice or in-app disclosure. Basis is 6(1)(f) legitimate interest (employment context — consent would be invalid there), which makes **transparency** the binding obligation | one-time in-app notice ("location is shared with your dispatcher while on shift") in PWA + Expo, acknowledged on first use; documented in the privacy policy (**build**) |
 | 4 | Data minimization | Partial | good: TTLs on location/push/skipped-email; POD size caps; log redaction (S-5). Weak: full email bodies sent to AI parsing; indefinite orders/POD | scope AI parse to matched-rule emails only (already the case for the poller — verify elevate path); retention below |
 | 5 | Retention & deletion policy | **Gap** | no policy or job for orders / POD / invitations / onboarding records | define policy (e.g. orders+POD N months post-delivery, configurable per tenant) + a scheduled purge job (**build**) |
 | 6 | Right of access (export) | **Gap** | no per-person export; data is org-scoped, not person-scoped | admin "export person data" action: given email/driver-id, export matching rows (users, orders-by-customer-contact, PODs, invitations, audit refs) (**build**) |

--- a/docs/soc2-readiness.md
+++ b/docs/soc2-readiness.md
@@ -1,0 +1,132 @@
+# SOC 2 Readiness — Gap Analysis
+
+**Date:** 2026-06-29 · **Scope:** Security, Availability, Confidentiality trust criteria
+**Goal:** not certification now — get as close as practical cheaply, and avoid controls that are
+expensive to retrofit later. Statuses: **Met / Partial / Gap**.
+
+Companion doc: [gdpr-readiness.md](gdpr-readiness.md) (PII handling). Security remediation
+history: PRs #184–#187 (RBAC matrix, invitation hardening, S-1…S-9 backlog).
+
+> Items marked *(#187)* are implemented on the open PR `fix/security-hardening-s3-s5` and count
+> as Met once it merges and deploys.
+
+## Control assessment
+
+### 1. Access control & least privilege — **Partial (mostly Met)**
+
+| Aspect | Status | Evidence |
+|---|---|---|
+| App-layer RBAC (Admin/Dispatcher/Driver) | Met | `backend/auth.py` `require_roles`; 48-endpoint × 3-role deny matrix in `backend/tests/test_rbac_matrix.py` (PR #184) |
+| Object-level authorization (IDOR) | Met | driver-own-order/POD/route guards + cross-org 404s, all matrix-tested (#184) |
+| Tenant isolation | Met | every store keyed by `org_id` from the verified JWT; `_require_tenant_order` |
+| JWT verification | Met | RS256-only, issuer+audience+exp enforced (`auth.py:_decode_jwt`); startup guard refuses `JWT_VERIFY_SIGNATURE=false` when deployed *(#187, S-8)* |
+| Lambda IAM least privilege | Met *(#187)* | all grants scoped to ARNs; zero bare `Resource: "*"` after S-4/S-6 |
+| Human AWS-account access | **Gap** | not managed in-repo: no documented IAM user/MFA/root-lockdown policy |
+| Cognito password/MFA policy | **Gap** | user pool is provisioned outside `template.yaml`; policy not codified or evidenced |
+
+**Smallest changes:** document the AWS account access policy (root MFA, no long-lived keys,
+admin via SSO/MFA); export the Cognito pool's password/MFA config into the repo (or manage the
+pool in the template) so it is evidenced and reviewable.
+
+### 2. Audit logging — **Partial**
+
+| Aspect | Status | Evidence |
+|---|---|---|
+| Sensitive actions logged w/ actor + roles + request id | Partial | `AuditLogRecord` written for order assign/unassign/bulk/update, all billing actions, onboarding decisions (`routers/*.py` `_audit_event`) |
+| Coverage gaps | **Gap** | order **status transitions** (`orders.py:update_order_status`) and **POD metadata creation** (`pod.py:create_pod_metadata`) write no audit event; auth events (login/logout/dev-auth) not audited |
+| Tamper evidence | **Gap** | the function role has `dynamodb:DeleteItem`/`UpdateItem` on `AuditLogsTable` (`template.yaml` DynamoDB policy) — a compromised function could erase its own trail |
+| Retention | Partial | no TTL on `AuditLogsTable` → retained indefinitely (good), but retention is implicit, not a stated policy; PITR enabled *(#187, S-9)* |
+| Review | **Gap** | Admin/Dispatcher audit viewer exists (`/audit/logs` + console panel) but no periodic-review practice defined |
+
+**Smallest changes (cheap-now):** (1) split the IAM policy so the audit table gets
+**put/query-only** (no delete/update) — one template statement; (2) add `_audit_event` calls to
+`update_order_status` and `create_pod_metadata`; (3) one sentence of stated retention policy in
+this doc or the ledger.
+
+### 3. Encryption — **Met** (in transit and at rest)
+
+| Aspect | Status | Evidence |
+|---|---|---|
+| In transit | Met | HTTPS-only API Gateway; AWS SDK calls over TLS; HSTS sent over HTTPS (S-1, merged) |
+| DynamoDB at rest | Met *(#187)* | `SSEEnabled: true` on all 13 tables (AWS-managed `aws/dynamodb` KMS key, CloudTrail-auditable) — S-7 |
+| S3 at rest | Met | `AES256` SSE + full PublicAccessBlock; versioning + lifecycle *(#187, S-9)* |
+| Key management | Partial | AWS-managed keys only — no customer-managed CMK (no rotation control / key-policy audit) |
+
+**Cheap-now / expensive-later:** CMK is a **later** item — switching DynamoDB/S3 to a CMK is a
+non-destructive property update, so deferring it does not create rework. Adopt only if an
+auditor/customer requires key-policy control.
+
+### 4. Change management — **Partial**
+
+| Aspect | Status | Evidence |
+|---|---|---|
+| PR-based workflow | Met (practice) | all changes land via reviewed PRs (#180–#187 history) |
+| CI gates | Met | `python-backend-ci.yml`: Ruff (E9,F63,F7,F82) + pytest (397 tests) + `sam build`; `validate-openapi.yml` (Spectral); `mobile-ci.yml` (typecheck) |
+| Enforcement | **Gap** | **`main` has no branch protection** (verified via GitHub API 2026-06-29) — direct pushes and merges without review/green CI are possible |
+| Deploy traceability | Met | `deploy-dev.yml` deploys via CI with Version=Git SHA + post-deploy smoke |
+
+**Smallest change (cheap-now, 5 minutes):** enable branch protection on `main` — require PR,
+require `python-backend-ci` green, no force pushes. This is the single highest-value SOC-2 item
+in this document.
+
+### 5. Monitoring & alerting — **Gap**
+
+| Aspect | Status | Evidence |
+|---|---|---|
+| Structured request logs + correlation ids | Met | `app.py` request middleware (`x-request-id`, JSON logs) |
+| No PII in logs | Met *(#187)* | S-5 redaction + `test_email_log_redaction.py` |
+| Alarms (5xx, latency, throttles, DLQ) | **Gap** | no CloudWatch alarms or dashboard in `template.yaml` |
+| Log retention | **Gap** | no explicit `AWS::Logs::LogGroup` resources → default never-expire, unmanaged |
+| Error tracking (web/mobile) | **Gap** | none (planned in playbook 6.1) |
+
+**Smallest changes:** add explicit log groups with `RetentionInDays` (e.g. 90) and two alarms
+(API 5xx rate, Lambda errors) to the template — small YAML, big audit value. Full observability
+is scheduled as Phase 6.1.
+
+### 6. Incident response — **Gap**
+
+No runbook, severity definitions, contact list, or customer-notification path exists.
+**Smallest change:** a one-page `docs/incident-response.md`: severity ladder, first-hour steps
+(revoke keys, rotate secrets, disable dev flags, snapshot logs), owner contacts, and the
+customer/breach notification decision point (links to GDPR breach section). Cheap-now.
+
+### 7. Backup & restore — **Partial → Met *(#187)* pending one doc**
+
+| Aspect | Status | Evidence |
+|---|---|---|
+| DynamoDB PITR | Met *(#187)* | enabled on the 9 persistent business tables (S-9); ephemeral TTL'd tables deliberately excluded |
+| S3 versioning | Met *(#187)* | POD bucket versioning + 90d noncurrent lifecycle (S-9) |
+| Restore procedure | **Gap** | never documented or exercised |
+
+**Smallest change:** document + one dry-run of a PITR table restore and an S3 version
+retrieval on the dev stack (fits Phase 6.1); record the evidence in the ledger.
+
+### 8. Vendor management — **Partial**
+
+Subprocessors in the data path (full table with data categories in
+[gdpr-readiness.md](gdpr-readiness.md)): **AWS** (all data), **Stripe** (billing), **Google**
+(Gmail read for order ingest), **Anthropic** (email content for AI parsing/format detection),
+**OpenRouteService** (route coordinates), **CARTO** (map tiles, client-side). All are
+standard-DPA vendors; nothing is evidenced.
+
+**Smallest change:** the vendor register in the GDPR doc (done there) + link each vendor's
+DPA/terms; review annually. Cheap-now.
+
+## Prioritized remediation list
+
+| # | Item | Criterion | Effort | Timing |
+|---|------|-----------|--------|--------|
+| 1 | **Branch protection on `main`** (require PR + green CI) | Change mgmt | 5 min | **Cheap-now** |
+| 2 | Audit table IAM → put/query-only (no delete/update) | Audit | XS (template) | **Cheap-now** |
+| 3 | Audit coverage: status transitions + POD creation | Audit | S | **Cheap-now** |
+| 4 | Explicit log groups w/ retention + 5xx/error alarms | Monitoring | S (template) | Cheap-now / 6.1 |
+| 5 | `docs/incident-response.md` one-pager | IR | S | **Cheap-now** |
+| 6 | Documented + dry-run restore procedure | Backup | S | 6.1 |
+| 7 | AWS human-access + Cognito password/MFA policy evidenced | Access | S (doc) | Cheap-now |
+| 8 | Error tracking + dashboard | Monitoring | M | 6.1 |
+| 9 | Customer-managed CMK for tables/bucket | Encryption | M | **Later, only if required** (non-destructive to defer) |
+
+**Expensive-later watchlist:** none of the current gaps get materially harder with time —
+the classic traps (no audit trail, no encryption, unmanaged log retention) are already
+covered or queued above. The one to not postpone past real-customer data is #2
+(audit tamper-evidence), since it cannot retroactively protect events written before it.


### PR DESCRIPTION
## Phase 3, Steps 3.2 + 3.3 — compliance gap analyses (assessment only, no code)

Two committed deliverables (per decision to keep compliance docs in-repo, unlike the local QA ledger):

### `docs/soc2-readiness.md`
8 controls assessed (Security / Availability / Confidentiality) with Met/Partial/Gap status, file-level evidence, and the smallest closing change each. Highlights:
- **Strong:** RBAC + IDOR (matrix-tested, #184), tenant isolation, JWT, encryption at rest/in transit, IAM least-privilege (zero wildcards after #187), backups (PITR + S3 versioning, #187).
- **Verified gaps:** **`main` has no branch protection** (GitHub API-checked — the #1 five-minute fix), function role can `DeleteItem` on the audit table (tamper evidence), audit coverage misses order status transitions + POD creation, no log-group retention/alarms, no IR runbook.
- Prioritized cheap-now / expensive-later list; CMK explicitly deferred as non-destructive-later.

### `docs/gdpr-readiness.md`
- Full **PII inventory** (store-by-store with today's retention) and a **sub-processor register** with data flows — including that **Anthropic receives email content** for AI parsing (DPA/ZDR paperwork flagged).
- 10-item assessment: art. 32 security is in good shape post-Phase 3; the gaps are subject-rights plumbing.
- **Must-BUILD list** feeding Phase 4/6: privacy policy + **driver-location notice (both pre-pilot)**, tenant DPA, retention/purge job, DSAR export + erasure actions, breach runbook.

Items marked *(#187)* count as Met once that PR merges/deploys. Independent of #187 (docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)