### PR TITLE
feat(billing): assign invitee's Cognito group on invitation activation (G-1)

### DIFF
--- a/backend/onboarding_service.py
+++ b/backend/onboarding_service.py
@@ -347,16 +347,25 @@ def get_onboarding_repository() -> OnboardingRepository:
         return _IN_MEMORY_ONBOARDING_REPOSITORY
 
 
+class CognitoUserNotFoundError(Exception):
+    """Raised when a Cognito group/attribute update targets a username that does
+    not exist yet (e.g. an invitee who has not signed up)."""
+
+
 class OnboardingCognitoAdminClient(ABC):
     @abstractmethod
-    def ensure_admin_access(self, *, username: str, org_id: str, role_name: str = "Admin") -> None:
+    def ensure_admin_access(self, *, username: str, org_id: str, role_name: str = "Admin") -> bool:
+        """Add the user to the Cognito group `role_name` and bind their org
+        attribute. Returns True when applied, False when the client is a no-op
+        (no user pool configured). Raises CognitoUserNotFoundError when the
+        username does not exist in the pool."""
         raise NotImplementedError
 
 
 class DisabledOnboardingCognitoAdminClient(OnboardingCognitoAdminClient):
-    def ensure_admin_access(self, *, username: str, org_id: str, role_name: str = "Admin") -> None:
+    def ensure_admin_access(self, *, username: str, org_id: str, role_name: str = "Admin") -> bool:
         del username, org_id, role_name
-        return
+        return False
 
 
 class AwsOnboardingCognitoAdminClient(OnboardingCognitoAdminClient):
@@ -366,23 +375,29 @@ class AwsOnboardingCognitoAdminClient(OnboardingCognitoAdminClient):
         self._client = boto3.client("cognito-idp")
         self._user_pool_id = user_pool_id
 
-    def ensure_admin_access(self, *, username: str, org_id: str, role_name: str = "Admin") -> None:
+    def ensure_admin_access(self, *, username: str, org_id: str, role_name: str = "Admin") -> bool:
         attr_key = onboarding_cognito_org_attribute_key()
-        self._client.admin_add_user_to_group(
-            UserPoolId=self._user_pool_id,
-            Username=username,
-            GroupName=role_name,
-        )
-        self._client.admin_update_user_attributes(
-            UserPoolId=self._user_pool_id,
-            Username=username,
-            UserAttributes=[
-                {
-                    "Name": attr_key,
-                    "Value": org_id,
-                }
-            ],
-        )
+        try:
+            self._client.admin_add_user_to_group(
+                UserPoolId=self._user_pool_id,
+                Username=username,
+                GroupName=role_name,
+            )
+            self._client.admin_update_user_attributes(
+                UserPoolId=self._user_pool_id,
+                Username=username,
+                UserAttributes=[
+                    {
+                        "Name": attr_key,
+                        "Value": org_id,
+                    }
+                ],
+            )
+        except self._client.exceptions.UserNotFoundException as exc:
+            raise CognitoUserNotFoundError(
+                f"Cognito user '{username}' not found in pool"
+            ) from exc
+        return True
 
 
 def get_onboarding_cognito_admin_client() -> OnboardingCognitoAdminClient:

--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -23,6 +23,10 @@ try:
         get_stripe_client,
         new_invitation,
     )
+    from backend.onboarding_service import (
+        CognitoUserNotFoundError,
+        get_onboarding_cognito_admin_client,
+    )
     from backend.order_store import get_order_store
     from backend.repositories import get_identity_repository
     from backend.schemas import (
@@ -61,6 +65,10 @@ except ModuleNotFoundError:  # local run from backend/ directory
         get_or_default_subscription,
         get_stripe_client,
         new_invitation,
+    )
+    from onboarding_service import (
+        CognitoUserNotFoundError,
+        get_onboarding_cognito_admin_client,
     )
     from order_store import get_order_store
     from repositories import get_identity_repository
@@ -710,6 +718,7 @@ async def activate_invitation(
     identity_repo=Depends(get_identity_repository),
     billing_store=Depends(get_billing_store),
     audit_store=Depends(get_audit_log_store),
+    cognito_admin=Depends(get_onboarding_cognito_admin_client),
 ):
     invitation = billing_store.get_invitation(user["org_id"], invitation_id)
     if invitation is None:
@@ -726,6 +735,31 @@ async def activate_invitation(
         ensure_seat_limit_for_activation(invitation.role, subscription, usage)
     except SeatLimitExceededError as exc:
         raise HTTPException(status_code=http_status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    # G-1 (ledger I-1): RBAC reads roles from the JWT's cognito:groups, so the
+    # activation must put the invitee in the Cognito group (and bind their org
+    # attribute) or the seat grants no working access. Done BEFORE any state
+    # mutation: if the invitee hasn't signed up yet, the invitation stays
+    # PENDING (seat stays reserved) and the admin gets an actionable 409.
+    try:
+        cognito_group_assigned = cognito_admin.ensure_admin_access(
+            username=invitation.user_id,
+            org_id=user["org_id"],
+            role_name=invitation.role.value,
+        )
+    except CognitoUserNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=(
+                "Invitee has not created their account yet. Ask them to sign up "
+                "via the app first, then activate the invitation."
+            ),
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_502_BAD_GATEWAY,
+            detail=f"Failed to apply Cognito group for invitee: {exc}",
+        ) from exc
 
     existing_user = identity_repo.get_user(user["org_id"], invitation.user_id)
     now = _utc_now()
@@ -779,6 +813,8 @@ async def activate_invitation(
             "user_id": invitation.user_id,
             "role": invitation.role.value,
             "status": accepted_invitation.status.value,
+            # False = no user pool configured (local/dev no-op client).
+            "cognito_group_assigned": cognito_group_assigned,
         },
     )
 

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -45,6 +45,8 @@ def _test_env(monkeypatch):
     monkeypatch.delenv("STRIPE_DISPATCHER_PRICE_ID", raising=False)
     monkeypatch.delenv("STRIPE_DRIVER_PRICE_ID", raising=False)
     monkeypatch.delenv("ALLOW_UNSAFE_STRIPE_WEBHOOK_WITHOUT_SECRET", raising=False)
+    # Keep the Cognito admin client a no-op unless a test overrides it.
+    monkeypatch.delenv("COGNITO_USER_POOL_ID", raising=False)
     reset_in_memory_billing_store()
     reset_in_memory_audit_log_store()
     _IN_MEMORY_REPO._orgs.clear()
@@ -699,6 +701,92 @@ def test_non_admin_cannot_create_admin_invitation():
             headers=_auth_header(token),
         )
         assert resp.status_code == 403, f"{role} -> {resp.status_code}"
