### PR TITLE
feat(design): driver PWA polish — 44px touch targets, status parity, focus ring (Step 5.3)

### DIFF
--- a/backend/frontend/assets/driver-mobile.css
+++ b/backend/frontend/assets/driver-mobile.css
@@ -113,7 +113,11 @@ body {
   font-family: var(--drv-font-display); font-weight: 600; font-size: .78rem;
   letter-spacing: 0.1em; text-transform: uppercase;
   cursor: pointer; padding: .55rem 1rem;
-  transition: background .15s, border-color .15s, box-shadow .15s, opacity .15s;
+  /* 5.3 one-handed use: all primary controls meet the 44px touch-target
+     minimum — drivers tap these gloved, moving, one-thumbed. */
+  min-height: 44px;
+  transition: background var(--motion-fast), border-color var(--motion-fast),
+              box-shadow var(--motion-fast), opacity var(--motion-fast);
 }
 .drv-btn:active { transform: scale(0.98); opacity: .85; }
 .drv-btn-accent {
@@ -160,9 +164,20 @@ body {
   color: var(--drv-text-heading);
   border-color: var(--drv-border-accent);
 }
-.drv-btn-sm { padding: .38rem .8rem; font-size: .72rem; }
-.drv-btn-xs { padding: .28rem .55rem; font-size: .68rem; }
+/* -sm keeps the compact look but never drops below the touch minimum (the
+   status actions — the most-used driving controls — are -sm). -xs is reserved
+   for secondary chrome (e.g. Clear signature) and still gets 36px. */
+.drv-btn-sm { padding: .38rem .8rem; font-size: .72rem; min-height: 44px; }
+.drv-btn-xs { padding: .28rem .55rem; font-size: .68rem; min-height: 36px; }
 .drv-btn:disabled { opacity: .4; pointer-events: none; }
+
+/* Keyboard/AT focus parity with the admin console (tokens.css --border-glow). */
+:focus-visible {
+  outline: 2px solid var(--border-glow);
+  outline-offset: 2px;
+  border-radius: var(--drv-radius-sm);
+}
+:focus:not(:focus-visible) { outline: none; }
 
 /* ===== MESSAGES ===== */
 .drv-msg { font-size: .75rem; padding: .25rem .5rem; min-height: 1em; }
@@ -461,15 +476,17 @@ body {
   color: var(--purple-light);
   border-color: rgba(123, 79, 166, 0.4);
 }
+/* PickedUp/EnRoute follow the shared --status-* progression (tokens.css) so
+   the driver app and admin console tell the same color story. */
 .drv-badge-pickedup {
-  background: rgba(200, 151, 58, 0.12);
-  color: var(--drv-accent-bright);
-  border-color: rgba(200, 151, 58, 0.4);
+  background: rgba(224, 164, 59, 0.14);
+  color: var(--status-pickedup);
+  border-color: rgba(224, 164, 59, 0.45);
 }
 .drv-badge-enroute {
-  background: rgba(200, 151, 58, 0.12);
-  color: var(--drv-accent-bright);
-  border-color: rgba(200, 151, 58, 0.4);
+  background: rgba(74, 158, 92, 0.18);
+  color: var(--status-enroute);
+  border-color: rgba(74, 158, 92, 0.4);
 }
 .drv-badge-delivered {
   background: rgba(74, 158, 92, 0.18);

--- a/backend/frontend/driver-sw.js
+++ b/backend/frontend/driver-sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = "discra-driver-v20260705b";
+const CACHE_NAME = "discra-driver-v20260705c";
 const PRECACHE_URLS = [
   "driver",
   "assets/tokens.css?v=20260705b",
-  "assets/driver-mobile.css?v=20260705b",
+  "assets/driver-mobile.css?v=20260705c",
   "assets/common.js?v=20260524a",
   "assets/driver.js?v=20260529b",
   "assets/driver-manifest.json",

--- a/backend/frontend/driver.html
+++ b/backend/frontend/driver.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <link rel="manifest" href="assets/driver-manifest.json">
   <meta name="theme-color" content="#0b1117">
-  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260705b">
+  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260705c">
 </head>
 <body>
 


### PR DESCRIPTION
## Phase 5, Step 5.3 — Driver PWA polish

**Stacked on #194 (5.2) → #193 (5.1)** — retarget as the stack merges. CSS-only (3 files); no JS changes.

Focus per the playbook: one-handed mobile use, glanceable while driving, tasteful celebration.

### Changes
- **44px touch targets** — `.drv-btn` gains `min-height: 44px`, and crucially `.drv-btn-sm` (the **PickedUp / EnRoute / Failed status actions** — the most-used controls while driving, previously ~30px tall) now meets the minimum too. `.drv-btn-xs` (secondary chrome like *Clear signature*) gets 36px. Button transitions moved onto `--motion-fast`.
- **Cross-surface status parity** — `.drv-badge-pickedup` / `.drv-badge-enroute` were *identical gold*; they now use the shared `--status-*` tokens from 5.2, so the driver app and admin console tell the same color story (PickedUp = warm amber, EnRoute = green).
- **Keyboard/AT focus ring** — same warm-gold `:focus-visible` rule as the console (driver.html doesn't load styles.css, so parity must live in driver-mobile.css).
- **Celebration audited, deliberately untouched** — already fast (~1.1s), tasteful, and fully `prefers-reduced-motion`-covered.
- Cache: `driver-mobile.css ?v` + driver-sw `CACHE_NAME` bumped `…705b → …705c`.

### Verification (live, desktop + 375×812 phone width)
Status buttons measure **44px** (POD submit 44, refresh 44, clear-sig 36); PickedUp badge computes `rgb(224,164,59)` on `rgba(224,164,59,.14)`; `:focus-visible` rule present; stylesheet `v=20260705c` confirmed loaded; **no horizontal overflow at phone width; zero console errors**. (Screenshots stall on the WebGL map renderer — verified via boundingBox/computed-style metrics.)

Next: 5.4 mobile theme adoption → 5.5 accessibility pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)