### PR TITLE
feat(orders): persist and surface failed-delivery reasons (G-2)

### DIFF
--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -342,6 +342,11 @@
         "<div class=\"dispatch-card-details\">" +
         "<div class=\"dispatch-card-detail\"><span class=\"dispatch-card-label\">Pickup</span><span class=\"dispatch-card-value\">" + pickup + "</span></div>" +
         "<div class=\"dispatch-card-detail\"><span class=\"dispatch-card-label\">Delivery</span><span class=\"dispatch-card-value\">" + delivery + "</span></div>" +
+        (order.status_notes
+          ? "<div class=\"dispatch-card-detail\" data-testid=\"status-notes\"><span class=\"dispatch-card-label\">" +
+            (order.status === "Failed" ? "Failure reason" : "Status note") +
+            "</span><span class=\"dispatch-card-value\">" + C.escapeHtml(order.status_notes) + "</span></div>"
+          : "") +
         "</div>" +
         "<div class=\"dispatch-card-footer\">" +
         "<div class=\"dispatch-card-driver\"><span class=\"" + dotClass + "\"></span>" + driverLabel + "</div>" +
@@ -611,8 +616,17 @@
       el.orderHistoryBody.innerHTML = "<tr><td colspan=\"5\" style=\"text-align:center;color:var(--text-muted)\">Loading…</td></tr>";
     }
     try {
-      var orders = await C.requestJson(apiBase, "/orders?status=Delivered&sort_field=created_at&sort_direction=desc", { token });
-      renderOrderHistory(Array.isArray(orders) ? orders : []);
+      // G-2: failed orders were invisible (dispatch hides terminal statuses and
+      // this table fetched Delivered only) — include Failed so dispatchers see
+      // failed deliveries and their reasons.
+      var results = await Promise.all([
+        C.requestJson(apiBase, "/orders?status=Delivered&sort_field=created_at&sort_direction=desc", { token }),
+        C.requestJson(apiBase, "/orders?status=Failed&sort_field=created_at&sort_direction=desc", { token }),
+      ]);
+      var orders = []
+        .concat(Array.isArray(results[0]) ? results[0] : [], Array.isArray(results[1]) ? results[1] : [])
+        .sort(function (a, b) { return String(b.created_at || "").localeCompare(String(a.created_at || "")); });
+      renderOrderHistory(orders);
     } catch (error) {
       if (el.orderHistoryMessage) C.showMessage(el.orderHistoryMessage, error.message, "error");
     }