+
+
+# --- G-1: activation assigns the invitee's Cognito group ---
+
+from backend.onboarding_service import CognitoUserNotFoundError  # noqa: E402
+
+
+class _RecordingCognitoAdmin:
+    def __init__(self, error: Exception = None):
+        self.calls = []
+        self._error = error
+
+    def ensure_admin_access(self, *, username: str, org_id: str, role_name: str = "Admin") -> bool:
+        self.calls.append({"username": username, "org_id": org_id, "role_name": role_name})
+        if self._error is not None:
+            raise self._error
+        return True
+
+
+def _pending_invitation(admin_token, user_id="cog-user", role="Driver"):
+    client.post(
+        "/billing/seats",
+        json={"dispatcher_seat_limit": 2, "driver_seat_limit": 2},
+        headers=_auth_header(admin_token),
+    )
+    invite = client.post(
+        "/billing/invitations",
+        json={"user_id": user_id, "email": f"{user_id}@example.com", "role": role},
+        headers=_auth_header(admin_token),
+    )
+    assert invite.status_code == 200, invite.text
+    return invite.json()["invitation_id"]
+
+
+def test_activation_assigns_cognito_group():
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    cognito = _RecordingCognitoAdmin()
+    app.dependency_overrides[billing_router.get_onboarding_cognito_admin_client] = lambda: cognito
+
+    invitation_id = _pending_invitation(admin_token, user_id="cog-driver", role="Driver")
+    activate = client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token))
+    assert activate.status_code == 200, activate.text
+
+    assert cognito.calls == [{"username": "cog-driver", "org_id": "org-1", "role_name": "Driver"}]
+    audit_events = get_audit_log_store().list_events("org-1", limit=10)
+    activated = [e for e in audit_events if e.action == "billing.invitation.activated"]
+    assert activated and activated[0].details["cognito_group_assigned"] is True
+
+
+def test_activation_blocked_until_invitee_signs_up():
+    """User-not-found in Cognito -> 409, the invitation stays PENDING (seat still
+    reserved), no user record is created, and a later activation succeeds."""
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    app.dependency_overrides[billing_router.get_onboarding_cognito_admin_client] = (
+        lambda: _RecordingCognitoAdmin(error=CognitoUserNotFoundError("no such user"))
+    )
+
+    invitation_id = _pending_invitation(admin_token, user_id="not-signed-up", role="Driver")
+    blocked = client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token))
+    assert blocked.status_code == 409
+    assert "sign up" in blocked.json()["detail"].lower()
+
+    pending = client.get("/billing/invitations?status=Pending", headers=_auth_header(admin_token))
+    assert invitation_id in [item["invitation_id"] for item in pending.json()]
+    assert _IN_MEMORY_REPO.get_user("org-1", "not-signed-up") is None
+
+    # Invitee signs up -> activation now succeeds cleanly.
+    app.dependency_overrides[billing_router.get_onboarding_cognito_admin_client] = (
+        lambda: _RecordingCognitoAdmin()
+    )
+    retry = client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token))
+    assert retry.status_code == 200, retry.text
+
+
+def test_activation_cognito_failure_returns_502_and_stays_pending():
+    admin_token = make_token("admin-1", "org-1", ["Admin"])
+    app.dependency_overrides[billing_router.get_onboarding_cognito_admin_client] = (
+        lambda: _RecordingCognitoAdmin(error=RuntimeError("cognito unavailable"))
+    )
+
+    invitation_id = _pending_invitation(admin_token, user_id="unlucky", role="Dispatcher")
+    resp = client.post(f"/billing/invitations/{invitation_id}/activate", headers=_auth_header(admin_token))
+    assert resp.status_code == 502
+
+    pending = client.get("/billing/invitations?status=Pending", headers=_auth_header(admin_token))
+    assert invitation_id in [item["invitation_id"] for item in pending.json()]
 
 
 # --- RBAC: every billing endpoint is Admin-only ---


### PR DESCRIPTION
## Feature-gap G-1 (Must #1, largest effort) — invited users now get a working role

From `docs/feature-gaps.md` (#189) / ledger **I-1 (Sev2)**: activation wrote the app-side role + consumed a seat but never set the invitee's **Cognito group** — and RBAC reads roles from the JWT's `cognito:groups`, so invited users had no working access.

### Behavior
`POST /billing/invitations/{id}/activate` now calls the existing `ensure_admin_access` primitive with the invitation's role **before any state mutation**:

| Cognito outcome | Result |
|---|---|
| User exists | Added to role group + `custom:org_id` bound → activation proceeds |
| **User not signed up yet** | **409** with actionable message; invitation stays **PENDING** (seat stays reserved) → activate again after they sign up |
| Other AWS error | 502, invitation stays PENDING |
| No user pool configured (local/dev) | No-op; audit event records `cognito_group_assigned: false` |

This makes the intended flow explicit: invite → invitee self-signs-up via Hosted UI → admin activates → role works on next sign-in.

### Notes
- `ensure_admin_access` gains a typed `CognitoUserNotFoundError` + returns applied/skipped; onboarding-approve is unchanged (approver identities always exist).
- Known limitation (documented): `custom:org_id` binds the invitee to the inviting org — cross-org membership is out of scope for alpha (single-org user model).
- Real-Cognito round-trip needs the dev stack (no local Cognito) — logic is fully covered by fakes.

### Verification
3 new tests (exact group call recorded; not-found → 409 + still-pending + no user record + clean retry; failure → 502 + still-pending). **Backend suite: 390 passed.**

G-2 (failure reasons), G-3/G-4 (privacy/notice) follow as separate PRs. Independent of #187/#188/#189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)