### PR TITLE
feat(privacy): privacy policy page + driver location-sharing notice (G-3, G-4)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -465,6 +465,20 @@ def create_app() -> FastAPI:
     async def dev_backend_ui_review():
         return FileResponse(str(FRONTEND_DIR / "review.html"))
 
+    # Privacy policy (G-3, GDPR art. 13) — public, linked from the entry pages,
+    # the driver location notice, and the mobile app.
+    @app.get("/ui/privacy", include_in_schema=False)
+    async def ui_privacy():
+        return FileResponse(str(FRONTEND_DIR / "privacy.html"))
+
+    @app.get("/backend/ui/privacy", include_in_schema=False)
+    async def backend_ui_privacy():
+        return FileResponse(str(FRONTEND_DIR / "privacy.html"))
+
+    @app.get("/dev/backend/ui/privacy", include_in_schema=False)
+    async def dev_backend_ui_privacy():
+        return FileResponse(str(FRONTEND_DIR / "privacy.html"))
+
     @app.get("/ui/driver-sw.js", include_in_schema=False)
     async def ui_driver_service_worker():
         return FileResponse(str(FRONTEND_DIR / "driver-sw.js"), media_type="application/javascript")

--- a/backend/frontend/assets/driver.js
+++ b/backend/frontend/assets/driver.js
@@ -748,8 +748,39 @@
     }
   }
 
+  // G-4 (GDPR transparency): drivers see a one-time notice before the first
+  // location share. Sharing stays off until they acknowledge it.
+  var LOCATION_NOTICE_ACK_KEY = "discra_location_notice_ack_v1";
+
+  function locationNoticeAcknowledged() {
+    try { return !!window.localStorage.getItem(LOCATION_NOTICE_ACK_KEY); } catch (e) { return true; }
+  }
+
+  function showLocationNotice() {
+    if (!el.locationBar || document.getElementById("location-notice")) return;
+    var notice = document.createElement("div");
+    notice.id = "location-notice";
+    notice.setAttribute("data-testid", "location-notice");
+    notice.style.cssText = "display:flex;gap:10px;align-items:center;justify-content:space-between;padding:8px 12px;font-size:.8rem;line-height:1.35;border-bottom:1px solid rgba(255,255,255,.12);";
+    notice.innerHTML =
+      '<span>While you are signed in, your location is shared with your dispatcher to coordinate deliveries. ' +
+      '<a href="privacy" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;">Privacy Policy</a></span>' +
+      '<button id="location-notice-ack" data-testid="location-notice-ack" class="drv-btn drv-btn-accent drv-btn-sm" type="button" style="flex-shrink:0;">Got it</button>';
+    el.locationBar.insertBefore(notice, el.locationBar.firstChild);
+    if (el.locationStatus) el.locationStatus.textContent = "Location paused";
+    notice.querySelector("#location-notice-ack").addEventListener("click", function () {
+      try { window.localStorage.setItem(LOCATION_NOTICE_ACK_KEY, new Date().toISOString()); } catch (e) { /* storage blocked — proceed */ }
+      notice.remove();
+      startAutoLocationShare();
+    });
+  }
+
   function startAutoLocationShare() {
     if (locationTimer) return;
+    if (!locationNoticeAcknowledged()) {
+      showLocationNotice();
+      return;
+    }
     sendLocationUpdate();
     locationTimer = window.setInterval(sendLocationUpdate, 60000);
   }

--- a/backend/frontend/index.html
+++ b/backend/frontend/index.html
@@ -134,6 +134,8 @@
       <span>Discra</span>
       <span class="landing-footer-sep"></span>
       <span>Delivery Operations Platform</span>
+      <span class="landing-footer-sep"></span>
+      <a href="ui/privacy" style="color:inherit;">Privacy</a>
     </footer>
   </main>
   <script src="ui/assets/landing.js?v=20260524a"></script>

--- a/backend/frontend/login.html
+++ b/backend/frontend/login.html
@@ -37,6 +37,7 @@
         <div class="login-footer-links">
           <button id="login-forgot-link" class="btn-link" type="button">Forgot password?</button>
           <a href="register" class="btn-link">Request access</a>
+          <a href="privacy" class="btn-link">Privacy</a>
         </div>
       </div>
 