@@ -621,7 +635,7 @@
   function renderOrderHistory(orders) {
     if (!el.orderHistoryBody) return;
     if (!orders.length) {
-      el.orderHistoryBody.innerHTML = "<tr><td colspan=\"5\" style=\"text-align:center;color:var(--text-muted);padding:24px\">No delivered orders yet.</td></tr>";
+      el.orderHistoryBody.innerHTML = "<tr><td colspan=\"5\" style=\"text-align:center;color:var(--text-muted);padding:24px\">No completed orders yet.</td></tr>";
       return;
     }
     el.orderHistoryBody.innerHTML = orders.map(function (order) {
@@ -630,8 +644,15 @@
         : "<span style=\"color:var(--text-muted)\">—</span>";
       var pickup = C.escapeHtml((order.pick_up_street || "") + ", " + (order.pick_up_city || ""));
       var delivery = C.escapeHtml((order.delivery_street || "") + ", " + (order.delivery_city || ""));
+      var failedInfo = "";
+      if (order.status === "Failed") {
+        failedInfo = "<br><span class=\"table-status status-failed\" data-testid=\"history-status-failed\">Failed</span>" +
+          (order.status_notes
+            ? "<br><small style=\"color:var(--text-danger,#D94D4D)\" data-testid=\"history-failure-reason\">" + C.escapeHtml(order.status_notes) + "</small>"
+            : "");
+      }
       return "<tr>" +
-        "<td><strong>" + C.escapeHtml(order.customer_name || "") + "</strong><br><small style=\"color:var(--text-muted)\">Ref " + C.escapeHtml(order.reference_id || "") + "</small></td>" +
+        "<td><strong>" + C.escapeHtml(order.customer_name || "") + "</strong><br><small style=\"color:var(--text-muted)\">Ref " + C.escapeHtml(order.reference_id || "") + "</small>" + failedInfo + "</td>" +
         "<td><small>" + pickup + "</small><br><small style=\"color:var(--text-muted)\">→ " + delivery + "</small></td>" +
         "<td>" + driver + "</td>" +
         "<td><small>" + C.escapeHtml(C.formatTimestamp(order.created_at)) + "</small></td>" +
@@ -1784,7 +1805,11 @@
         "<small>" + C.escapeHtml(_formatOrderDeadlines(order)) + "</small>" +
         "<br><span class=\"" + C.escapeHtml(due.cssClass) + "\">" + C.escapeHtml(due.label) + "</span>" +
         "</td>" +
-        "<td><span class=\"table-status " + currentStatusClass + "\">" + C.escapeHtml(order.status) + "</span></td>" +
+        "<td><span class=\"table-status " + currentStatusClass + "\">" + C.escapeHtml(order.status) + "</span>" +
+        (order.status_notes
+          ? "<br><small style=\"color:var(--text-danger,#D94D4D)\" data-testid=\"order-status-notes\">" + C.escapeHtml(order.status_notes) + "</small>"
+          : "") +
+        "</td>" +
         "<td class=\"order-cell-assign\">" +
         (hasDriver
           ? "<span class=\"assign-badge\">" + C.escapeHtml(driverName) + "</span>"

--- a/backend/frontend/assets/driver.js
+++ b/backend/frontend/assets/driver.js
@@ -788,8 +788,10 @@
     } catch (e) { C.showMessage(el.ordersMessage, e.message, "error"); }
   }
 
-  async function updateOrderStatus(orderId, statusValue) {
-    await C.requestJson(apiBase, "/orders/" + orderId + "/status", { method: "POST", token: token, json: { status: statusValue } });
+  async function updateOrderStatus(orderId, statusValue, statusNotes) {
+    var payload = { status: statusValue };
+    if (statusNotes) payload.notes = statusNotes;
+    await C.requestJson(apiBase, "/orders/" + orderId + "/status", { method: "POST", token: token, json: payload });
   }
 
   async function uploadWithPresignedPost(upload, fileBlob, fileName) {
@@ -1154,7 +1156,14 @@
     try {
       if (action === "status") {
         var statusValue = target.getAttribute("data-status");
-        await updateOrderStatus(orderId, statusValue);
+        var statusNotes = null;
+        if (statusValue === "Failed") {
+          // G-2: capture the failed-delivery reason so dispatch sees WHY.
+          statusNotes = window.prompt("Why did the delivery fail? (e.g. business closed, refused, no access)", "");
+          if (statusNotes === null) return; // driver cancelled — don't mark Failed
+          statusNotes = statusNotes.trim() || null;
+        }
+        await updateOrderStatus(orderId, statusValue, statusNotes);
         C.showMessage(el.ordersMessage, "Updated to " + statusValue + ".", "success");
         await refreshInbox();
         closeDetailPanel();

--- a/backend/routers/orders.py
+++ b/backend/routers/orders.py
@@ -411,9 +411,11 @@ async def update_order(
 async def update_order_status(
     order_id: str,
     body: StatusUpdateRequest,
+    request: Request,
     user=Depends(require_roles([ROLE_ADMIN, ROLE_DISPATCHER, ROLE_DRIVER])),
     order_store=Depends(get_order_store),
     pod_store=Depends(get_pod_data_store),
+    audit_store=Depends(get_audit_log_store),
 ):
     order = _require_tenant_order(order_id, user["org_id"], order_store=order_store)
 
@@ -449,8 +451,31 @@ async def update_order_status(
                 detail="Cannot mark order Delivered without proof of delivery. Upload a POD photo or signature first.",
             )
 
+    previous_status = order.status
     order.status = body.status
-    return order_store.upsert_order(order)
+    # G-2: persist the transition note (e.g. failed-delivery reason). Previously
+    # StatusUpdateRequest.notes was accepted and silently dropped.
+    status_notes = (body.notes or "").strip() or None
+    if status_notes is not None:
+        order.status_notes = status_notes
+    saved = order_store.upsert_order(order)
+
+    _audit_event(
+        audit_store,
+        org_id=user["org_id"],
+        action="order.status_changed",
+        actor_id=user.get("sub"),
+        actor_roles=user.get("groups") or [],
+        target_type="order",
+        target_id=saved.id,
+        request=request,
+        details={
+            "from_status": previous_status.value,
+            "to_status": saved.status.value,
+            "notes": status_notes,
+        },
+    )
+    return saved
 
 
 @router.get("/driver/inbox", response_model=List[Order])

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -111,6 +111,10 @@ class Order(BaseModel):
     external_order_id: Optional[str] = None
     source: Optional[str] = None
     status: OrderStatus
+    # Reason/note recorded with the most recent status transition (G-2) — e.g. a
+    # driver's failed-delivery reason. The full transition history lives in the
+    # audit log (action=order.status_changed).
+    status_notes: Optional[str] = Field(default=None, max_length=500)
     assigned_to: Optional[str] = None
     created_at: datetime
     org_id: str

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -707,3 +707,103 @@ def test_driver_cannot_access_another_drivers_order(monkeypatch):
     assert client.get(
         f"/orders/{order_id}", headers={"Authorization": f"Bearer {other_org_admin}"}
     ).status_code in (403, 404)
+
+
+# --- G-2: status-transition notes (failed-delivery reasons) persist + audit ---
+
+
+def test_failed_status_persists_reason_and_audits():
+    admin_token = make_token("admin-a", "org-a", ["Admin"])
+    driver_token = make_token("driver-1", "org-a", ["Driver"])
+
+    created = client.post(
+        "/orders/",
+        json=make_order_payload("Reason Co", "Warehouse 9", "9 Fail St"),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    order_id = created.json()["id"]
+    assert client.post(
+        f"/orders/{order_id}/assign",
+        json={"driver_id": "driver-1"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    ).status_code == 200
+
+    failed = client.post(
+        f"/orders/{order_id}/status",
+        json={"status": "Failed", "notes": "Business closed at arrival"},
+        headers={"Authorization": f"Bearer {driver_token}"},
+    )
+    assert failed.status_code == 200
+    assert failed.json()["status_notes"] == "Business closed at arrival"
+
+    fetched = client.get(f"/orders/{order_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    assert fetched.json()["status_notes"] == "Business closed at arrival"
+
+    events = [
+        e for e in get_audit_log_store().list_events("org-a", limit=20)
+        if e.action == "order.status_changed"
+    ]
+    assert len(events) == 1
+    assert events[0].target_id == order_id
+    assert events[0].details == {
+        "from_status": "Assigned",
+        "to_status": "Failed",
+        "notes": "Business closed at arrival",
+    }
+
+
+def test_status_note_is_optional_and_preserved_until_replaced():
+    admin_token = make_token("admin-a", "org-a", ["Admin"])
+    driver_token = make_token("driver-1", "org-a", ["Driver"])
+
+    created = client.post(
+        "/orders/",
+        json=make_order_payload("Retry Co", "Warehouse 9", "10 Retry Ave"),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    order_id = created.json()["id"]
+    client.post(
+        f"/orders/{order_id}/assign",
+        json={"driver_id": "driver-1"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    # No notes -> status_notes stays unset, audit records notes=None.
+    en_route = client.post(
+        f"/orders/{order_id}/status",
+        json={"status": "EnRoute"},
+        headers={"Authorization": f"Bearer {driver_token}"},
+    )
+    assert en_route.status_code == 200
+    assert en_route.json()["status_notes"] is None
+
+    # Whitespace-only notes are treated as absent.
+    fail = client.post(
+        f"/orders/{order_id}/status",
+        json={"status": "Failed", "notes": "   "},
+        headers={"Authorization": f"Bearer {driver_token}"},
+    )
+    assert fail.status_code == 200
+    assert fail.json()["status_notes"] is None
+
+    # A real reason persists across the retry re-assignment (dispatch context).
+    fail_again = client.post(
+        f"/orders/{order_id}/assign",
+        json={"driver_id": "driver-1"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert fail_again.status_code == 200
+    with_reason = client.post(
+        f"/orders/{order_id}/status",
+        json={"status": "Failed", "notes": "No access to loading dock"},
+        headers={"Authorization": f"Bearer {driver_token}"},
+    )
+    assert with_reason.status_code == 200
+    refetched = client.get(f"/orders/{order_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    assert refetched.json()["status_notes"] == "No access to loading dock"
+
+    changed_events = [
+        e for e in get_audit_log_store().list_events("org-a", limit=30)
+        if e.action == "order.status_changed"
+    ]
+    assert len(changed_events) == 3  # EnRoute, Failed (blank note), Failed (reason)

--- a/mobile/lib.ts
+++ b/mobile/lib.ts
@@ -27,6 +27,8 @@ export type OrderRecord = {
   time_window_start?: string | null;
   time_window_end?: string | null;
   status: string;
+  // Reason recorded with the latest status transition (e.g. failed delivery).
+  status_notes?: string | null;
   assigned_to?: string | null;
   phone?: string | null;
   notes?: string | null;

--- a/mobile/screens/DriverScreen.tsx
+++ b/mobile/screens/DriverScreen.tsx
@@ -92,6 +92,9 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
   const [selectedOrder, setSelectedOrder] = useState<OrderRecord | null>(null);
   const [detailVisible, setDetailVisible] = useState(false);
   const [signatureOrderId, setSignatureOrderId] = useState<string | null>(null);
+  // G-2: failed-delivery reason capture — which order is being failed + reason text.
+  const [failingOrderId, setFailingOrderId] = useState<string | null>(null);
+  const [failReason, setFailReason] = useState("");
   const [podState, setPodState] = useState<Map<string, PodState>>(new Map());
   const [profileVisible, setProfileVisible] = useState(false);
   const [profile, setProfile] = useState<UserProfile | null>(null);
@@ -270,7 +273,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
   }, [apiBase, token, geocodeOrders]);
 
   // ── Update order status ────────────────────────────────────────────────────
-  async function updateStatus(orderId: string, status: string) {
+  async function updateStatus(orderId: string, status: string, notes?: string) {
     // Drop a concurrent tap while a status change is already in flight.
     if (statusUpdating) return;
     setStatusUpdating(true);
@@ -279,7 +282,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
       await apiRequest(apiBase, `/orders/${orderId}/status`, {
         method: "POST",
         token,
-        json: { status },
+        json: notes ? { status, notes } : { status },
       });
       await loadInbox();
       setStatusMsg(`Status updated: ${status}`);
@@ -907,12 +910,54 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                           statusUpdating && styles.actionBtnDisabled,
                         ]}
                         disabled={statusUpdating}
-                        onPress={() => updateStatus(selectedOrder.id, s).catch(() => undefined)}
+                        onPress={() => {
+                          if (s === "Failed") {
+                            // G-2: ask for the reason before marking Failed.
+                            setFailReason("");
+                            setFailingOrderId(selectedOrder.id);
+                            return;
+                          }
+                          updateStatus(selectedOrder.id, s).catch(() => undefined);
+                        }}
                       >
                         <Text style={styles.actionBtnText}>{s}</Text>
                       </Pressable>
                     ))}
                   </View>
+                  {failingOrderId === selectedOrder.id ? (
+                    <View style={styles.detailSection}>
+                      <TextInput
+                        testID="fail-reason-input"
+                        style={styles.input}
+                        value={failReason}
+                        onChangeText={setFailReason}
+                        placeholder="Why did the delivery fail? (e.g. business closed)"
+                        placeholderTextColor="#4A3F60"
+                        multiline
+                      />
+                      <View style={styles.statusActions}>
+                        <Pressable
+                          testID="fail-confirm-btn"
+                          style={[styles.actionBtn, styles.actionBtnDanger, statusUpdating && styles.actionBtnDisabled]}
+                          disabled={statusUpdating}
+                          onPress={() => {
+                            const reason = failReason.trim();
+                            setFailingOrderId(null);
+                            updateStatus(selectedOrder.id, "Failed", reason || undefined).catch(() => undefined);
+                          }}
+                        >
+                          <Text style={styles.actionBtnText}>Confirm Failed</Text>
+                        </Pressable>
+                        <Pressable
+                          testID="fail-cancel-btn"
+                          style={styles.actionBtn}
+                          onPress={() => setFailingOrderId(null)}
+                        >
+                          <Text style={styles.actionBtnText}>Cancel</Text>
+                        </Pressable>
+                      </View>
+                    </View>
+                  ) : null}
                 </View>
 
                 {/* POD section */}


### PR DESCRIPTION
## Feature-gap G-2 (Must #2) — failed-delivery reasons: captured, persisted, visible

From `docs/feature-gaps.md` (#189). Two verified problems fixed:
1. `POST /orders/{id}/status` accepted `StatusUpdateRequest.notes` and **silently dropped it** — a driver's failure reason was lost.
2. **Failed orders were invisible in the admin console**: the dispatch queue hides terminal statuses and the history table fetched `status=Delivered` only (discovered during live verification).

### Changes
- **Backend**: `Order.status_notes` (trimmed, ≤500); `update_order_status` persists it and emits the previously missing **`order.status_changed` audit event** (`from_status`/`to_status`/`notes`) — also closes the SOC-2 status-transition audit gap.
- **Driver PWA**: marking *Failed* prompts for the reason (cancel aborts the transition); the POST carries `notes`.
- **Mobile (Expo)**: *Failed* opens an inline reason input with Confirm/Cancel; `updateStatus` forwards optional notes.
- **Admin console**: order history now fetches **Delivered + Failed** with a Failed badge + reason; the main orders table and dispatch card show the reason under the status badge.

### Verification
- **Live browser run** (uvicorn + dev-auth): create → assign → driver marks Failed → prompt captured `"  Business closed at arrival  "` → persisted **trimmed** → admin Orders table renders `Failed / Business closed at arrival`. Zero console errors. Screenshot in session.
- 2 new pytest cases (reason persist + audit payload; optional/whitespace notes + retry preservation + 3 audit events). **Backend suite: 389 passed**; mobile `tsc --noEmit` green.

Second of the Must shortlist (after #190/G-1). G-3+G-4 (privacy policy + location notice) follow. Independent of open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)