### PR TITLE
feat(design): re-land accessibility & responsive pass (Step 5.5) — actually completes Phase 5

### DIFF
--- a/backend/frontend/admin-sw.js
+++ b/backend/frontend/admin-sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = "discra-admin-v20260705b";
+const CACHE_NAME = "discra-admin-v20260705e";
 const CACHE_PREFIX = "discra-admin-";
 const PRECACHE_URLS = [
-  "assets/tokens.css?v=20260705b",
-  "assets/styles.css?v=20260705b",
+  "assets/tokens.css?v=20260705e",
+  "assets/styles.css?v=20260705e",
   "assets/common.js?v=20260603a",
   "assets/admin.js?v=20260603a",
   "assets/admin-manifest.json",

--- a/backend/frontend/admin.html
+++ b/backend/frontend/admin.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <link rel="manifest" href="assets/admin-manifest.json">
   <meta name="theme-color" content="#0b1117">
-  <link rel="stylesheet" href="assets/styles.css?v=20260705b">
+  <link rel="stylesheet" href="assets/styles.css?v=20260705e">
 </head>
 <body class="theme-admin">
 
@@ -306,7 +306,7 @@
       <div class="modal-dialog modal-lg">
         <div class="modal-header">
           <h3 id="edit-order-title">Edit Order</h3>
-          <button id="edit-order-close" class="modal-close-btn" type="button">&times;</button>
+          <button id="edit-order-close" class="modal-close-btn" type="button" aria-label="Close">&times;</button>
         </div>
         <form id="edit-order-form" class="modal-body">
           <input type="hidden" id="edit-order-id">
@@ -353,7 +353,7 @@
       <div class="modal-dialog modal-lg">
         <div class="modal-header">
           <h3>Create Order</h3>
-          <button id="create-order-modal-close" class="modal-close-btn" type="button">&times;</button>
+          <button id="create-order-modal-close" class="modal-close-btn" type="button" aria-label="Close">&times;</button>
         </div>
         <div class="modal-body">
           <form id="create-order-form" class="form-grid">
@@ -387,7 +387,7 @@
       <div class="modal-dialog modal-lg">
         <div class="modal-header">
           <h3>Proof of Delivery</h3>
-          <button id="pod-view-modal-close" class="modal-close-btn" type="button">&times;</button>
+          <button id="pod-view-modal-close" class="modal-close-btn" type="button" aria-label="Close">&times;</button>
         </div>
         <div class="modal-body" id="pod-view-content">
           <p style="color:var(--text-muted);text-align:center;padding:32px">Loading…</p>

--- a/backend/frontend/assets/driver-mobile.css
+++ b/backend/frontend/assets/driver-mobile.css
@@ -2,7 +2,7 @@
 /* Design tokens live in ONE place — tokens.css (see docs/design-system.md).
    The --drv-* names are driver-scoped ALIASES onto the shared tokens; never
    assign a raw hex here. */
-@import url("tokens.css?v=20260705b");
+@import url("tokens.css?v=20260705e");
 
 :root {
   --drv-bg: var(--bg-base);

--- a/backend/frontend/assets/styles.css
+++ b/backend/frontend/assets/styles.css
@@ -1,6 +1,6 @@
 /* Design tokens live in ONE place — tokens.css (see docs/design-system.md).
    This import must stay the first rule in the file. */
-@import url("tokens.css?v=20260705b");
+@import url("tokens.css?v=20260705e");
 
 * {
   box-sizing: border-box;
@@ -1438,9 +1438,15 @@ canvas.signature-pad {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .landing-fog, .landing-ember {
-    animation: none !important;
+  /* Neutralize ALL motion for users who ask for it — covers toasts, order-
+     highlight pulse, panel fade/rise, and anything added later. */
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
+  .landing-fog, .landing-ember { animation: none !important; }
   .landing-ember { opacity: 0.25; }
 }
 

--- a/backend/frontend/assets/tokens.css
+++ b/backend/frontend/assets/tokens.css
@@ -32,7 +32,7 @@
   --text-primary: #EDE0C4;
   --text-heading: #F5D98B;
   --text-muted: #968AA8;
-  --text-danger: #D94D4D;
+  --text-danger: #E05F5F;  /* WCAG AA on all surfaces incl. bg-elevated (5.0:1) */
   --text-success: #4A9E5C;
 
   /* Status depth */
@@ -45,7 +45,7 @@
   --status-pickedup: #E0A43B;  /* warm amber — mid-progress */
   --status-enroute: #4A9E5C;   /* == success green — almost there */
   --status-delivered: #4A9E5C;
-  --status-failed: #D94D4D;    /* == text-danger */
+  --status-failed: var(--text-danger);
 
   /* Secondary accents */
   --purple-accent: #7B4FA6;

--- a/backend/frontend/driver-sw.js
+++ b/backend/frontend/driver-sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = "discra-driver-v20260705c";
+const CACHE_NAME = "discra-driver-v20260705e";
 const PRECACHE_URLS = [
   "driver",
-  "assets/tokens.css?v=20260705b",
-  "assets/driver-mobile.css?v=20260705c",
+  "assets/tokens.css?v=20260705e",
+  "assets/driver-mobile.css?v=20260705e",
   "assets/common.js?v=20260524a",
   "assets/driver.js?v=20260529b",
   "assets/driver-manifest.json",

--- a/backend/frontend/driver.html
+++ b/backend/frontend/driver.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <link rel="manifest" href="assets/driver-manifest.json">
   <meta name="theme-color" content="#0b1117">
-  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260705c">
+  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260705e">
 </head>
 <body>
 
@@ -36,7 +36,7 @@
       </div>
       <div class="drv-topbar-right">
         <span id="driver-auth-state" class="drv-status-pill drv-status-off">Offline</span>
-        <button id="profile-btn" class="drv-profile-btn" type="button" title="Profile">
+        <button id="profile-btn" class="drv-profile-btn" type="button" title="Profile" aria-label="Profile">
           <span id="profile-avatar" class="drv-profile-avatar">?</span>
         </button>
         <button id="driver-logout-hosted-ui" class="drv-btn drv-btn-ghost drv-btn-sm" type="button">Logout</button>
@@ -92,7 +92,7 @@
     <div id="driver-detail-panel" class="drv-detail" style="display:none;">
       <div class="drv-detail-header">
         <h3 id="detail-customer-name">Order Details</h3>
-        <button id="detail-close" class="drv-close-btn" type="button">&times;</button>
+        <button id="detail-close" class="drv-close-btn" type="button" aria-label="Close">&times;</button>
       </div>
       <div id="detail-body" class="drv-detail-body"></div>
     </div>
@@ -101,7 +101,7 @@
     <div id="profile-modal" class="drv-detail" style="display:none;">
       <div class="drv-detail-header">
         <h3>My Profile</h3>
-        <button id="profile-close" class="drv-close-btn" type="button">&times;</button>
+        <button id="profile-close" class="drv-close-btn" type="button" aria-label="Close">&times;</button>
       </div>
       <div class="drv-detail-body">
         <form id="profile-form">

--- a/backend/frontend/index.html
+++ b/backend/frontend/index.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700;900&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="ui/assets/styles.css?v=20260705b">
+  <link rel="stylesheet" href="ui/assets/styles.css?v=20260705e">
 </head>
 <body class="landing-theme">
   <div class="landing-atmosphere" aria-hidden="true">

--- a/backend/frontend/login.html
+++ b/backend/frontend/login.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css?v=20260705b">
+  <link rel="stylesheet" href="assets/styles.css?v=20260705e">
 </head>
 <body class="theme-admin">
   <main class="center-stage">

--- a/backend/frontend/register.html
+++ b/backend/frontend/register.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css?v=20260705b">
+  <link rel="stylesheet" href="assets/styles.css?v=20260705e">
 </head>
 <body class="theme-admin">
   <div class="app-shell app-shell-compact">

--- a/backend/frontend/review.html
+++ b/backend/frontend/review.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css?v=20260705b">
+  <link rel="stylesheet" href="assets/styles.css?v=20260705e">
 </head>
 <body class="theme-admin">
   <div class="app-shell app-shell-compact">

--- a/mobile/theme.ts
+++ b/mobile/theme.ts
@@ -31,7 +31,7 @@ export const theme = {
     textPrimary: "#EDE0C4",
     textHeading: "#F5D98B",
     textMuted: "#968AA8",
-    danger: "#D94D4D",
+    danger: "#E05F5F",  // WCAG AA on all surfaces (parity with tokens.css --text-danger)
     success: "#4A9E5C",
 
     // Status depth
@@ -43,7 +43,7 @@ export const theme = {
     statusPickedUp: "#E0A43B",
     statusEnRoute: "#4A9E5C",
     statusDelivered: "#4A9E5C",
-    statusFailed: "#D94D4D",
+    statusFailed: "#E05F5F",
 
     // Secondary accents
     purpleAccent: "#7B4FA6",


### PR DESCRIPTION
## Why this PR exists

**PR #197 was merged but its commits never reached `main`.** It was stacked with base `feat/mobile-theme-adoption`, and PR #196 merged that branch into `main` at `13:01:26` — 79 seconds *before* #197 merged into it at `13:02:45`. The Step 5.5 commits orphaned on the closed branch.

This is the same mid-batch-merge failure mode that stranded S-3/S-4/S-5 during Phase 3 (recovered then via cherry-pick onto a fresh branch off updated `main` — same recovery here).

Verified on `main` before this PR:
- `--text-danger: #D94D4D` — the 4.28:1 contrast failure 5.5 was meant to fix
- `@media (prefers-reduced-motion)` still landing-only
- driver SW cache still `20260705c`
- the live dev stack serves `95de374` (= `main`), so **the pilot would have shipped without the accessibility pass**

## Contents

**Commit 1** — `bcb8271` cherry-picked clean onto current `main` (no conflicts, 8 files):
| Area | Change |
|---|---|
| Contrast | `--text-danger` `#D94D4D` → `#E05F5F` (5.0:1 on `--bg-elevated`, AA on all surfaces); `--status-failed` now aliases it; `mobile/theme.ts` `danger`/`statusFailed` parity |
| Reduced motion | Landing-only block → universal `*, ::before, ::after` animation/transition neutralizer (toasts, order-highlight pulse, panel fade/rise, anything added later) |
| Screen readers | `aria-label="Close"` on 3 admin modal-close buttons + driver detail/profile close; `aria-label="Profile"` on the driver avatar |
| Cache | tokens/styles/driver-mobile + both SW precaches + admin/driver HTML → `20260705e` |

**Commit 2** — a gap found while verifying the re-land, not present in the original #197:

`index.html`, `login.html`, `register.html`, and `review.html` still linked `styles.css?v=20260705b`. Those four pages would have kept serving the **pre-5.5 stylesheet** to returning visitors — no contrast fix, and no reduced-motion neutralizer on the landing page, which is precisely where the fog/ember animation lives. All six pages now reference `20260705e`; no stale refs remain under `backend/frontend/`.

## Verification

- Backend suite **404 passed**
- `tsc --noEmit` clean
- Diff vs `main` contains only 5.5 hunks — no local QA-layer testids leaked into `admin.js`/`driver.js` (this commit set touches neither file)
- Cache-version grep: zero `20260705[abcd]` refs remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)