--- a/backend/frontend/privacy.html
+++ b/backend/frontend/privacy.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Discra | Privacy Policy</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/styles.css?v=20260524a">
+  <style>
+    .privacy-card { max-width: 760px; text-align: left; }
+    .privacy-card h1 { margin-bottom: .25rem; }
+    .privacy-card h2 { font-size: 1.05rem; margin: 1.4rem 0 .4rem; }
+    .privacy-card p, .privacy-card li { font-size: .95rem; line-height: 1.55; color: var(--text-secondary, #C9BDA8); }
+    .privacy-card ul { padding-left: 1.2rem; margin: .3rem 0 .6rem; }
+    .privacy-meta { font-size: .8rem; color: var(--text-muted, #8A7F6C); }
+  </style>
+</head>
+<body class="theme-admin">
+  <main class="center-stage" style="padding: 32px 16px;">
+    <section class="hero-card privacy-card">
+      <div class="login-brand">
+        <span class="login-brand-mark">D</span>
+        <span class="login-brand-text">Discra</span>
+      </div>
+
+      <h1>Privacy Policy</h1>
+      <p class="privacy-meta">Last updated: June 29, 2026 · Applies to the Discra web apps and mobile app (alpha).</p>
+
+      <h2>Who we are</h2>
+      <p>
+        Discra is a delivery-dispatch platform. Your dispatch company (the organization that
+        invited you or created your account) decides what order and delivery data enters
+        Discra and is the controller of that data; Discra processes it on their behalf to
+        run the service.
+      </p>
+
+      <h2>What we collect</h2>
+      <ul>
+        <li><strong>Account &amp; profile</strong> — name, email, phone, and an optional profile photo, tied to your organization.</li>
+        <li><strong>Orders &amp; deliveries</strong> — order details your organization enters or imports, including delivery recipient name, addresses, and contact details.</li>
+        <li><strong>Driver location</strong> — while a driver is signed in to the driver app, their device location is shared with their organization's dispatchers to coordinate deliveries. Location pings expire from our systems automatically.</li>
+        <li><strong>Proof of delivery</strong> — delivery photos and recipient signatures captured at drop-off, stored securely for your organization's delivery records.</li>
+        <li><strong>Email integration</strong> — if your organization's administrator connects a mailbox, we read incoming order emails from it to create orders.</li>
+        <li><strong>Usage &amp; security records</strong> — sign-ins and sensitive actions are recorded in an audit trail; operational logs avoid personal content.</li>
+      </ul>
+
+      <h2>Why we use it</h2>
+      <ul>
+        <li>To provide the service your organization signed up for (account management, dispatch, delivery tracking, proof of delivery, billing seats).</li>
+        <li>To coordinate active deliveries (driver location and status, shared only within your organization).</li>
+        <li>To keep the service secure and accountable (authentication, access control, audit logging).</li>
+      </ul>
+
+      <h2>Who processes it for us</h2>
+      <p>We use these service providers, under their standard data-protection terms:</p>
+      <ul>
+        <li><strong>Amazon Web Services</strong> — hosting and storage (United States).</li>
+        <li><strong>Stripe</strong> — subscription billing for your organization.</li>
+        <li><strong>Google</strong> — only if your administrator connects a Gmail mailbox for order intake.</li>
+        <li><strong>Anthropic</strong> — order emails may be processed by an AI service to extract order details, when your organization enables email parsing.</li>
+        <li><strong>Routing &amp; maps</strong> — delivery coordinates are sent to routing providers (Amazon Location, OpenRouteService) to plan routes; map tiles are loaded from CARTO in your browser.</li>
+      </ul>
+      <p>Data is not sold or used for advertising.</p>
+
+      <h2>Retention</h2>
+      <ul>
+        <li>Order, delivery, and proof-of-delivery records are kept while your organization's account is active.</li>
+        <li>Driver location pings and push-notification registrations expire automatically.</li>
+        <li>Backups roll off automatically (35 days for databases, 90 days for prior file versions).</li>
+      </ul>
+
+      <h2>Your rights</h2>
+      <p>
+        You can review and update your profile in the app. To request access to, correction of,
+        or deletion of your personal data, contact your organization's Discra administrator,
+        who can raise the request with the Discra operator named in your organization's
+        service agreement. We will support access and deletion requests within the limits of
+        your organization's legal record-keeping needs.
+      </p>
+
+      <h2>Changes</h2>
+      <p>
+        Discra is in an early-access (alpha) phase and this policy will evolve with the
+        product. Material changes will be announced in the app.
+      </p>
+
+      <p class="privacy-meta" style="margin-top:1.5rem;"><a class="btn-link" href="login">Back to sign in</a></p>
+    </section>
+  </main>
+</body>
+</html>

--- a/backend/frontend/register.html
+++ b/backend/frontend/register.html
@@ -35,6 +35,7 @@
           <button id="register-logout-hosted-ui" class="btn btn-ghost" type="button" hidden disabled>Sign Out</button>
         </div>
         <p id="register-account-hint" class="panel-help">You will be redirected to secure authentication. <strong>Create Account</strong> opens sign-up directly.</p>
+        <p class="panel-help"><a href="privacy" class="btn-link">Privacy Policy</a></p>
         <label class="field">
           <span>Signed-In Email</span>
           <input id="register-email-view" disabled placeholder="Sign in to continue">

--- a/backend/tests/test_ui.py
+++ b/backend/tests/test_ui.py
@@ -108,3 +108,21 @@ def test_ui_config_reflects_env(monkeypatch):
     assert body["onboarding_enabled"] is True
     assert body["register_url_path"] == "/ui/register"
     assert body["review_url_path"] == "/ui/review"
+
+
+# --- G-3: privacy policy page (GDPR art. 13) ---
+
+
+def test_privacy_policy_page_is_served_on_all_prefixes():
+    for path in ("/ui/privacy", "/backend/ui/privacy", "/dev/backend/ui/privacy"):
+        resp = client.get(path)
+        assert resp.status_code == 200, f"{path} -> {resp.status_code}"
+        assert "Privacy Policy" in resp.text
+        assert "location is shared" in resp.text  # driver-location transparency
+        assert "Anthropic" in resp.text  # sub-processor disclosure
+
+
+def test_entry_pages_link_to_privacy_policy():
+    assert 'href="privacy"' in client.get("/ui/login").text
+    assert 'href="privacy"' in client.get("/ui/register").text
+    assert 'href="ui/privacy"' in client.get("/ui").text

--- a/mobile/screens/DriverScreen.tsx
+++ b/mobile/screens/DriverScreen.tsx
@@ -1,4 +1,5 @@
 // DriverScreen.tsx — Full-screen map + bottom sheet driver experience
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as FileSystem from "expo-file-system";
 import * as ImagePicker from "expo-image-picker";
 import * as Location from "expo-location";
@@ -9,6 +10,7 @@ import {
   Dimensions,
   Image,
   KeyboardAvoidingView,
+  Linking,
   Modal,
   PanResponder,
   Platform,
@@ -50,6 +52,8 @@ const SHEET_HEIGHT = Math.round(SCREEN_HEIGHT * 0.72);
 const SHEET_OPEN_Y = 0;
 const SHEET_CLOSED_Y = SHEET_HEIGHT - PEEK_HEIGHT;
 const DRIVER_STATUS = ["PickedUp", "EnRoute", "Failed", "Delivered"] as const;
+// G-4 (GDPR transparency): one-time location-sharing notice acknowledgment.
+const LOCATION_NOTICE_ACK_KEY = "discra_location_notice_ack_v1";
 const AUSTIN_REGION: Region = {
   latitude: 30.2672,
   longitude: -97.7431,
@@ -110,6 +114,8 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
   // POST resolves would fire a duplicate /orders/{id}/status request.
   const [statusUpdating, setStatusUpdating] = useState(false);
   const [locationActive, setLocationActive] = useState(false);
+  // null = still loading from storage; false = notice pending; true = acknowledged.
+  const [locationNoticeAck, setLocationNoticeAck] = useState<boolean | null>(null);
   const locationTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mapRef = useRef<MapView | null>(null);
 
@@ -639,12 +645,26 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
   useEffect(() => {
     loadInbox().catch(() => undefined);
     loadProfile().catch(() => undefined);
-    startAutoLocation();
+    // G-4: don't start sharing until the one-time notice is acknowledged.
+    AsyncStorage.getItem(LOCATION_NOTICE_ACK_KEY)
+      .then((v) => setLocationNoticeAck(!!v))
+      .catch(() => setLocationNoticeAck(true)); // storage unavailable — fail open
     return () => {
       stopAutoLocation();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Start location sharing once (and only once) the notice is acknowledged.
+  useEffect(() => {
+    if (locationNoticeAck === true) startAutoLocation();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [locationNoticeAck]);
+
+  function acknowledgeLocationNotice() {
+    AsyncStorage.setItem(LOCATION_NOTICE_ACK_KEY, new Date().toISOString()).catch(() => undefined);
+    setLocationNoticeAck(true);
+  }
 
   // ─── Render ───────────────────────────────────────────────────────────────
 
@@ -724,6 +744,27 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
             </Pressable>
           </View>
         </View>
+        {locationNoticeAck === false ? (
+          <View style={styles.locationNotice} testID="location-notice">
+            <Text style={styles.locationNoticeText}>
+              While you are signed in, your location is shared with your dispatcher to
+              coordinate deliveries.{" "}
+              <Text
+                style={styles.locationNoticeLink}
+                onPress={() => Linking.openURL(`${apiBase}/ui/privacy`).catch(() => undefined)}
+              >
+                Privacy Policy
+              </Text>
+            </Text>
+            <Pressable
+              testID="location-notice-ack"
+              style={styles.locationNoticeBtn}
+              onPress={acknowledgeLocationNotice}
+            >
+              <Text style={styles.locationNoticeBtnText}>Got it</Text>
+            </Pressable>
+          </View>
+        ) : null}
       </SafeAreaView>
 
       {/* ── Status bar (floats above sheet) ────────────────────────── */}
@@ -1093,6 +1134,12 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                   <Text style={styles.btnGhostText}>Sign Out</Text>
                 </Pressable>
               </View>
+              <Text
+                style={styles.privacyLink}
+                onPress={() => Linking.openURL(`${apiBase}/ui/privacy`).catch(() => undefined)}
+              >
+                Privacy Policy
+              </Text>
             </View>
           </SafeAreaView>
         </View>
@@ -1210,6 +1257,46 @@ const styles = StyleSheet.create({
     color: "#EDE0C4",
     fontSize: 12,
     fontWeight: "600",
+  },
+  locationNotice: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginTop: 8,
+    marginHorizontal: 12,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: "rgba(11,9,16,0.92)",
+    borderWidth: 1,
+    borderColor: "#3A2F50",
+  },
+  locationNoticeText: {
+    flex: 1,
+    color: "#EDE0C4",
+    fontSize: 12,
+    lineHeight: 17,
+  },
+  locationNoticeLink: {
+    color: "#C8973A",
+    textDecorationLine: "underline",
+  },
+  locationNoticeBtn: {
+    backgroundColor: "#C8973A",
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  locationNoticeBtnText: {
+    color: "#1A1424",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  privacyLink: {
+    color: "#8A7F6C",
+    fontSize: 12,
+    textAlign: "center",
+    textDecorationLine: "underline",
+    marginTop: 12,
   },
   profileBtn: {
     width: 36,


### PR DESCRIPTION
## Feature-gap Musts G-3 + G-4 — the GDPR pre-pilot gates

Last pair of the alpha Must shortlist from `docs/feature-gaps.md` (#189), per the readiness analysis in `docs/gdpr-readiness.md` (#188).

### G-3 — Privacy policy page
- New **`/ui/privacy`** (+ `/backend` + `/dev/backend` prefixes), dark-fantasy themed, honest plain-language coverage: controller/processor roles, full data inventory (profile, orders, **driver location**, POD photos/**signatures**, email integration, audit records), purposes, **sub-processor disclosure** (AWS, Stripe, Google, **Anthropic**, routing/maps), retention (TTL'd location pings, backup roll-off), and rights/contact. Marked as an alpha policy.
- Linked from the landing footer, login footer, register page, and the mobile profile modal.

### G-4 — Driver location-sharing transparency notice
- **Driver PWA**: a one-time notice renders in the location bar **before the first location share** — sharing stays off (`Location paused`) until the driver taps **Got it** (ack persisted in `localStorage`); then sharing starts and the notice never returns.
- **Mobile (Expo)**: same gating via `AsyncStorage` — the lifecycle no longer auto-starts location; an inline notice card (policy link + Got it) shows until acknowledged. Storage-unavailable fails open (never blocks dispatch).
- Per the GDPR analysis this is a **transparency notice, not consent** (basis = legitimate interest in the employment context) — acknowledgment resumes sharing; nothing is consent-gated.

### Verification
- **Live browser run**: fresh driver session → notice shown, sharing paused, no ack stored → acknowledge → flag stored + sharing starts → reload with flag → no notice, immediate share attempt. Privacy page 200s on all three prefixes (screenshot in session).
- New `test_ui.py` cases: privacy content on all prefixes + entry-page links. **Backend suite: 389 passed**; mobile `tsc --noEmit` green.

Completes the four-Must alpha shortlist (G-1 #190, G-2 #191, G-3+G-4 here). Independent of other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)