### PR TITLE
feat(ops): CloudWatch alarms, log retention, dashboard + restore runbook (Step 6.1)

### DIFF
--- a/docs/runbook-ops.md
+++ b/docs/runbook-ops.md
@@ -1,0 +1,217 @@
+# Discra Ops Runbook
+
+> Operational procedures for the deployed stack: what is protected, how to restore
+> it, and what to do when an alarm fires. Written for Phase 6.1 (pilot cutover).
+>
+> **Scope:** the `discra-api-dev` stack in `us-east-1` (account `422814825143`).
+> The same procedures apply to any future stack — substitute the stack name.
+>
+> Every fact below was verified against the live account on **2026-07-26**. Claims
+> that have *not* been exercised end to end are marked **UNDRILLED** — treat those
+> as designs, not proven procedures.
+
+---
+
+## 1. What is protected
+
+| Asset | Protection | Verified |
+|---|---|---|
+| 9 persistent DynamoDB tables | Point-in-time recovery (PITR), 35-day rolling window | ✅ live: all 9 `ENABLED` |
+| 4 ephemeral DynamoDB tables | **None, by design** — TTL'd, reconstructable | ✅ live: all 4 `DISABLED` |
+| All 13 tables | SSE-KMS with the AWS-managed `aws/dynamodb` key | ✅ live: 13/13 |
+| POD photos + signatures (S3) | Bucket versioning + lifecycle | ✅ live: versioning `Enabled`, `expire-noncurrent-versions` rule active |
+| Lambda logs | 30-day retention (`LogRetentionDays`) | ⚠️ takes effect on next deploy — see §5 |
+
+**Persistent (PITR on):** `organizations`, `users`, `orders`, `pod-artifacts`,
+`seat-subscriptions`, `seat-invitations`, `audit-logs`, `onboarding-registrations`,
+`email-config`.
+
+**Ephemeral (PITR deliberately off):** `driver-locations`, `push-subscriptions`,
+`skipped-emails`, `ws-connections`. These carry TTLs and rebuild themselves from
+live traffic; paying to back them up would protect nothing. If you add a table,
+decide which list it belongs to and update both the template and this table.
+
+Current PITR window on `discra-orders-discra-api-dev` (checked 2026-07-26):
+earliest restorable `2026-07-12T08:14:56-05:00`. The window grows to 35 days and
+then rolls; **PITR was enabled 2026-07-12, so anything before that date is not
+recoverable.**
+
+---
+
+## 2. Restoring DynamoDB data (PITR)
+
+### The constraint that shapes every procedure
+
+**PITR cannot restore in place.** `restore-table-to-point-in-time` always creates a
+**new** table. The live table names are fixed by the template
+(`discra-orders-${AWS::StackName}`), so a restored table never lands on the name the
+application reads. Every procedure below is built around that.
+
+A restored table also does **not** inherit: PITR (off), TTL configuration, tags,
+stream settings, or auto-scaling. Re-apply what you need afterwards.
+
+### 2a. Scoped repair — the common case **UNDRILLED**
+
+Use when specific records were corrupted or deleted (bad import, mistaken bulk
+action) and the rest of the table is healthy. This is the expected pilot scenario.
+
+```bash
+aws dynamodb restore-table-to-point-in-time --source-table-name discra-orders-discra-api-dev --target-table-name discra-orders-restore-20260726 --restore-date-time 2026-07-26T12:00:00Z
+```
+
+Then wait for `ACTIVE`, read the good records out of the restored table, and write
+only those records back into the live table. Delete the restored table when done —
+it bills as a normal table until you do.
+
+```bash
+aws dynamodb wait table-exists --table-name discra-orders-restore-20260726
+```
+
+Because the app is org-scoped, always filter by `org_id` when copying records back
+so a repair for one tenant cannot touch another.
+
+### 2b. Whole-table loss **UNDRILLED**
+
+Use when a table is gone or wholly corrupt.
+
+1. Restore to a new name (as above) and verify the item count and a sample of
+   records before touching anything live.
+2. Bring it back into service. Two options, both with real costs:
+   - **Copy back** (preferred at pilot scale): recreate the live table by
+     redeploying the stack, then bulk-copy items from the restored table. Keeps
+     CloudFormation as the source of truth.
+   - **Rename-in-place**: not possible in DynamoDB. Deleting the live table and
+     restoring into its exact name works, but CloudFormation no longer owns the
+     table — the next `sam deploy` will fail or try to recreate it. Only do this
+     with a plan to re-import the resource into the stack.
+3. Re-enable PITR on whatever table ends up live — restores do not carry it over,
+   and a table without PITR is unprotected from that moment on.
+
+> **Do not skip step 3.** The most likely way to turn one incident into two is to
+> finish a restore and leave the new table with backups switched off.
+
+### 2c. Restore drill
+
+The procedures in §2a/§2b are **UNDRILLED** — designed against the AWS API contract
+but never executed here. Before the pilot carries real customer data, run §2a once
+against `discra-orders-discra-api-dev`, restoring to a throwaway table, and record
+the result in §6. A drill that has never run is a guess.
+
+---
+
+## 3. Restoring POD artifacts (S3)
+
+Bucket: `discra-api-dev-podartifactsbucket-qb3smjyzucue` (versioning `Enabled`).
+
+Versioning means deletes are recoverable: a "delete" writes a delete marker rather
+than removing data.
+
+**Recover a deleted object** — list its versions, find the delete marker, remove the
+marker:
+
+```bash
+aws s3api list-object-versions --bucket discra-api-dev-podartifactsbucket-qb3smjyzucue --prefix "<org>/<order>/" --query '{Versions:Versions[].{Key:Key,Id:VersionId,Latest:IsLatest},Markers:DeleteMarkers[].{Key:Key,Id:VersionId}}'
+```
+
+Deleting the delete marker (by its version id) makes the previous version current
+again. **Recover an overwritten object** by copying the desired older version back
+over the current key.
+
+**Retention limit:** the `expire-noncurrent-versions` lifecycle rule permanently
+removes noncurrent versions after 90 days, and abandoned multipart uploads after 7.
+Recovery beyond 90 days is not possible — this is intentional (storage-limitation),
+not a gap.
+
+---
+
+## 4. Alarms — what fires and what to do
+
+All alarms publish to SNS topic `discra-api-dev-ops-alerts`. They fire regardless of
+whether anyone is subscribed; set the `OpsAlertEmail` stack parameter to get email
+delivery (AWS sends a confirmation link that must be clicked before anything
+arrives).
+
+All alarms use `TreatMissingData: notBreaching` — a quiet stack produces no
+datapoints, and silence must not read as failure.
+
+| Alarm | Fires when | First move |
+|---|---|---|
+| `backend-api-errors` | ≥5 Lambda errors in 5 min | Primary "app is broken" signal. Read the backend log group for tracebacks. |
+| `backend-api-throttles` | ≥1 throttle in 5 min | Concurrency exhausted — requests are failing outright. Check for a traffic spike or a runaway caller; raise concurrency. |
+| `backend-api-duration-p95` | p95 >20s for 10 min | Approaching the 30s timeout. Usually a slow dependency (Stripe, Location, Dynamo scan). |
+| `api-5xx` | ≥5 API Gateway 5xx in 5 min | Catches gateway/integration failures that never reach the Lambda error metric. |
+| `api-latency-p95` | p95 >5s for 10 min | The console and driver PWA feel broken well before anything errors. |
+| `email-poller-errors` | ≥1 error in 15 min | Order intake from email has stopped silently. Check Gmail OAuth token expiry first — the 7-day caveat is documented in the README. |
+| `ws-handler-errors` | ≥3 errors in 5 min | Real-time push degraded; app still functions via polling, so this is not user-blocking. |
+| `orders-table-throttles` | ≥1 throttled request in 5 min | On-demand tables still throttle when traffic outruns partition auto-scaling. |
+
+Dashboard: `discra-api-dev-ops` (`OpsDashboardUrl` stack output) — API traffic and
+latency, per-function invocations/errors/concurrency/duration against the timeout,
+and orders-table capacity.
+
+**Alarm count is 8**, deliberately under the 10-alarm free tier. Adding more starts
+billing at $0.10/alarm/month — cheap, but keep the set high-signal: an alarm nobody
+acts on trains people to ignore the ones that matter.
+
+---
+
+## 5. Log retention **(one-time cleanup owed)**
+
+Before 6.1 every Lambda log group was set to **never expire** — unbounded cost
+growth and indefinite retention of request data (a GDPR storage-limitation concern).
+
+The template now declares log groups explicitly with `RetentionInDays` and points
+each function at its group via `LoggingConfig`. **This routes logging to new group
+names**, so after the next deploy the old groups stop receiving data but remain,
+still with no retention:
+
+| Orphaned group | Size | Why |
+|---|---|---|
+| `/aws/lambda/discra-api-dev-BackendApiFunction-uiGTZYimpFzF` | 11.8 MB | superseded by the managed group |
+| `/aws/lambda/discra-api-dev-EmailPollerFunction-q9TfelZpxjGe` | 62.8 MB | superseded by the managed group |
+| `/aws/lambda/discra-api-dev-BackendApiFunction-5TL4L3hDRdPl` | 1.2 MB | function long since replaced |
+| `/aws/lambda/discra-api-dev-AdminPingFunction-*` | 40 KB | function no longer in the template |
+| `/aws/lambda/discra-api-dev-HealthFunction-*` | 54 KB | function no longer in the template |
+| `/aws/lambda/discra-api-dev-VersionFunction-*` | 52 KB | function no longer in the template |
+| `/aws/lambda/discra-api-health-dev` | 1.7 KB | legacy |
+
+After the deploy that lands 6.1, either set retention on these or delete them —
+CloudFormation will not, because it never owned them. Setting retention is the
+safer of the two (it preserves recent history and lets the data age out):
+
+```bash
+aws logs put-retention-policy --log-group-name /aws/lambda/discra-api-dev-EmailPollerFunction-q9TfelZpxjGe --retention-in-days 30
+```
+
+Verify none are left unbounded:
+
+```bash
+aws logs describe-log-groups --query 'logGroups[?contains(logGroupName,`discra`) && retentionInDays==null].logGroupName'
+```
+
+---
+
+## 6. Drill log
+
+Record every restore drill here. An entry is only valid if the procedure was
+actually executed against AWS.
+
+| Date | Procedure | Result | Run by |
+|---|---|---|---|
+| — | — | *no drill has been run yet* | — |
+
+---
+
+## 7. Known gaps
+
+- **Restore procedures are undrilled** (§2c) — the highest-value next ops action.
+- **No per-IP rate limiting.** API Gateway stage throttling (S-3, 100 req/s
+  aggregate) is the only limiter; per-IP abuse limiting needs CloudFront + WAF
+  (S-3b), deferred by decision.
+- **No error-tracking service.** CloudWatch alarms tell you *that* something broke;
+  they do not group or de-duplicate stack traces. Sentry was considered and deferred.
+- **No cold-start mitigation.** Provisioned concurrency was considered and deferred
+  as a cost decision; the first request after idle will be slow.
+- **Stale stack outputs.** `HealthUrl`, `VersionUrl`, and `AdminPingUrl` point at
+  routes whose functions no longer exist and return 404. Use `BackendHealthUrl` /
+  `BackendVersionUrl` instead. Harmless but misleading in the pilot handover pack.

