### PR TITLE
feat(design): adopt design tokens across mobile screens (Step 5.4)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,5 +1,6 @@
 // App.tsx — Auth gateway + workspace router for Discra Mobile
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { theme } from "./theme";
 import {
   AuthenticationDetails,
   CognitoUser,
@@ -355,7 +356,7 @@ export default function App() {
     return (
       <SafeAreaView style={styles.screen}>
         <View style={styles.loadingWrap}>
-          <ActivityIndicator color="#C8973A" />
+          <ActivityIndicator color={theme.colors.goldPrimary} />
           <Text style={styles.loadingText}>Loading…</Text>
         </View>
       </SafeAreaView>
@@ -491,7 +492,7 @@ export default function App() {
             autoCapitalize="none"
             autoCorrect={false}
             placeholder="Enter username"
-            placeholderTextColor="#4A3F60"
+            placeholderTextColor={theme.colors.placeholder}
             returnKeyType="next"
           />
           <Text style={styles.label}>Password</Text>
@@ -504,7 +505,7 @@ export default function App() {
             autoCapitalize="none"
             autoCorrect={false}
             placeholder="••••••••"
-            placeholderTextColor="#4A3F60"
+            placeholderTextColor={theme.colors.placeholder}
             returnKeyType="done"
             onSubmitEditing={() => signIn().catch(() => undefined)}
           />
@@ -518,7 +519,7 @@ export default function App() {
             disabled={loginLoading}
           >
             {loginLoading
-              ? <ActivityIndicator size="small" color="#0B0910" />
+              ? <ActivityIndicator size="small" color={theme.colors.bgBase} />
               : <Text style={styles.btnPrimaryText}>Sign In</Text>}
           </Pressable>
 
@@ -674,7 +675,7 @@ function SimulatorPanel({
       <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
         <Text style={styles.loginHeading}>Driver Simulator</Text>
         <Pressable onPress={onClose}>
-          <Text style={{ color: "#968AA8", fontSize: 18 }}>✕</Text>
+          <Text style={{ color: theme.colors.textMuted, fontSize: 18 }}>✕</Text>
         </Pressable>
       </View>
 
@@ -685,7 +686,7 @@ function SimulatorPanel({
         value={count}
         onChangeText={setCount}
         keyboardType="number-pad"
-        placeholderTextColor="#4A3F60"
+        placeholderTextColor={theme.colors.placeholder}
       />
 
       <Text style={styles.label}>Area</Text>
@@ -752,7 +753,7 @@ function SimulatorPanel({
       </View>
 
       {/* Seed test orders */}
-      <View style={{ height: 1, backgroundColor: "#241A33", marginVertical: 4 }} />
+      <View style={{ height: 1, backgroundColor: theme.colors.bgElevatedAlt, marginVertical: 4 }} />
       <Text style={styles.label}>Seed test orders ({areaKey})</Text>
       <View style={{ flexDirection: "row", gap: 8, alignItems: "flex-end" }}>
         <View style={{ flex: 1 }}>
@@ -762,7 +763,7 @@ function SimulatorPanel({
             onChangeText={setSeedCount}
             keyboardType="number-pad"
             placeholder="5"
-            placeholderTextColor="#4A3F60"
+            placeholderTextColor={theme.colors.placeholder}
           />
         </View>
         <Pressable
@@ -774,7 +775,7 @@ function SimulatorPanel({
         </Pressable>
       </View>
 
-      {msg ? <Text style={{ color: "#C8973A", fontSize: 12 }}>{msg}</Text> : null}
+      {msg ? <Text style={{ color: theme.colors.goldPrimary, fontSize: 12 }}>{msg}</Text> : null}
 
       {/* Driver list */}
       {status && status.drivers.length > 0 ? (
@@ -797,7 +798,7 @@ function SimulatorPanel({
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
-    backgroundColor: "#0B0910",
+    backgroundColor: theme.colors.bgBase,
   },
   loadingWrap: {
     flex: 1,
@@ -807,7 +808,7 @@ const styles = StyleSheet.create({
     padding: 24,
   },
   loadingText: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 14,
   },
   loginScreen: {
@@ -819,9 +820,9 @@ const styles = StyleSheet.create({
   loginCard: {
     width: "100%",
     maxWidth: 400,
-    backgroundColor: "#130F1A",
+    backgroundColor: theme.colors.bgSurface,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     borderRadius: 16,
     padding: 24,
     gap: 10,
@@ -836,46 +837,46 @@ const styles = StyleSheet.create({
     width: 32,
     height: 32,
     borderRadius: 8,
-    backgroundColor: "#C8973A",
+    backgroundColor: theme.colors.goldPrimary,
     alignItems: "center",
     justifyContent: "center",
   },
   brandMarkText: {
-    color: "#0B0910",
+    color: theme.colors.bgBase,
     fontWeight: "800",
     fontSize: 18,
   },
   brandName: {
-    color: "#F5D98B",
+    color: theme.colors.textHeading,
     fontSize: 20,
     fontWeight: "700",
   },
   loginHeading: {
-    color: "#F5D98B",
+    color: theme.colors.textHeading,
     fontSize: 20,
     fontWeight: "700",
   },
   loginLead: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 13,
   },
   label: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 11,
     fontWeight: "600",
   },
   input: {
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     borderRadius: 10,
-    color: "#EDE0C4",
-    backgroundColor: "#0F0C16",
+    color: theme.colors.textPrimary,
+    backgroundColor: theme.colors.bgInput,
     paddingHorizontal: 12,
     paddingVertical: 9,
     fontSize: 14,
   },
   errorText: {
-    color: "#F0C060",
+    color: theme.colors.goldBright,
     fontSize: 12,
     fontWeight: "600",
   },
@@ -887,20 +888,20 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   btnPrimary: {
-    backgroundColor: "#C8973A",
+    backgroundColor: theme.colors.goldPrimary,
   },
   btnGhost: {
     borderWidth: 1,
-    borderColor: "#6B4F2A",
-    backgroundColor: "#130F1A",
+    borderColor: theme.colors.borderAccent,
+    backgroundColor: theme.colors.bgSurface,
   },
   btnPrimaryText: {
-    color: "#0B0910",
+    color: theme.colors.bgBase,
     fontWeight: "700",
     fontSize: 14,
   },
   btnGhostText: {
-    color: "#C8973A",
+    color: theme.colors.goldPrimary,
     fontWeight: "700",
     fontSize: 14,
   },
@@ -912,9 +913,9 @@ const styles = StyleSheet.create({
   workspaceBanner: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: "#0B0910",
+    backgroundColor: theme.colors.bgBase,
     borderBottomWidth: 1,
-    borderBottomColor: "#3A2F50",
+    borderBottomColor: theme.colors.borderDefault,
     paddingHorizontal: 8,
     paddingVertical: 8,
   },
@@ -932,27 +933,27 @@ const styles = StyleSheet.create({
   },
   settingsGearText: {
     fontSize: 18,
-    color: "#968AA8",
+    color: theme.colors.textMuted,
   },
   wsChip: {
     borderRadius: 999,
     paddingHorizontal: 16,
     paddingVertical: 6,
     borderWidth: 1,
-    borderColor: "#3A2F50",
-    backgroundColor: "#1A1526",
+    borderColor: theme.colors.borderDefault,
+    backgroundColor: theme.colors.bgSheet,
   },
   wsChipActive: {
-    backgroundColor: "#C8973A",
-    borderColor: "#C8973A",
+    backgroundColor: theme.colors.goldPrimary,
+    borderColor: theme.colors.goldPrimary,
   },
   wsChipText: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontWeight: "600",
     fontSize: 13,
   },
   wsChipTextActive: {
-    color: "#0B0910",
+    color: theme.colors.bgBase,
   },
   // Workspace not available
   workspaceSwitcher: {
@@ -965,22 +966,22 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: 10,
     borderWidth: 1,
-    borderColor: "#3A2F50",
-    backgroundColor: "#1A1526",
+    borderColor: theme.colors.borderDefault,
+    backgroundColor: theme.colors.bgSheet,
     minWidth: 160,
     alignItems: "center",
   },
   wsBtnActive: {
-    backgroundColor: "#C8973A",
-    borderColor: "#C8973A",
+    backgroundColor: theme.colors.goldPrimary,
+    borderColor: theme.colors.goldPrimary,
   },
   wsBtnText: {
-    color: "#0B0910",
+    color: theme.colors.bgBase,
     fontWeight: "700",
     fontSize: 14,
   },
   wsBtnGhostText: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontWeight: "600",
     fontSize: 14,
   },
@@ -991,11 +992,11 @@ const styles = StyleSheet.create({
     justifyContent: "flex-end",
   },
   settingsCard: {
-    backgroundColor: "#130F1A",
+    backgroundColor: theme.colors.bgSurface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 20,
     gap: 10,
     maxHeight: "92%",
@@ -1006,20 +1007,20 @@ const styles = StyleSheet.create({
     paddingVertical: 5,
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: "#3A2F50",
-    backgroundColor: "#0F0C16",
+    borderColor: theme.colors.borderDefault,
+    backgroundColor: theme.colors.bgInput,
   },
-  simChipActive: { borderColor: "#C8973A", backgroundColor: "#2A1E10" },
-  simChipText: { color: "#968AA8", fontSize: 12, fontWeight: "600" },
-  simChipTextActive: { color: "#C8973A" },
+  simChipActive: { borderColor: theme.colors.goldPrimary, backgroundColor: theme.colors.goldTintBg },
+  simChipText: { color: theme.colors.textMuted, fontSize: 12, fontWeight: "600" },
+  simChipTextActive: { color: theme.colors.goldPrimary },
   simStatusBar: {
-    backgroundColor: "#0F0C16",
+    backgroundColor: theme.colors.bgInput,
     borderRadius: 6,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 8,
   },
-  simStatusText: { color: "#EDE0C4", fontSize: 12, fontWeight: "600" },
+  simStatusText: { color: theme.colors.textPrimary, fontSize: 12, fontWeight: "600" },
   simDriverRow: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -1027,8 +1028,8 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     paddingHorizontal: 8,
     borderBottomWidth: 1,
-    borderBottomColor: "#241A33",
+    borderBottomColor: theme.colors.bgElevatedAlt,
   },
-  simDriverName: { color: "#EDE0C4", fontSize: 13, fontWeight: "600", flex: 1 },
-  simDriverState: { color: "#C8973A", fontSize: 12, fontWeight: "700" },
+  simDriverName: { color: theme.colors.textPrimary, fontSize: 13, fontWeight: "600", flex: 1 },
+  simDriverState: { color: theme.colors.goldPrimary, fontSize: 12, fontWeight: "700" },
 });

--- a/mobile/components/DeliveryCelebration.tsx
+++ b/mobile/components/DeliveryCelebration.tsx
@@ -5,6 +5,7 @@
 // backdrop, a golden sigil, expanding rune rings, a radiant sunburst, and
 // rising embers.
 import React, { useEffect, useMemo, useRef } from "react";
+import { theme } from "../theme";
 import {
   Animated,
   Easing,
@@ -25,14 +26,14 @@ type Props = {
 };
 
 // ─── Dark-fantasy palette (matches DriverScreen) ──────────────────────────────
-const VOID = "#070510";
-const GOLD = "#C8973A";
-const GOLD_BRIGHT = "#F5D98B";
-const GOLD_PALE = "#F0C060";
-const EMBER = "#E05A3B";
-const CREAM = "#EDE0C4";
-const PANEL = "#130F1A";
-const MUTED = "#968AA8";
+const VOID = theme.colors.bgDeepest;
+const GOLD = theme.colors.goldPrimary;
+const GOLD_BRIGHT = theme.colors.textHeading;
+const GOLD_PALE = theme.colors.goldBright;
+const EMBER = theme.colors.emberOrange;
+const CREAM = theme.colors.textPrimary;
+const PANEL = theme.colors.bgSurface;
+const MUTED = theme.colors.textMuted;
 
 // react-native-web has no native animation module; fall back to the JS driver
 // there so the flourish still plays in the web preview without warnings.

--- a/mobile/screens/AdminScreen.tsx
+++ b/mobile/screens/AdminScreen.tsx
@@ -1,5 +1,6 @@
 // AdminScreen.tsx — Dispatcher / admin dashboard with map, stats, order management
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { theme } from "../theme";
 import {
   Animated,
   Easing,
@@ -751,7 +752,7 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
             <Text style={styles.brandName}>Discra Dispatch</Text>
           </View>
           <View style={styles.headerRight}>
-            {loading ? <ActivityIndicator size="small" color="#C8973A" /> : null}
+            {loading ? <ActivityIndicator size="small" color={theme.colors.goldPrimary} /> : null}
             <Pressable style={styles.hamburgerBtn} onPress={openMenu}>
               <Text style={styles.hamburgerIcon}>☰</Text>
             </Pressable>
@@ -823,12 +824,12 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
                   );
                 })}
                 {routePoints.length > 1 ? (
-                  <Polyline coordinates={routePoints} strokeColor="#C8973A" strokeWidth={3} />
+                  <Polyline coordinates={routePoints} strokeColor={theme.colors.goldPrimary} strokeWidth={3} />
                 ) : null}
                 {previewState?.route && previewState.route.length > 1 ? (
                   <Polyline
                     coordinates={previewState.route}
-                    strokeColor="#9D6FC8"
+                    strokeColor={theme.colors.purpleBright}
                     strokeWidth={5}
                   />
                 ) : null}
@@ -870,7 +871,7 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
                   value={searchQuery}
                   onChangeText={setSearchQuery}
                   placeholder="Search orders…"
-                  placeholderTextColor="#4A3F60"
+                  placeholderTextColor={theme.colors.placeholder}
                   autoCapitalize="none"
                   autoCorrect={false}
                 />
@@ -973,7 +974,7 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
             <View style={{ flexDirection: "row", justifyContent: "flex-end" }}>
               <Pressable style={[styles.btn, styles.btnGhost]} onPress={() => loadAdminData().catch(() => undefined)}>
                 {adminLoading
-                  ? <ActivityIndicator size="small" color="#C8973A" />
+                  ? <ActivityIndicator size="small" color={theme.colors.goldPrimary} />
                   : <Text style={styles.btnGhostText}>↻ Refresh All</Text>}
               </Pressable>
             </View>
@@ -995,7 +996,7 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
                     </View>
                     <View style={styles.adminStatRow}>
                       <Text style={styles.adminStatLabel}>Status</Text>
-                      <Text style={[styles.adminStatValue, { color: emailStatus.last_error ? "#F0C060" : "#6ABF7B" }]}>
+                      <Text style={[styles.adminStatValue, { color: emailStatus.last_error ? theme.colors.goldBright : "#6ABF7B" }]}>
                         {emailStatus.last_error ? emailStatus.last_error : "OK"}
                       </Text>
                     </View>
@@ -1049,7 +1050,7 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
                   value={inviteEmail}
                   onChangeText={setInviteEmail}
                   placeholder="colleague@example.com"
-                  placeholderTextColor="#4A3F60"
+                  placeholderTextColor={theme.colors.placeholder}
                   keyboardType="email-address"
                   autoCapitalize="none"
                   autoCorrect={false}
@@ -1066,7 +1067,7 @@ export default function AdminScreen({ token, apiBase, onSignOut }: Props) {
                     </Pressable>
                   ))}
                 </View>
-                {inviteMsg ? <Text style={[styles.metaText, { color: inviteMsg.includes("sent") ? "#6ABF7B" : "#F0C060" }]}>{inviteMsg}</Text> : null}
+                {inviteMsg ? <Text style={[styles.metaText, { color: inviteMsg.includes("sent") ? "#6ABF7B" : theme.colors.goldBright }]}>{inviteMsg}</Text> : null}
                 <Pressable
                   style={[styles.btn, styles.btnPrimary, { alignSelf: "flex-start" }, adminLoading && { opacity: 0.6 }]}
                   onPress={() => sendInvitation().catch(() => undefined)}
@@ -1356,9 +1357,9 @@ function DispatchTab({
                 style={[styles.driverPill, isSelected && styles.driverPillSelected]}
                 onPress={() => onSelectDriver(driver)}
               >
-                <View style={[styles.driverDot, { backgroundColor: isSelected ? "#C8973A" : "#0e7aa6" }]} />
+                <View style={[styles.driverDot, { backgroundColor: isSelected ? theme.colors.goldPrimary : "#0e7aa6" }]} />
                 <View>
-                  <Text style={[styles.driverPillName, isSelected && { color: "#C8973A" }]} numberOfLines={1}>
+                  <Text style={[styles.driverPillName, isSelected && { color: theme.colors.goldPrimary }]} numberOfLines={1}>
                     {displayName}
                   </Text>
                   <Text style={styles.metaText}>{driverOrderCount} order{driverOrderCount !== 1 ? "s" : ""}</Text>
@@ -1576,7 +1577,7 @@ function AssignSheet({
             </Text>
           ) : null}
           {!isMulti && previewedDriverName ? (
-            <Text style={[styles.metaText, { color: "#9D6FC8", fontWeight: "700" }]}>
+            <Text style={[styles.metaText, { color: theme.colors.purpleBright, fontWeight: "700" }]}>
               Previewing route for {previewedDriverName}
             </Text>
           ) : !isMulti && pickupCoord ? (
@@ -1599,7 +1600,7 @@ function AssignSheet({
                     style={[styles.driverRow, isPreviewed && styles.driverRowSelected]}
                     onPress={() => handleRowPress(driver.driver_id)}
                   >
-                    <View style={[styles.driverDot, { backgroundColor: isPreviewed ? "#9D6FC8" : "#0e7aa6" }]} />
+                    <View style={[styles.driverDot, { backgroundColor: isPreviewed ? theme.colors.purpleBright : "#0e7aa6" }]} />
                     <View style={{ flex: 1 }}>
                       <Text style={styles.driverRowName} numberOfLines={1}>{displayName}</Text>
                       <Text style={styles.metaText}>
@@ -1607,7 +1608,7 @@ function AssignSheet({
                         {load} order{load !== 1 ? "s" : ""}
                       </Text>
                     </View>
-                    <Text style={[styles.driverRowAction, isPreviewed && { color: "#9D6FC8" }]}>
+                    <Text style={[styles.driverRowAction, isPreviewed && { color: theme.colors.purpleBright }]}>
                       {isMulti ? "Assign ›" : isPreviewed ? "● Preview" : "Preview ›"}
                     </Text>
                   </Pressable>
@@ -1654,7 +1655,7 @@ function OrdersTab({ orders, searchQuery, setSearchQuery, onEdit, onUpdateStatus
         value={searchQuery}
         onChangeText={setSearchQuery}
         placeholder="Search orders…"
-        placeholderTextColor="#4A3F60"
+        placeholderTextColor={theme.colors.placeholder}
         autoCapitalize="none"
         autoCorrect={false}
       />
@@ -1720,7 +1721,7 @@ function OrderFormFields({
           autoCapitalize="none"
           autoCorrect={false}
           keyboardType={opts?.keyboardType ?? "default"}
-          placeholderTextColor="#4A3F60"
+          placeholderTextColor={theme.colors.placeholder}
         />
       </>
     );
@@ -1741,7 +1742,7 @@ function OrderFormFields({
 // ─── Styles ───────────────────────────────────────────────────────────────────
 
 const styles = StyleSheet.create({
-  root: { flex: 1, backgroundColor: "#0B0910" },
+  root: { flex: 1, backgroundColor: theme.colors.bgBase },
   safeArea: { flex: 1 },
 
   // Header
@@ -1752,19 +1753,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 10,
     borderBottomWidth: 1,
-    borderBottomColor: "#3A2F50",
+    borderBottomColor: theme.colors.borderDefault,
   },
   brandRow: { flexDirection: "row", alignItems: "center", gap: 8 },
   brandMark: {
     width: 28,
     height: 28,
     borderRadius: 7,
-    backgroundColor: "#C8973A",
+    backgroundColor: theme.colors.goldPrimary,
     alignItems: "center",
     justifyContent: "center",
   },
-  brandMarkText: { color: "#0B0910", fontWeight: "800", fontSize: 16 },
-  brandName: { color: "#F5D98B", fontSize: 16, fontWeight: "700" },
+  brandMarkText: { color: theme.colors.bgBase, fontWeight: "800", fontSize: 16 },
+  brandName: { color: theme.colors.textHeading, fontSize: 16, fontWeight: "700" },
   headerRight: { flexDirection: "row", alignItems: "center", gap: 10 },
 
   // Dispatch layout
@@ -1783,28 +1784,28 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(19,15,26,0.88)",
     borderRadius: 8,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     paddingHorizontal: 8,
     paddingVertical: 5,
     alignItems: "center",
     minWidth: 52,
   },
-  statChipAccent: { borderColor: "#C8973A", backgroundColor: "rgba(42,30,16,0.92)" },
-  statValue: { color: "#EDE0C4", fontWeight: "700", fontSize: 14 },
-  statLabel: { color: "#968AA8", fontSize: 9, fontWeight: "600", textTransform: "uppercase" },
+  statChipAccent: { borderColor: theme.colors.goldPrimary, backgroundColor: "rgba(42,30,16,0.92)" },
+  statValue: { color: theme.colors.textPrimary, fontWeight: "700", fontSize: 14 },
+  statLabel: { color: theme.colors.textMuted, fontSize: 9, fontWeight: "600", textTransform: "uppercase" },
 
   // Dispatch bottom panel
   dispatchPanel: {
     flex: 2,
-    backgroundColor: "#0F0C16",
+    backgroundColor: theme.colors.bgInput,
     borderTopWidth: 1,
-    borderTopColor: "#3A2F50",
+    borderTopColor: theme.colors.borderDefault,
   },
   sheetHandle: {
     width: 36,
     height: 4,
     borderRadius: 2,
-    backgroundColor: "#3A2F50",
+    backgroundColor: theme.colors.borderDefault,
     alignSelf: "center",
     marginTop: 8,
     marginBottom: 4,
@@ -1813,7 +1814,7 @@ const styles = StyleSheet.create({
   dispatchScrollContent: { padding: 12, gap: 8, paddingBottom: 16 },
 
   statusMsg: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 11,
     paddingHorizontal: 12,
     paddingVertical: 3,
@@ -1821,7 +1822,7 @@ const styles = StyleSheet.create({
 
   // Tab bar (now at bottom)
   hamburgerBtn: { padding: 8 },
-  hamburgerIcon: { color: "#EDE0C4", fontSize: 22, lineHeight: 26 },
+  hamburgerIcon: { color: theme.colors.textPrimary, fontSize: 22, lineHeight: 26 },
 
   menuOverlay: {
     position: "absolute", top: 0, left: 0, right: 0, bottom: 0,
@@ -1835,7 +1836,7 @@ const styles = StyleSheet.create({
     backgroundColor: "#130F1E",
     zIndex: 101,
     borderLeftWidth: 1,
-    borderLeftColor: "#3A2F50",
+    borderLeftColor: theme.colors.borderDefault,
     paddingTop: 16,
   },
   menuDrawerHeader: {
@@ -1845,11 +1846,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingBottom: 16,
     borderBottomWidth: 1,
-    borderBottomColor: "#3A2F50",
+    borderBottomColor: theme.colors.borderDefault,
     marginBottom: 8,
   },
-  menuDrawerTitle: { color: "#EDE0C4", fontSize: 16, fontWeight: "700" },
-  menuDrawerClose: { color: "#968AA8", fontSize: 18, padding: 4 },
+  menuDrawerTitle: { color: theme.colors.textPrimary, fontSize: 16, fontWeight: "700" },
+  menuDrawerClose: { color: theme.colors.textMuted, fontSize: 18, padding: 4 },
   menuItem: {
     flexDirection: "row",
     alignItems: "center",
@@ -1859,13 +1860,13 @@ const styles = StyleSheet.create({
   },
   menuItemActive: { backgroundColor: "#1E1830" },
   menuItemIcon: { fontSize: 18, width: 24, textAlign: "center" },
-  menuItemText: { color: "#968AA8", fontSize: 15, fontWeight: "600", flex: 1 },
-  menuItemTextActive: { color: "#C8973A" },
+  menuItemText: { color: theme.colors.textMuted, fontSize: 15, fontWeight: "600", flex: 1 },
+  menuItemTextActive: { color: theme.colors.goldPrimary },
   menuItemDot: {
     width: 6, height: 6, borderRadius: 3,
-    backgroundColor: "#C8973A",
+    backgroundColor: theme.colors.goldPrimary,
   },
-  menuDivider: { height: 1, backgroundColor: "#3A2F50", marginVertical: 8, marginHorizontal: 20 },
+  menuDivider: { height: 1, backgroundColor: theme.colors.borderDefault, marginVertical: 8, marginHorizontal: 20 },
 
   // Orders / Admin tab scroll
   scroll: { flex: 1 },
@@ -1873,10 +1874,10 @@ const styles = StyleSheet.create({
 
   searchInput: {
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     borderRadius: 10,
-    color: "#EDE0C4",
-    backgroundColor: "#0F0C16",
+    color: theme.colors.textPrimary,
+    backgroundColor: theme.colors.bgInput,
     paddingHorizontal: 12,
     paddingVertical: 9,
     fontSize: 14,
@@ -1884,62 +1885,62 @@ const styles = StyleSheet.create({
   },
 
   sectionCard: {
-    backgroundColor: "#1A1526",
+    backgroundColor: theme.colors.bgSheet,
     borderRadius: 10,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 10,
     gap: 4,
   },
-  sectionTitle: { color: "#F5D98B", fontSize: 14, fontWeight: "700" },
-  sectionSubtitle: { color: "#EDE0C4", fontSize: 13, fontWeight: "600", marginTop: 4 },
-  metaText: { color: "#968AA8", fontSize: 12 },
+  sectionTitle: { color: theme.colors.textHeading, fontSize: 14, fontWeight: "700" },
+  sectionSubtitle: { color: theme.colors.textPrimary, fontSize: 13, fontWeight: "600", marginTop: 4 },
+  metaText: { color: theme.colors.textMuted, fontSize: 12 },
 
   // Driver pills (horizontal scroll in dispatch panel)
   driverPill: {
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
-    backgroundColor: "#1A1526",
+    backgroundColor: theme.colors.bgSheet,
     borderRadius: 10,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     paddingHorizontal: 12,
     paddingVertical: 8,
     minWidth: 120,
   },
-  driverPillSelected: { borderColor: "#C8973A", backgroundColor: "#2A1E10" },
-  driverPillName: { color: "#EDE0C4", fontWeight: "700", fontSize: 13, maxWidth: 140 },
+  driverPillSelected: { borderColor: theme.colors.goldPrimary, backgroundColor: theme.colors.goldTintBg },
+  driverPillName: { color: theme.colors.textPrimary, fontWeight: "700", fontSize: 13, maxWidth: 140 },
   driverDot: { width: 10, height: 10, borderRadius: 5 },
 
-  routeStop: { color: "#968AA8", fontSize: 11 },
+  routeStop: { color: theme.colors.textMuted, fontSize: 11 },
 
   orderCard: {
-    backgroundColor: "#1A1526",
+    backgroundColor: theme.colors.bgSheet,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 12,
     gap: 5,
   },
-  orderCardSelected: { borderColor: "#C8973A", backgroundColor: "#2A1E10" },
+  orderCardSelected: { borderColor: theme.colors.goldPrimary, backgroundColor: theme.colors.goldTintBg },
   orderCardHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  orderTitle: { color: "#EDE0C4", fontSize: 14, fontWeight: "700", flex: 1 },
-  orderMeta: { color: "#968AA8", fontSize: 12 },
+  orderTitle: { color: theme.colors.textPrimary, fontSize: 14, fontWeight: "700", flex: 1 },
+  orderMeta: { color: theme.colors.textMuted, fontSize: 12 },
   orderCheckRow: { flexDirection: "row", alignItems: "flex-start", gap: 8 },
   checkbox: {
     width: 20,
     height: 20,
     borderRadius: 5,
     borderWidth: 1,
-    borderColor: "#3A2F50",
-    backgroundColor: "#0F0C16",
+    borderColor: theme.colors.borderDefault,
+    backgroundColor: theme.colors.bgInput,
     alignItems: "center",
     justifyContent: "center",
     marginTop: 2,
   },
-  checkboxChecked: { backgroundColor: "#C8973A", borderColor: "#C8973A" },
-  checkboxMark: { color: "#0B0910", fontWeight: "800", fontSize: 12 },
+  checkboxChecked: { backgroundColor: theme.colors.goldPrimary, borderColor: theme.colors.goldPrimary },
+  checkboxMark: { color: theme.colors.bgBase, fontWeight: "800", fontSize: 12 },
   orderChevron: { color: "#6B5F80", fontSize: 22, lineHeight: 22, marginLeft: 6 },
   unassignedHeader: {
     flexDirection: "row",
@@ -1954,20 +1955,20 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 4,
     borderBottomWidth: 1,
-    borderBottomColor: "#241A33",
+    borderBottomColor: theme.colors.bgElevatedAlt,
   },
-  driverRowName: { color: "#EDE0C4", fontSize: 14, fontWeight: "700" },
-  driverRowAction: { color: "#C8973A", fontSize: 13, fontWeight: "700" },
+  driverRowName: { color: theme.colors.textPrimary, fontSize: 14, fontWeight: "700" },
+  driverRowAction: { color: theme.colors.goldPrimary, fontSize: 13, fontWeight: "700" },
   driverRowSelected: {
     backgroundColor: "#1F1730",
-    borderBottomColor: "#9D6FC8",
+    borderBottomColor: theme.colors.purpleBright,
   },
   assignToast: {
     position: "absolute",
     top: 64,
     alignSelf: "center",
-    backgroundColor: "#1C1628",
-    borderColor: "#C8973A",
+    backgroundColor: theme.colors.bgElevated,
+    borderColor: theme.colors.goldPrimary,
     borderWidth: 1,
     paddingHorizontal: 16,
     paddingVertical: 10,
@@ -1979,118 +1980,118 @@ const styles = StyleSheet.create({
     zIndex: 1000,
   },
   assignToastText: {
-    color: "#F5D98B",
+    color: theme.colors.textHeading,
     fontSize: 13,
     fontWeight: "700",
     letterSpacing: 0.5,
   },
   editBtn: {
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     borderRadius: 6,
     paddingHorizontal: 8,
     paddingVertical: 3,
     marginLeft: 6,
   },
-  editBtnText: { color: "#968AA8", fontSize: 11, fontWeight: "600" },
+  editBtnText: { color: theme.colors.textMuted, fontSize: 11, fontWeight: "600" },
 
   statusWrap: { flexDirection: "row", flexWrap: "wrap", gap: 5, marginTop: 2 },
   statusBtn: {
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     paddingHorizontal: 8,
     paddingVertical: 4,
   },
-  statusBtnActive: { backgroundColor: "#2A1E10", borderColor: "#C8973A" },
-  statusBtnText: { color: "#EDE0C4", fontSize: 11, fontWeight: "600" },
+  statusBtnActive: { backgroundColor: theme.colors.goldTintBg, borderColor: theme.colors.goldPrimary },
+  statusBtnText: { color: theme.colors.textPrimary, fontSize: 11, fontWeight: "600" },
   btnDisabled: { opacity: 0.5 },
 
   // Orders sub-tabs
   tabContent: { flex: 1 },
   subTabBar: {
     flexDirection: "row",
-    backgroundColor: "#0B0910",
+    backgroundColor: theme.colors.bgBase,
     borderBottomWidth: 1,
-    borderBottomColor: "#3A2F50",
+    borderBottomColor: theme.colors.borderDefault,
   },
   subTab: { flex: 1, paddingVertical: 10, alignItems: "center" },
-  subTabActive: { borderBottomWidth: 2, borderBottomColor: "#C8973A" },
-  subTabText: { color: "#968AA8", fontWeight: "600", fontSize: 12 },
-  subTabTextActive: { color: "#C8973A" },
+  subTabActive: { borderBottomWidth: 2, borderBottomColor: theme.colors.goldPrimary },
+  subTabText: { color: theme.colors.textMuted, fontWeight: "600", fontSize: 12 },
+  subTabTextActive: { color: theme.colors.goldPrimary },
   statusBadge: {
     borderRadius: 999,
     paddingHorizontal: 8,
     paddingVertical: 3,
     backgroundColor: "#2A2040",
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
   },
   statusBadgeSuccess: { backgroundColor: "#0E2A1A", borderColor: "#3A7A4A" },
   statusBadgeFail: { backgroundColor: "#2A1010", borderColor: "#7A3A3A" },
-  statusBadgeText: { color: "#EDE0C4", fontSize: 11, fontWeight: "600" },
+  statusBadgeText: { color: theme.colors.textPrimary, fontSize: 11, fontWeight: "600" },
 
   // Admin tab
   adminSection: {
-    backgroundColor: "#1A1526",
+    backgroundColor: theme.colors.bgSheet,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 14,
     gap: 4,
   },
-  adminSectionTitle: { color: "#F5D98B", fontSize: 15, fontWeight: "700", marginBottom: 4 },
-  adminStatRow: { flexDirection: "row", justifyContent: "space-between", paddingVertical: 4, borderBottomWidth: 1, borderBottomColor: "#1F1A2E" },
-  adminStatLabel: { color: "#968AA8", fontSize: 12 },
-  adminStatValue: { color: "#EDE0C4", fontSize: 12, fontWeight: "600" },
+  adminSectionTitle: { color: theme.colors.textHeading, fontSize: 15, fontWeight: "700", marginBottom: 4 },
+  adminStatRow: { flexDirection: "row", justifyContent: "space-between", paddingVertical: 4, borderBottomWidth: 1, borderBottomColor: theme.colors.bgPanelAlt },
+  adminStatLabel: { color: theme.colors.textMuted, fontSize: 12 },
+  adminStatValue: { color: theme.colors.textPrimary, fontSize: 12, fontWeight: "600" },
   seatGrid: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 10 },
   seatCard: {
     flex: 1,
     minWidth: 100,
-    backgroundColor: "#130F1A",
+    backgroundColor: theme.colors.bgSurface,
     borderRadius: 8,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 10,
     gap: 2,
   },
-  seatCardLabel: { color: "#968AA8", fontSize: 10, fontWeight: "600", textTransform: "uppercase" },
-  seatCardValue: { color: "#EDE0C4", fontSize: 18, fontWeight: "700" },
+  seatCardLabel: { color: theme.colors.textMuted, fontSize: 10, fontWeight: "600", textTransform: "uppercase" },
+  seatCardValue: { color: theme.colors.textPrimary, fontSize: 18, fontWeight: "700" },
   roleRow: { flexDirection: "row", gap: 8, flexWrap: "wrap" },
   roleBtn: {
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     paddingHorizontal: 14,
     paddingVertical: 7,
   },
-  roleBtnActive: { backgroundColor: "#2A1E10", borderColor: "#C8973A" },
-  roleBtnText: { color: "#968AA8", fontSize: 13, fontWeight: "600" },
-  roleBtnTextActive: { color: "#C8973A" },
+  roleBtnActive: { backgroundColor: theme.colors.goldTintBg, borderColor: theme.colors.goldPrimary },
+  roleBtnText: { color: theme.colors.textMuted, fontSize: 13, fontWeight: "600" },
+  roleBtnTextActive: { color: theme.colors.goldPrimary },
   invitationRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
     paddingVertical: 8,
     borderBottomWidth: 1,
-    borderBottomColor: "#1F1A2E",
+    borderBottomColor: theme.colors.bgPanelAlt,
   },
   auditRow: {
     borderBottomWidth: 1,
-    borderBottomColor: "#1F1A2E",
+    borderBottomColor: theme.colors.bgPanelAlt,
     paddingVertical: 6,
     gap: 2,
   },
-  auditAction: { color: "#EDE0C4", fontSize: 13, fontWeight: "600" },
+  auditAction: { color: theme.colors.textPrimary, fontSize: 13, fontWeight: "600" },
 
   // Modal
   modalBackdrop: { flex: 1, backgroundColor: "rgba(7,5,12,0.88)", justifyContent: "flex-end" },
   modalCard: {
-    backgroundColor: "#130F1A",
+    backgroundColor: theme.colors.bgSurface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 16,
     maxHeight: "92%",
     gap: 8,
@@ -2101,21 +2102,21 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     marginBottom: 8,
   },
-  modalTitle: { color: "#F5D98B", fontSize: 16, fontWeight: "700" },
-  modalClose: { color: "#968AA8", fontSize: 18 },
+  modalTitle: { color: theme.colors.textHeading, fontSize: 16, fontWeight: "700" },
+  modalClose: { color: theme.colors.textMuted, fontSize: 18 },
 
-  label: { color: "#968AA8", fontSize: 11, fontWeight: "600" },
+  label: { color: theme.colors.textMuted, fontSize: 11, fontWeight: "600" },
   input: {
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     borderRadius: 10,
-    color: "#EDE0C4",
-    backgroundColor: "#0F0C16",
+    color: theme.colors.textPrimary,
+    backgroundColor: theme.colors.bgInput,
     paddingHorizontal: 12,
     paddingVertical: 9,
     fontSize: 14,
   },
-  errorText: { color: "#F0C060", fontSize: 12, fontWeight: "600" },
+  errorText: { color: theme.colors.goldBright, fontSize: 12, fontWeight: "600" },
 
   row: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
   btn: {
@@ -2125,8 +2126,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  btnPrimary: { backgroundColor: "#C8973A" },
-  btnGhost: { borderWidth: 1, borderColor: "#6B4F2A", backgroundColor: "#130F1A" },
-  btnText: { color: "#0B0910", fontWeight: "700", fontSize: 13 },
-  btnGhostText: { color: "#C8973A", fontWeight: "700", fontSize: 13 },
+  btnPrimary: { backgroundColor: theme.colors.goldPrimary },
+  btnGhost: { borderWidth: 1, borderColor: theme.colors.borderAccent, backgroundColor: theme.colors.bgSurface },
+  btnText: { color: theme.colors.bgBase, fontWeight: "700", fontSize: 13 },
+  btnGhostText: { color: theme.colors.goldPrimary, fontWeight: "700", fontSize: 13 },
 });

--- a/mobile/screens/DriverScreen.tsx
+++ b/mobile/screens/DriverScreen.tsx
@@ -1,5 +1,6 @@
 // DriverScreen.tsx — Full-screen map + bottom sheet driver experience
 import * as FileSystem from "expo-file-system";
+import { theme } from "../theme";
 import * as ImagePicker from "expo-image-picker";
 import * as Location from "expo-location";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -178,8 +179,8 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
   // ── Stop pin colour ────────────────────────────────────────────────────────
   function stopPinColor(order: OrderRecord): string {
     const s = (order.status || "").toLowerCase();
-    if (s === "pickedup" || s === "enroute") return "#4A9E5C";
-    return "#C8973A";
+    if (s === "pickedup" || s === "enroute") return theme.colors.success;
+    return theme.colors.goldPrimary;
   }
 
   // ── Geocode all stops ──────────────────────────────────────────────────────
@@ -664,7 +665,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
         {driverLoc ? (
           <Marker
             coordinate={{ latitude: driverLoc.lat, longitude: driverLoc.lng }}
-            pinColor="#F0C060"
+            pinColor={theme.colors.goldBright}
             title="Your Location"
           />
         ) : null}
@@ -687,7 +688,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
 
         {/* Route polyline */}
         {routeResult && routeResult.coords.length > 1 ? (
-          <Polyline coordinates={routeResult.coords} strokeColor="#C8973A" strokeWidth={5} />
+          <Polyline coordinates={routeResult.coords} strokeColor={theme.colors.goldPrimary} strokeWidth={5} />
         ) : null}
       </MapView>
 
@@ -695,13 +696,13 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
       <SafeAreaView pointerEvents="box-none" style={styles.topBar}>
         <View style={styles.topBarInner} pointerEvents="box-none">
           <View style={styles.locationPill}>
-            <View style={[styles.locationDot, { backgroundColor: locationActive ? "#4A9E5C" : "#9B3A3A" }]} />
+            <View style={[styles.locationDot, { backgroundColor: locationActive ? theme.colors.success : theme.colors.dangerMuted }]} />
             <Text style={styles.locationPillText}>
               {locationActive ? "Sharing location" : "Location off"}
             </Text>
           </View>
           <View style={styles.topBarRight}>
-            {loading ? <ActivityIndicator size="small" color="#C8973A" style={{ marginRight: 8 }} /> : null}
+            {loading ? <ActivityIndicator size="small" color={theme.colors.goldPrimary} style={{ marginRight: 8 }} /> : null}
             <Pressable
               style={styles.profileBtn}
               // The avatar is 36×36; expand the tap target to ~52×52 so it
@@ -954,7 +955,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                     value={pod.notes}
                     onChangeText={(v) => setPodField(selectedOrder.id, "notes", v)}
                     placeholder="Delivery notes…"
-                    placeholderTextColor="#4A3F60"
+                    placeholderTextColor={theme.colors.placeholder}
                     multiline
                   />
 
@@ -995,9 +996,9 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                 descriptionText="Sign below"
                 autoClear
                 webStyle={`
-                  .m-signature-pad--footer { background: #1A1526; }
-                  .m-signature-pad--body { border: 1px solid #3A2F50; }
-                  .button { background: #C8973A; color: #0B0910; border-radius: 8px; }
+                  .m-signature-pad--footer { background: ${theme.colors.bgSheet}; }
+                  .m-signature-pad--body { border: 1px solid ${theme.colors.borderDefault}; }
+                  .button { background: ${theme.colors.goldPrimary}; color: ${theme.colors.bgBase}; border-radius: 8px; }
                 `}
               />
             </View>
@@ -1037,23 +1038,23 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                 )}
                 <Text style={styles.avatarPickerLabel}>Change Photo</Text>
               </Pressable>
-              <Text style={styles.detailLabel}>FIRST NAME <Text style={{ color: "#E05A3B" }}>*</Text></Text>
+              <Text style={styles.detailLabel}>FIRST NAME <Text style={{ color: theme.colors.emberOrange }}>*</Text></Text>
               <TextInput
                 style={styles.input}
                 value={profileFirstName}
                 onChangeText={setProfileFirstName}
                 placeholder="First name"
-                placeholderTextColor="#4A3F60"
+                placeholderTextColor={theme.colors.placeholder}
                 autoCapitalize="words"
                 maxLength={80}
               />
-              <Text style={styles.detailLabel}>LAST NAME <Text style={{ color: "#E05A3B" }}>*</Text></Text>
+              <Text style={styles.detailLabel}>LAST NAME <Text style={{ color: theme.colors.emberOrange }}>*</Text></Text>
               <TextInput
                 style={styles.input}
                 value={profileLastName}
                 onChangeText={setProfileLastName}
                 placeholder="Last name"
-                placeholderTextColor="#4A3F60"
+                placeholderTextColor={theme.colors.placeholder}
                 autoCapitalize="words"
                 maxLength={80}
               />
@@ -1065,7 +1066,7 @@ export default function DriverScreen({ token, apiBase, onSignOut }: Props) {
                 value={profilePhone}
                 onChangeText={(v) => setProfilePhone(formatPhoneNumber(v))}
                 placeholder="(555) 555-5555"
-                placeholderTextColor="#4A3F60"
+                placeholderTextColor={theme.colors.placeholder}
                 keyboardType="phone-pad"
                 maxLength={14}
               />
@@ -1168,7 +1169,7 @@ function statusBg(status: string): string {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: "#0B0910",
+    backgroundColor: theme.colors.bgBase,
   },
   // Top bar
   topBar: {
@@ -1199,7 +1200,7 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     gap: 6,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
   },
   locationDot: {
     width: 8,
@@ -1207,7 +1208,7 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   locationPillText: {
-    color: "#EDE0C4",
+    color: theme.colors.textPrimary,
     fontSize: 12,
     fontWeight: "600",
   },
@@ -1217,7 +1218,7 @@ const styles = StyleSheet.create({
     borderRadius: 18,
     backgroundColor: "rgba(11,9,16,0.82)",
     borderWidth: 1,
-    borderColor: "#C8973A",
+    borderColor: theme.colors.goldPrimary,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -1236,7 +1237,7 @@ const styles = StyleSheet.create({
     alignSelf: "center",
     marginBottom: 12,
     borderWidth: 2,
-    borderColor: "#C8973A",
+    borderColor: theme.colors.goldPrimary,
   },
   // Status badge
   statusBadge: {
@@ -1247,14 +1248,14 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(11,9,16,0.88)",
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     paddingHorizontal: 14,
     paddingVertical: 7,
     alignItems: "center",
     zIndex: 5,
   },
   statusBadgeText: {
-    color: "#C8973A",
+    color: theme.colors.goldPrimary,
     fontSize: 12,
     fontWeight: "600",
   },
@@ -1265,11 +1266,11 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     height: SHEET_HEIGHT,
-    backgroundColor: "#130F1A",
+    backgroundColor: theme.colors.bgSurface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: -4 },
     shadowOpacity: 0.5,
@@ -1283,7 +1284,7 @@ const styles = StyleSheet.create({
   handle: {
     width: 40,
     height: 4,
-    backgroundColor: "#3A2F50",
+    backgroundColor: theme.colors.borderDefault,
     borderRadius: 2,
     alignSelf: "center",
     marginTop: 10,
@@ -1292,7 +1293,7 @@ const styles = StyleSheet.create({
   tabBar: {
     flexDirection: "row",
     borderBottomWidth: 1,
-    borderBottomColor: "#3A2F50",
+    borderBottomColor: theme.colors.borderDefault,
     marginHorizontal: 16,
   },
   tab: {
@@ -1302,15 +1303,15 @@ const styles = StyleSheet.create({
   },
   tabActive: {
     borderBottomWidth: 2,
-    borderBottomColor: "#C8973A",
+    borderBottomColor: theme.colors.goldPrimary,
   },
   tabText: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontWeight: "600",
     fontSize: 13,
   },
   tabTextActive: {
-    color: "#C8973A",
+    color: theme.colors.goldPrimary,
   },
   sheetScroll: {
     flex: 1,
@@ -1328,28 +1329,28 @@ const styles = StyleSheet.create({
   stopCard: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: "#1A1526",
+    backgroundColor: theme.colors.bgSheet,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 12,
     marginBottom: 8,
     gap: 10,
   },
   stopCardSelected: {
-    borderColor: "#C8973A",
-    backgroundColor: "#2A1E10",
+    borderColor: theme.colors.goldPrimary,
+    backgroundColor: theme.colors.goldTintBg,
   },
   stopSeq: {
     width: 28,
     height: 28,
     borderRadius: 14,
-    backgroundColor: "#C8973A",
+    backgroundColor: theme.colors.goldPrimary,
     alignItems: "center",
     justifyContent: "center",
   },
   stopSeqText: {
-    color: "#0B0910",
+    color: theme.colors.bgBase,
     fontWeight: "800",
     fontSize: 13,
   },
@@ -1357,17 +1358,17 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   stopName: {
-    color: "#EDE0C4",
+    color: theme.colors.textPrimary,
     fontWeight: "700",
     fontSize: 14,
   },
   stopAddr: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 12,
     marginTop: 2,
   },
   stopDist: {
-    color: "#C8973A",
+    color: theme.colors.goldPrimary,
     fontSize: 11,
     marginTop: 2,
   },
@@ -1378,7 +1379,7 @@ const styles = StyleSheet.create({
     paddingVertical: 3,
   },
   statusPillText: {
-    color: "#EDE0C4",
+    color: theme.colors.textPrimary,
     fontSize: 11,
     fontWeight: "700",
   },
@@ -1392,20 +1393,20 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   emptyText: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 14,
   },
   // Directions
   routeSummary: {
-    backgroundColor: "#1A1526",
+    backgroundColor: theme.colors.bgSheet,
     borderRadius: 10,
     padding: 12,
     marginBottom: 12,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
   },
   routeSummaryText: {
-    color: "#C8973A",
+    color: theme.colors.goldPrimary,
     fontWeight: "700",
     fontSize: 15,
     textAlign: "center",
@@ -1420,19 +1421,19 @@ const styles = StyleSheet.create({
     width: 10,
     height: 10,
     borderRadius: 5,
-    backgroundColor: "#C8973A",
+    backgroundColor: theme.colors.goldPrimary,
     marginTop: 4,
   },
   stepInfo: {
     flex: 1,
   },
   stepInstruction: {
-    color: "#EDE0C4",
+    color: theme.colors.textPrimary,
     fontSize: 13,
     fontWeight: "600",
   },
   stepMeta: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 11,
     marginTop: 2,
   },
@@ -1443,11 +1444,11 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(7,5,12,0.6)",
   },
   detailPanel: {
-    backgroundColor: "#130F1A",
+    backgroundColor: theme.colors.bgSurface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     maxHeight: "92%",
   },
   detailHeader: {
@@ -1457,16 +1458,16 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 14,
     borderBottomWidth: 1,
-    borderBottomColor: "#3A2F50",
+    borderBottomColor: theme.colors.borderDefault,
   },
   detailTitle: {
-    color: "#F5D98B",
+    color: theme.colors.textHeading,
     fontSize: 17,
     fontWeight: "700",
     flex: 1,
   },
   detailClose: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 18,
     paddingLeft: 12,
   },
@@ -1484,21 +1485,21 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   detailLabel: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 10,
     fontWeight: "700",
     letterSpacing: 1,
   },
   detailValue: {
-    color: "#EDE0C4",
+    color: theme.colors.textPrimary,
     fontSize: 14,
   },
   detailLink: {
-    color: "#C8973A",
+    color: theme.colors.goldPrimary,
     fontSize: 14,
   },
   detailMeta: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 12,
   },
   // Status actions
@@ -1512,37 +1513,37 @@ const styles = StyleSheet.create({
     borderRadius: 999,
     paddingHorizontal: 12,
     paddingVertical: 7,
-    backgroundColor: "#1A1526",
+    backgroundColor: theme.colors.bgSheet,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
   },
   actionBtnActive: {
-    backgroundColor: "#2A1E10",
-    borderColor: "#C8973A",
+    backgroundColor: theme.colors.goldTintBg,
+    borderColor: theme.colors.goldPrimary,
   },
   actionBtnDanger: {
-    borderColor: "#9B3A3A",
+    borderColor: theme.colors.dangerMuted,
   },
   actionBtnGreen: {
-    borderColor: "#1A5C3A",
+    borderColor: theme.colors.successDim,
   },
   actionBtnDisabled: {
     opacity: 0.5,
   },
   actionBtnText: {
-    color: "#EDE0C4",
+    color: theme.colors.textPrimary,
     fontWeight: "700",
     fontSize: 12,
   },
   // POD
   podSection: {
     borderTopWidth: 1,
-    borderTopColor: "#3A2F50",
+    borderTopColor: theme.colors.borderDefault,
     paddingTop: 14,
     gap: 10,
   },
   podTitle: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontSize: 10,
     fontWeight: "700",
     letterSpacing: 1,
@@ -1552,21 +1553,21 @@ const styles = StyleSheet.create({
     height: 160,
     borderRadius: 8,
     borderWidth: 1,
-    borderColor: "#3A2F50",
-    backgroundColor: "#0F0C16",
+    borderColor: theme.colors.borderDefault,
+    backgroundColor: theme.colors.bgInput,
   },
   podCaptured: {
-    color: "#4A9E5C",
+    color: theme.colors.success,
     fontSize: 12,
     fontWeight: "600",
   },
   // Inputs
   input: {
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     borderRadius: 10,
-    color: "#EDE0C4",
-    backgroundColor: "#0F0C16",
+    color: theme.colors.textPrimary,
+    backgroundColor: theme.colors.bgInput,
     paddingHorizontal: 12,
     paddingVertical: 9,
     fontSize: 14,
@@ -1586,23 +1587,23 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   btnPrimary: {
-    backgroundColor: "#C8973A",
+    backgroundColor: theme.colors.goldPrimary,
   },
   btnGhost: {
     borderWidth: 1,
-    borderColor: "#6B4F2A",
-    backgroundColor: "#130F1A",
+    borderColor: theme.colors.borderAccent,
+    backgroundColor: theme.colors.bgSurface,
   },
   btnGreen: {
-    backgroundColor: "#1A5C3A",
+    backgroundColor: theme.colors.successDim,
   },
   btnText: {
-    color: "#0B0910",
+    color: theme.colors.bgBase,
     fontWeight: "700",
     fontSize: 13,
   },
   btnGhostText: {
-    color: "#C8973A",
+    color: theme.colors.goldPrimary,
     fontWeight: "700",
     fontSize: 13,
   },
@@ -1613,16 +1614,16 @@ const styles = StyleSheet.create({
     justifyContent: "flex-end",
   },
   sigCard: {
-    backgroundColor: "#130F1A",
+    backgroundColor: theme.colors.bgSurface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 16,
     gap: 12,
   },
   sigTitle: {
-    color: "#F5D98B",
+    color: theme.colors.textHeading,
     fontSize: 16,
     fontWeight: "700",
     textAlign: "center",
@@ -1632,21 +1633,21 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     overflow: "hidden",
     borderWidth: 1,
-    borderColor: "#3A2F50",
-    backgroundColor: "#0F0C16",
+    borderColor: theme.colors.borderDefault,
+    backgroundColor: theme.colors.bgInput,
   },
   // Profile
   profileCard: {
-    backgroundColor: "#130F1A",
+    backgroundColor: theme.colors.bgSurface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     borderWidth: 1,
-    borderColor: "#3A2F50",
+    borderColor: theme.colors.borderDefault,
     padding: 16,
     gap: 10,
   },
   profileMsg: {
-    color: "#C8973A",
+    color: theme.colors.goldPrimary,
     fontSize: 12,
     fontWeight: "600",
   },
@@ -1656,20 +1657,20 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 5,
     borderWidth: 1,
-    borderColor: "#3A2F50",
-    backgroundColor: "#1A1526",
+    borderColor: theme.colors.borderDefault,
+    backgroundColor: theme.colors.bgSheet,
   },
   toggleChipActive: {
-    backgroundColor: "#1A5C3A",
-    borderColor: "#4A9E5C",
+    backgroundColor: theme.colors.successDim,
+    borderColor: theme.colors.success,
   },
   toggleChipText: {
-    color: "#968AA8",
+    color: theme.colors.textMuted,
     fontWeight: "700",
     fontSize: 12,
   },
   toggleChipTextActive: {
-    color: "#EDE0C4",
+    color: theme.colors.textPrimary,
   },
   // Profile photo picker
   avatarPickerBtn: {
@@ -1678,8 +1679,8 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   avatarPlaceholder: {
-    backgroundColor: "#1A1526",
-    borderColor: "#3A2F50",
+    backgroundColor: theme.colors.bgSheet,
+    borderColor: theme.colors.borderDefault,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -1687,7 +1688,7 @@ const styles = StyleSheet.create({
     fontSize: 32,
   },
   avatarPickerLabel: {
-    color: "#C8973A",
+    color: theme.colors.goldPrimary,
     fontSize: 11,
     fontWeight: "600",
     letterSpacing: 0.5,


### PR DESCRIPTION
## Phase 5, Step 5.4 — Mobile theme adoption

**Stacked on #195 (5.3) → #194 → #193** — retarget as the stack merges.

Migrates the Expo app off ~300 hardcoded hex values onto the parallel token object (`mobile/theme.ts`, from 5.1; status tokens added in 5.2), closing the last drift gap between web and mobile.

### Changes
- **269 hex literals → `theme.colors.*`** across `DriverScreen`, `AdminScreen`, `App`, and `DeliveryCelebration` — JSX attrs became `{theme.colors.X}`, style/object literals became `theme.colors.X`, and the signature-pad `webStyle` template interpolates tokens too.
- **`App.tsx` + `DeliveryCelebration` are now 100% token-driven** (0 raw hex). The delivery celebration is themed via the shared palette.
- `DriverScreen`/`AdminScreen` retain only **~21 single-use semantic tint fills** (per-status green/red/blue backgrounds, a couple of map/route accents) — minting a shared token for a one-off would violate the "don't near-duplicate" rule in the design-system doc; left inline by design.

### Deferred (documented, not skipped)
**Haptics on key actions** needs `expo install expo-haptics` + on-device verification — the same emulator-blocked class as **A-7**. Importing an uninstalled native module would break the build, so it's a 5.4 follow-up rather than done blind.

### Verification
`tsc --noEmit` **clean**; no `"theme.colors"` string artifacts; residual hex is exactly the documented one-off tints. Migration is value-preserving by construction (mechanical hex→token map). On-device visual pass pending an emulator (A-7).

Next: 5.5 accessibility & responsive pass (the final polish step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)