--- a/template.yaml
+++ b/template.yaml
@@ -40,6 +40,23 @@ Parameters:
     Description: >-
       API Gateway stage burst limit (max concurrent request spike, aggregate per
       route). Should be >= ApiThrottleRateLimit.
+  LogRetentionDays:
+    Type: Number
+    Default: 30
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653]
+    Description: >-
+      CloudWatch Logs retention for the Lambda log groups (6.1 ops). Lambda-created
+      groups default to "never expire", which grows cost without bound and holds
+      request data indefinitely (a GDPR storage-limitation concern). 30 days suits
+      a pilot; raise for prod audit needs.
+  OpsAlertEmail:
+    Type: String
+    Default: ""
+    Description: >-
+      Optional email address subscribed to the ops alert SNS topic (6.1). When set,
+      AWS sends a confirmation email that must be accepted before alarms deliver.
+      Leave empty to create the topic without a subscription (alarms still fire and
+      are visible in the console).
   OrsApiKey:
     Type: String
     Default: ""
@@ -204,6 +221,8 @@ Conditions:
   # role carries no geo permission otherwise (S-6 least privilege).
   HasLocationRouteCalculator: !Not [!Equals [!Ref LocationRouteCalculatorName, ""]]
   HasLocationPlaceIndex: !Not [!Equals [!Ref LocationPlaceIndexName, ""]]
+  # 6.1 ops: only create the SNS email subscription when an address is configured.
+  HasOpsAlertEmail: !Not [!Equals [!Ref OpsAlertEmail, ""]]
 
 Globals:
   Function:
@@ -668,6 +687,34 @@ Resources:
           Value: dev
 
 
+  # --- 6.1 ops: explicit log groups with retention -------------------------------
+  # Lambda auto-creates /aws/lambda/<generated-function-name> with retention
+  # "never expire". We instead declare the groups ourselves and point each
+  # function at its group via LoggingConfig, so retention is managed in the
+  # template. Names keep the /aws/lambda/ prefix so the SAM-generated execution
+  # role's basic-execution logs grant still covers them.
+  #
+  # NOTE: this moves logging to NEW groups. The previously auto-created groups
+  # (and those of long-deleted functions) stay behind holding old data with no
+  # retention — see docs/runbook-ops.md for the one-time cleanup.
+  BackendApiLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-backend-api"
+      RetentionInDays: !Ref LogRetentionDays
+
+  EmailPollerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-email-poller"
+      RetentionInDays: !Ref LogRetentionDays
+
+  WsHandlerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-ws-handler"
+      RetentionInDays: !Ref LogRetentionDays
+
   BackendApiFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -675,6 +722,8 @@ Resources:
       MemorySize: 512
       Timeout: 30
       Tracing: Active
+      LoggingConfig:
+        LogGroup: !Ref BackendApiLogGroup
       Environment:
         Variables:
           VERSION: !Ref Version
@@ -955,6 +1004,8 @@ Resources:
       MemorySize: 512
       Timeout: 60
       Tracing: Active
+      LoggingConfig:
+        LogGroup: !Ref EmailPollerLogGroup
       Environment:
         Variables:
           EMAIL_CONFIG_TABLE: !Ref EmailConfigTable
@@ -1076,6 +1127,8 @@ Resources:
       MemorySize: 256
       Timeout: 10
       Tracing: Active
+      LoggingConfig:
+        LogGroup: !Ref WsHandlerLogGroup
       Environment:
         Variables:
           WS_CONNECTIONS_TABLE: !Ref WsConnectionsTable
@@ -1104,6 +1157,304 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DiscraWebSocketApi}/*"
+
+  # --- 6.1 ops: alerting ---------------------------------------------------------
+  # Single topic for every alarm. Alarms fire into it whether or not a subscriber
+  # exists, so the alarm state is always visible in the console/dashboard; the
+  # email subscription just adds push delivery.
+  OpsAlertTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "${AWS::StackName}-ops-alerts"
+      DisplayName: Discra ops alerts
+      Tags:
+        - Key: App
+          Value: Discra
+        - Key: Env
+          Value: dev
+
+  OpsAlertEmailSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasOpsAlertEmail
+    Properties:
+      TopicArn: !Ref OpsAlertTopic
+      Protocol: email
+      Endpoint: !Ref OpsAlertEmail
+
+  # --- 6.1 ops: alarms -----------------------------------------------------------
+  # TreatMissingData: notBreaching throughout — a quiet pilot stack produces no
+  # datapoints, and "no traffic" must not read as "broken".
+  BackendApiErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-backend-api-errors"
+      AlarmDescription: >-
+        Backend API Lambda is returning unhandled errors. Check the function log
+        group for tracebacks; this is the primary "the app is broken" signal.
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref BackendApiFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsAlertTopic]
+      OKActions: [!Ref OpsAlertTopic]
+
+  BackendApiThrottlesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-backend-api-throttles"
+      AlarmDescription: >-
+        Backend API Lambda is being throttled (concurrency limit reached).
+        Requests are failing outright — raise reserved concurrency or the account
+        limit.
+      Namespace: AWS/Lambda
+      MetricName: Throttles
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref BackendApiFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsAlertTopic]
+      OKActions: [!Ref OpsAlertTopic]
+
+  BackendApiDurationAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-backend-api-duration-p95"
+      AlarmDescription: >-
+        Backend API p95 duration is within striking distance of the 30s function
+        timeout. Requests are about to start timing out.
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref BackendApiFunction
+      ExtendedStatistic: p95
+      Period: 300
+      EvaluationPeriods: 2
+      Threshold: 20000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsAlertTopic]
+      OKActions: [!Ref OpsAlertTopic]
+
+  ApiGateway5xxAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-api-5xx"
+      AlarmDescription: >-
+        HTTP API is serving 5xx responses. Catches gateway/integration failures
+        that never reach the Lambda error metric.
+      Namespace: AWS/ApiGateway
+      MetricName: 5xx
+      Dimensions:
+        - Name: ApiId
+          Value: !Ref DiscraApi
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsAlertTopic]
+      OKActions: [!Ref OpsAlertTopic]
+
+  ApiGatewayLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-api-latency-p95"
+      AlarmDescription: >-
+        HTTP API p95 end-to-end latency is above 5s — the console and driver PWA
+        will feel broken well before anything errors.
+      Namespace: AWS/ApiGateway
+      MetricName: Latency
+      Dimensions:
+        - Name: ApiId
+          Value: !Ref DiscraApi
+      ExtendedStatistic: p95
+      Period: 300
+      EvaluationPeriods: 2
+      Threshold: 5000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsAlertTopic]
+      OKActions: [!Ref OpsAlertTopic]
+
+  EmailPollerErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-email-poller-errors"
+      AlarmDescription: >-
+        Scheduled email poller is failing. Order intake from email silently stops
+        when this breaks, so even one error is worth surfacing (longer window than
+        the API alarms since it runs on a schedule).
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref EmailPollerFunction
+      Statistic: Sum
+      Period: 900
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsAlertTopic]
+      OKActions: [!Ref OpsAlertTopic]
+
+  WsHandlerErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ws-handler-errors"
+      AlarmDescription: >-
+        WebSocket handler is failing — real-time order/notification pushes are
+        degraded (the app still works via polling, hence the higher threshold).
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref WsHandlerFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsAlertTopic]
+      OKActions: [!Ref OpsAlertTopic]
+
+  OrdersTableThrottlesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-orders-table-throttles"
+      AlarmDescription: >-
+        The orders table is throttling requests. On-demand tables can still
+        throttle when traffic outruns the auto-scaled partition capacity.
+      Namespace: AWS/DynamoDB
+      MetricName: ThrottledRequests
+      Dimensions:
+        - Name: TableName
+          Value: !Ref OrdersTable
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsAlertTopic]
+      OKActions: [!Ref OpsAlertTopic]
+
+  # --- 6.1 ops: dashboard --------------------------------------------------------
+  # One dashboard (first 3 are free). Traffic/health up top, then per-function
+  # detail, then the data layer.
+  OpsDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Sub "${AWS::StackName}-ops"
+      DashboardBody: !Sub |
+        {
+          "widgets": [
+            {
+              "type": "metric", "x": 0, "y": 0, "width": 12, "height": 6,
+              "properties": {
+                "title": "HTTP API — requests and errors",
+                "region": "${AWS::Region}",
+                "stat": "Sum", "period": 300, "view": "timeSeries", "stacked": false,
+                "metrics": [
+                  [ "AWS/ApiGateway", "Count", "ApiId", "${DiscraApi}", { "label": "requests" } ],
+                  [ ".", "4xx", ".", ".", { "label": "4xx" } ],
+                  [ ".", "5xx", ".", ".", { "label": "5xx" } ]
+                ]
+              }
+            },
+            {
+              "type": "metric", "x": 12, "y": 0, "width": 12, "height": 6,
+              "properties": {
+                "title": "HTTP API — latency",
+                "region": "${AWS::Region}",
+                "period": 300, "view": "timeSeries", "stacked": false,
+                "metrics": [
+                  [ "AWS/ApiGateway", "Latency", "ApiId", "${DiscraApi}", { "stat": "p50", "label": "p50" } ],
+                  [ "...", { "stat": "p95", "label": "p95" } ],
+                  [ "...", { "stat": "p99", "label": "p99" } ],
+                  [ "AWS/ApiGateway", "IntegrationLatency", "ApiId", "${DiscraApi}", { "stat": "p95", "label": "integration p95" } ]
+                ],
+                "yAxis": { "left": { "label": "ms", "showUnits": false } }
+              }
+            },
+            {
+              "type": "metric", "x": 0, "y": 6, "width": 12, "height": 6,
+              "properties": {
+                "title": "Backend API Lambda",
+                "region": "${AWS::Region}",
+                "stat": "Sum", "period": 300, "view": "timeSeries", "stacked": false,
+                "metrics": [
+                  [ "AWS/Lambda", "Invocations", "FunctionName", "${BackendApiFunction}", { "label": "invocations" } ],
+                  [ ".", "Errors", ".", ".", { "label": "errors" } ],
+                  [ ".", "Throttles", ".", ".", { "label": "throttles" } ],
+                  [ ".", "ConcurrentExecutions", ".", ".", { "stat": "Maximum", "label": "peak concurrency" } ]
+                ]
+              }
+            },
+            {
+              "type": "metric", "x": 12, "y": 6, "width": 12, "height": 6,
+              "properties": {
+                "title": "Backend API duration (timeout 30s)",
+                "region": "${AWS::Region}",
+                "period": 300, "view": "timeSeries", "stacked": false,
+                "metrics": [
+                  [ "AWS/Lambda", "Duration", "FunctionName", "${BackendApiFunction}", { "stat": "Average", "label": "avg" } ],
+                  [ "...", { "stat": "p95", "label": "p95" } ],
+                  [ "...", { "stat": "Maximum", "label": "max" } ]
+                ],
+                "yAxis": { "left": { "label": "ms", "showUnits": false } },
+                "annotations": {
+                  "horizontal": [
+                    { "label": "p95 alarm", "value": 20000 },
+                    { "label": "timeout", "value": 30000, "fill": "above" }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "metric", "x": 0, "y": 12, "width": 12, "height": 6,
+              "properties": {
+                "title": "Background functions — errors",
+                "region": "${AWS::Region}",
+                "stat": "Sum", "period": 900, "view": "timeSeries", "stacked": false,
+                "metrics": [
+                  [ "AWS/Lambda", "Invocations", "FunctionName", "${EmailPollerFunction}", { "label": "email poller invocations" } ],
+                  [ ".", "Errors", ".", ".", { "label": "email poller errors" } ],
+                  [ ".", "Errors", ".", "${WsHandlerFunction}", { "label": "ws handler errors" } ]
+                ]
+              }
+            },
+            {
+              "type": "metric", "x": 12, "y": 12, "width": 12, "height": 6,
+              "properties": {
+                "title": "DynamoDB — orders table",
+                "region": "${AWS::Region}",
+                "stat": "Sum", "period": 300, "view": "timeSeries", "stacked": false,
+                "metrics": [
+                  [ "AWS/DynamoDB", "ConsumedReadCapacityUnits", "TableName", "${OrdersTable}", { "label": "read units" } ],
+                  [ ".", "ConsumedWriteCapacityUnits", ".", ".", { "label": "write units" } ],
+                  [ ".", "ThrottledRequests", ".", ".", { "label": "throttled" } ],
+                  [ ".", "SystemErrors", ".", ".", { "label": "system errors" } ]
+                ]
+              }
+            }
+          ]
+        }
 
 Outputs:
   ApiId:
@@ -1225,3 +1576,15 @@ Outputs:
   WebSocketApiEndpoint:
     Description: WebSocket API endpoint URL (wss://)
     Value: !Sub "wss://${DiscraWebSocketApi}.execute-api.${AWS::Region}.amazonaws.com/dev"
+
+  OpsAlertTopicArn:
+    Description: SNS topic all CloudWatch alarms publish to (6.1 ops)
+    Value: !Ref OpsAlertTopic
+
+  OpsDashboardUrl:
+    Description: CloudWatch dashboard for API/Lambda/DynamoDB health (6.1 ops)
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#dashboards:name=${OpsDashboard}"
+
+  BackendApiLogGroupName:
+    Description: Backend API Lambda log group (retention-managed, 6.1 ops)
+    Value: !Ref BackendApiLogGroup


### PR DESCRIPTION
Phase 6.1 ops hardening, ahead of pilot cutover. Scoped to the free-tier items; S-3b WAF, provisioned concurrency, and Sentry were considered and deferred by decision (recorded in the runbook's known-gaps section).

Verified against the live `discra-api-dev` stack, which had **zero alarms** and **zero log groups with retention**.

## Log retention

Lambda auto-creates its log groups with retention **"never expire"** — unbounded cost growth (the email poller had already reached 63 MB) and indefinite retention of request data, a GDPR storage-limitation concern.

The three log groups are now declared explicitly with `RetentionInDays` (`LogRetentionDays`, default 30), and each function points at its group via `LoggingConfig`. Names keep the `/aws/lambda/` prefix so the SAM-generated role's basic-execution logs grant still covers them.

This deliberately avoids pinning `FunctionName` — that would force **replacement** of the live image-backed API function, which is not something to do casually on a stack about to take pilot traffic.

**Trade-off, stated plainly:** logging moves to new group names, so the existing groups stay behind holding old data with no retention. CloudFormation will not clean them up because it never owned them. The one-time cleanup is documented in the runbook with exact commands rather than left implicit.

## Alarms — 8, deliberately under the 10-alarm free tier

| Alarm | Fires when |
|---|---|
| `backend-api-errors` | ≥5 Lambda errors / 5 min — the primary "app is broken" signal |
| `backend-api-throttles` | ≥1 throttle / 5 min — requests failing outright |
| `backend-api-duration-p95` | p95 >20s for 10 min — approaching the 30s timeout |
| `api-5xx` | ≥5 / 5 min — catches integration failures that never reach the Lambda error metric |
| `api-latency-p95` | p95 >5s — the UI feels broken well before anything errors |
| `email-poller-errors` | ≥1 / 15 min — order intake from email stops *silently* when this breaks |
| `ws-handler-errors` | ≥3 / 5 min — higher threshold; polling still works, so not user-blocking |
| `orders-table-throttles` | ≥1 / 5 min |

All use `TreatMissingData: notBreaching` — a quiet pilot stack produces no datapoints, and silence must not read as failure. All publish to one SNS topic with an optional condition-gated email subscription (`OpsAlertEmail`), matching the existing `HasSesFromEmail` pattern. Alarms fire whether or not anyone is subscribed.

Keeping the set small is a deliberate choice: an alarm nobody acts on trains people to ignore the ones that matter.

## Dashboard

One CloudWatch dashboard (first 3 are free): API traffic/latency percentiles, per-function invocations/errors/concurrency, duration annotated against the 30s timeout, and orders-table capacity.

## `docs/runbook-ops.md` — the restore procedure owed since S-9

- What is and isn't protected, and why the 4 ephemeral TTL'd tables are deliberately excluded. Live-verified: **9 tables PITR `ENABLED`, 4 `DISABLED`** — matches the template exactly.
- PITR restore built around the constraint that actually shapes it: **PITR cannot restore in place**, and a restored table inherits neither PITR nor TTL. Both the scoped-repair path (the likely real scenario) and whole-table loss are covered, including the CloudFormation-ownership problem in the latter.
- S3 POD recovery via delete-marker removal, with the 90-day lifecycle limit named as a hard boundary.
- Alarm-by-alarm first response.
- **Procedures are marked UNDRILLED, because they are.** They are designed against the AWS API contract but have never been executed. The drill log table is included and empty, and running a drill is named as the top ops gap. A restore procedure that has never run is a guess, and labelling it otherwise before a pilot would be worse than having none.

## Verification

- Template parses with CFN intrinsics; dashboard JSON valid (6 widgets)
- All 3 functions wired to retention-managed log groups
- Prior-phase hardening intact — S-7 SSE 13/13, S-9 PITR 9/9, zero IAM wildcards
- Backend suite **404 passed**
- Live PITR/versioning/lifecycle state confirmed via the AWS API
- Deploy-gated items are covered by the CI SAM build/validate; merging triggers `deploy-dev.yml`

## Also noticed (not fixed here)

Stack outputs `HealthUrl`, `VersionUrl`, and `AdminPingUrl` point at routes whose functions no longer exist — all return 404. Logged in the runbook's known-gaps section; worth cleaning before the pilot handover pack ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)