### PR TITLE
feat(pilot): Steps 6.2 + 6.3 — restore drill, cutover runbook, in-app feedback loop

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -59,6 +59,7 @@ try:
         billing_router,
         drivers_router,
         email_router,
+        feedback_router,
         identity_router,
         onboarding_router,
         orders_router,
@@ -89,6 +90,7 @@ except ModuleNotFoundError:  # local run from backend/ directory
         billing_router,
         drivers_router,
         email_router,
+        feedback_router,
         identity_router,
         onboarding_router,
         orders_router,
@@ -850,6 +852,7 @@ def create_app() -> FastAPI:
     app.include_router(onboarding_router)
     app.include_router(push_router)
     app.include_router(email_router)
+    app.include_router(feedback_router)
     app.include_router(simulator_router)
     app.include_router(identity_router, prefix="/backend")
     app.include_router(orders_router, prefix="/backend")
@@ -861,6 +864,7 @@ def create_app() -> FastAPI:
     app.include_router(onboarding_router, prefix="/backend")
     app.include_router(push_router, prefix="/backend")
     app.include_router(email_router, prefix="/backend")
+    app.include_router(feedback_router, prefix="/backend")
     app.include_router(simulator_router, prefix="/backend")
     app.include_router(identity_router, prefix="/dev/backend")
     app.include_router(orders_router, prefix="/dev/backend")
@@ -872,6 +876,7 @@ def create_app() -> FastAPI:
     app.include_router(onboarding_router, prefix="/dev/backend")
     app.include_router(push_router, prefix="/dev/backend")
     app.include_router(email_router, prefix="/dev/backend")
+    app.include_router(feedback_router, prefix="/dev/backend")
     app.include_router(simulator_router, prefix="/dev/backend")
 
     return app

--- a/backend/feedback_store.py
+++ b/backend/feedback_store.py
@@ -1,0 +1,114 @@
+"""Storage for in-app pilot feedback (Step 6.3).
+
+Mirrors the push/email store pattern: an ABC, an in-memory implementation used by
+tests and local runs, a DynamoDB implementation, and a factory that falls back to
+in-memory when the table env var is absent so the app still boots without AWS.
+
+Records are keyed (org_id, feedback_id) where feedback_id is timestamp-prefixed,
+so a Query returns newest-first via ScanIndexForward=False without needing a GSI.
+"""
+import json
+import os
+import uuid
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Dict, List, Optional, Tuple
+
+try:
+    import boto3
+    from boto3.dynamodb.conditions import Key
+except ImportError:  # pragma: no cover - boto3 available in Lambda
+    boto3 = None
+    Key = None
+
+try:
+    from backend.schemas import FeedbackRecord
+except ModuleNotFoundError:  # local run from backend/ directory
+    from schemas import FeedbackRecord
+
+
+# A single pilot tester should not be able to fill the table with one paste.
+MAX_MESSAGE_CHARS = 4000
+# Cap what a list call returns so a chatty org can't produce an unbounded response.
+MAX_LIST_LIMIT = 200
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def new_feedback_id(created_at: Optional[datetime] = None) -> str:
+    """Timestamp-prefixed id so range keys sort chronologically.
+
+    Format: <epoch_millis:013d>#<uuid4-hex-12>. The fixed-width millisecond prefix
+    keeps lexicographic order equal to chronological order; the uuid suffix keeps
+    two submissions in the same millisecond distinct.
+    """
+    moment = created_at or utc_now()
+    millis = int(moment.timestamp() * 1000)
+    return f"{millis:013d}#{uuid.uuid4().hex[:12]}"
+
+
+class FeedbackStore(ABC):
+    @abstractmethod
+    def add_feedback(self, record: FeedbackRecord) -> FeedbackRecord:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_feedback(self, org_id: str, limit: int = 50) -> List[FeedbackRecord]:
+        """Newest first, capped at MAX_LIST_LIMIT."""
+        raise NotImplementedError
+
+
+class InMemoryFeedbackStore(FeedbackStore):
+    def __init__(self):
+        self.items: Dict[Tuple[str, str], FeedbackRecord] = {}
+
+    def add_feedback(self, record: FeedbackRecord) -> FeedbackRecord:
+        self.items[(record.org_id, record.feedback_id)] = record
+        return record
+
+    def list_feedback(self, org_id: str, limit: int = 50) -> List[FeedbackRecord]:
+        capped = max(1, min(limit, MAX_LIST_LIMIT))
+        rows = [record for (org, _), record in self.items.items() if org == org_id]
+        rows.sort(key=lambda r: r.feedback_id, reverse=True)
+        return rows[:capped]
+
+
+class DynamoFeedbackStore(FeedbackStore):
+    def __init__(self, table_name: str):
+        if boto3 is None:
+            raise RuntimeError("boto3 not available")
+        self.table = boto3.resource("dynamodb").Table(table_name)
+
+    def add_feedback(self, record: FeedbackRecord) -> FeedbackRecord:
+        item = json.loads(json.dumps(record.model_dump(mode="json")), parse_float=Decimal)
+        self.table.put_item(Item=item)
+        return record
+
+    def list_feedback(self, org_id: str, limit: int = 50) -> List[FeedbackRecord]:
+        capped = max(1, min(limit, MAX_LIST_LIMIT))
+        response = self.table.query(
+            KeyConditionExpression=Key("org_id").eq(org_id),
+            ScanIndexForward=False,  # feedback_id is time-ordered -> newest first
+            Limit=capped,
+        )
+        return [FeedbackRecord.model_validate(item) for item in response.get("Items", [])]
+
+
+_IN_MEMORY_FEEDBACK_STORE = InMemoryFeedbackStore()
+
+
+def get_feedback_store() -> FeedbackStore:
+    table_name = os.environ.get("FEEDBACK_TABLE")
+    if not table_name:
+        return _IN_MEMORY_FEEDBACK_STORE
+    try:
+        return DynamoFeedbackStore(table_name=table_name)
+    except Exception:
+        return _IN_MEMORY_FEEDBACK_STORE
+
+
+def reset_in_memory_feedback_store():
+    _IN_MEMORY_FEEDBACK_STORE.items.clear()

--- a/backend/frontend/admin-sw.js
+++ b/backend/frontend/admin-sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = "discra-admin-v20260705e";
+const CACHE_NAME = "discra-admin-v20260726a";
 const CACHE_PREFIX = "discra-admin-";
 const PRECACHE_URLS = [
-  "assets/tokens.css?v=20260705e",
-  "assets/styles.css?v=20260705e",
+  "assets/tokens.css?v=20260726a",
+  "assets/styles.css?v=20260726a",
   "assets/common.js?v=20260603a",
   "assets/admin.js?v=20260603a",
   "assets/admin-manifest.json",

--- a/backend/frontend/admin.html
+++ b/backend/frontend/admin.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <link rel="manifest" href="assets/admin-manifest.json">
   <meta name="theme-color" content="#0b1117">
-  <link rel="stylesheet" href="assets/styles.css?v=20260705e">
+  <link rel="stylesheet" href="assets/styles.css?v=20260726a">
 </head>
 <body class="theme-admin">
 
@@ -584,6 +584,37 @@
               <button class="btn btn-ghost" type="submit">Manage Billing Portal</button>
             </form>
           </div>
+        </section>
+
+        <!-- Pilot Feedback (6.3) -->
+        <section class="panel" id="feedback-panel">
+          <div class="panel-title-row">
+            <h2>Pilot Feedback</h2>
+            <button id="refresh-feedback" class="btn btn-ghost" type="button">Refresh</button>
+          </div>
+          <p class="panel-help">In-app feedback submitted by anyone in this org. Drivers can send it but cannot read it.</p>
+          <form id="feedback-form" class="form-grid">
+            <label class="field">
+              <span>Category</span>
+              <select id="feedback-category" name="category">
+                <option value="bug">Something is broken</option>
+                <option value="confusing">Something is confusing</option>
+                <option value="idea">Idea or suggestion</option>
+                <option value="praise">This worked well</option>
+                <option value="general" selected>General comment</option>
+              </select>
+            </label>
+            <label class="field field-wide">
+              <span>Your feedback</span>
+              <textarea id="feedback-message" name="message" rows="3" maxlength="4000"
+                placeholder="What happened, and what did you expect?"></textarea>
+            </label>
+            <div class="form-actions">
+              <button id="feedback-submit" class="btn btn-primary" type="submit">Send Feedback</button>
+            </div>
+          </form>
+          <p id="feedback-status" class="form-message"></p>
+          <ul id="feedback-list" class="driver-list"></ul>
         </section>
 
         <!-- Audit Logs -->

--- a/backend/frontend/assets/admin.js
+++ b/backend/frontend/assets/admin.js
@@ -74,6 +74,13 @@
     inflightMessage: document.getElementById("inflight-message"),
     refreshInflight: document.getElementById("refresh-inflight"),
     refreshAuditLogs: document.getElementById("refresh-audit-logs"),
+    refreshFeedback: document.getElementById("refresh-feedback"),
+    feedbackForm: document.getElementById("feedback-form"),
+    feedbackCategory: document.getElementById("feedback-category"),
+    feedbackMessage: document.getElementById("feedback-message"),
+    feedbackSubmit: document.getElementById("feedback-submit"),
+    feedbackStatus: document.getElementById("feedback-status"),
+    feedbackList: document.getElementById("feedback-list"),
     auditFilterForm: document.getElementById("audit-filter-form"),
     auditActionFilter: document.getElementById("audit-action-filter"),
     auditTargetFilter: document.getElementById("audit-target-filter"),
@@ -2995,6 +3002,86 @@
     }
   }
 
+  // --- Pilot feedback (6.3) -------------------------------------------------
+  var FEEDBACK_CATEGORY_LABELS = {
+    bug: "Broken",
+    confusing: "Confusing",
+    idea: "Idea",
+    praise: "Worked well",
+    general: "General",
+  };
+
+  function renderFeedback(rows) {
+    if (!el.feedbackList) return;
+    if (!rows || !rows.length) {
+      el.feedbackList.innerHTML = "<li class=\"empty-row\">No feedback submitted yet.</li>";
+      return;
+    }
+    el.feedbackList.innerHTML = rows.map(function (row) {
+      var category = FEEDBACK_CATEGORY_LABELS[row.category] || "General";
+      var who = row.submitted_by_email || row.submitted_by || "unknown";
+      var roles = (row.submitted_by_roles || []).join(", ");
+      var when = row.created_at ? new Date(row.created_at).toLocaleString() : "";
+      var where = [row.surface, row.page].filter(Boolean).join(" · ");
+      return "<li class=\"feedback-item\">" +
+        "<div class=\"feedback-item-head\">" +
+          "<span class=\"pill\">" + C.escapeHtml(category) + "</span>" +
+          "<span class=\"feedback-item-meta\">" + C.escapeHtml(who) +
+            (roles ? " (" + C.escapeHtml(roles) + ")" : "") +
+            (when ? " · " + C.escapeHtml(when) : "") +
+          "</span>" +
+        "</div>" +
+        "<div class=\"feedback-item-body\">" + C.escapeHtml(row.message || "") + "</div>" +
+        (where ? "<div class=\"feedback-item-context\">" + C.escapeHtml(where) + "</div>" : "") +
+      "</li>";
+    }).join("");
+  }
+
+  async function refreshFeedback() {
+    if (!requireAuthorized(el.feedbackStatus)) {
+      renderFeedback([]);
+      return;
+    }
+    try {
+      const rows = await C.requestJson(apiBase, "/feedback?limit=50", { token });
+      renderFeedback(rows || []);
+    } catch (error) {
+      C.showMessage(el.feedbackStatus, error.message, "error");
+    }
+  }
+
+  async function submitFeedback() {
+    if (!el.feedbackMessage) return;
+    var message = (el.feedbackMessage.value || "").trim();
+    if (!message) {
+      C.showMessage(el.feedbackStatus, "Please enter some feedback first.", "error");
+      return;
+    }
+    // Double-submit guard (A-3 pattern): disable synchronously so the Enter path
+    // is blocked too, and re-enable in finally.
+    if (el.feedbackSubmit) el.feedbackSubmit.disabled = true;
+    try {
+      await C.requestJson(apiBase, "/feedback", {
+        token: token,
+        method: "POST",
+        json: {
+          message: message,
+          category: el.feedbackCategory ? el.feedbackCategory.value : "general",
+          surface: "admin-console",
+          page: window.location.pathname,
+          app_version: (window.DISCRA_APP_VERSION || ""),
+        },
+      });
+      el.feedbackMessage.value = "";
+      C.showMessage(el.feedbackStatus, "Thanks — your feedback was sent.", "success");
+      await refreshFeedback();
+    } catch (error) {
+      C.showMessage(el.feedbackStatus, error.message, "error");
+    } finally {
+      if (el.feedbackSubmit) el.feedbackSubmit.disabled = false;
+    }
+  }
+
   function _pillFromBoolean(value) {
     return value
       ? "<span class=\"pill pill-yes\">Enabled</span>"
@@ -3533,6 +3620,7 @@
         refreshDrivers(),
         refreshInflight(),
         refreshAuditLogs(),
+        refreshFeedback(),
       ]);
       if (isAdminRole) {
         await Promise.all([refreshBillingSummary(), refreshBillingInvitations()]);
@@ -3751,6 +3839,15 @@
     });
   }
   el.refreshAuditLogs.addEventListener("click", refreshAuditLogs);
+
+  // Feedback (6.3)
+  if (el.refreshFeedback) el.refreshFeedback.addEventListener("click", refreshFeedback);
+  if (el.feedbackForm) {
+    el.feedbackForm.addEventListener("submit", function (event) {
+      event.preventDefault();
+      submitFeedback();
+    });
+  }
   el.auditFilterForm.addEventListener("submit", function (event) {
     applyAuditFilters(event).catch(function (error) {
       C.showMessage(el.auditMessage, error.message, "error");

--- a/backend/frontend/assets/driver-mobile.css
+++ b/backend/frontend/assets/driver-mobile.css
@@ -2,7 +2,7 @@
 /* Design tokens live in ONE place — tokens.css (see docs/design-system.md).
    The --drv-* names are driver-scoped ALIASES onto the shared tokens; never
    assign a raw hex here. */
-@import url("tokens.css?v=20260705e");
+@import url("tokens.css?v=20260726a");
 
 :root {
   --drv-bg: var(--bg-base);

--- a/backend/frontend/assets/driver.js
+++ b/backend/frontend/assets/driver.js
@@ -58,6 +58,14 @@
     profilePhotoFile: document.getElementById("profile-photo-file"),
     profilePhotoPreview: document.getElementById("profile-photo-preview"),
     profileTsa: document.getElementById("profile-tsa"),
+    feedbackBtn: document.getElementById("feedback-btn"),
+    feedbackModal: document.getElementById("feedback-modal"),
+    feedbackClose: document.getElementById("feedback-close"),
+    feedbackForm: document.getElementById("feedback-form"),
+    feedbackCategory: document.getElementById("feedback-category"),
+    feedbackMessage: document.getElementById("feedback-message"),
+    feedbackStatus: document.getElementById("feedback-status"),
+    feedbackSubmit: document.getElementById("feedback-submit"),
     profileMessage: document.getElementById("profile-message"),
   };
 
@@ -1010,6 +1018,51 @@
     } catch (e) { /* ok */ }
   }
 
+  // --- Pilot feedback (6.3) -------------------------------------------------
+  // Deliberately a plain form, not a bug-report template: a driver mid-shift will
+  // not fill in reproduction steps. Context is captured automatically instead.
+  function openFeedbackModal() {
+    if (!el.feedbackModal) return;
+    if (el.feedbackStatus) C.showMessage(el.feedbackStatus, "", "");
+    el.feedbackModal.style.display = "flex";
+    if (el.feedbackMessage) el.feedbackMessage.focus();
+  }
+
+  function closeFeedbackModal() {
+    if (el.feedbackModal) el.feedbackModal.style.display = "none";
+  }
+
+  async function submitFeedback() {
+    if (!el.feedbackMessage) return;
+    const message = (el.feedbackMessage.value || "").trim();
+    if (!message) {
+      C.showMessage(el.feedbackStatus, "Please enter some feedback first.", "error");
+      return;
+    }
+    // Double-submit guard, same pattern as the status actions (M-2).
+    if (el.feedbackSubmit) el.feedbackSubmit.disabled = true;
+    try {
+      await C.requestJson(apiBase, "/feedback", {
+        token: token,
+        method: "POST",
+        json: {
+          message: message,
+          category: el.feedbackCategory ? el.feedbackCategory.value : "general",
+          surface: "driver-pwa",
+          page: window.location.pathname,
+          app_version: (window.DISCRA_APP_VERSION || ""),
+        },
+      });
+      el.feedbackMessage.value = "";
+      C.showMessage(el.feedbackStatus, "Thanks — your feedback was sent.", "success");
+      setTimeout(closeFeedbackModal, 1200);
+    } catch (e) {
+      C.showMessage(el.feedbackStatus, e.message || "Could not send feedback.", "error");
+    } finally {
+      if (el.feedbackSubmit) el.feedbackSubmit.disabled = false;
+    }
+  }
+
   function openProfileModal() {
     if (!el.profileModal) return;
     if (currentProfile) {
@@ -1233,6 +1286,11 @@
   if (el.profileForm) el.profileForm.addEventListener("submit", function (e) { e.preventDefault(); saveProfile(); });
   if (el.profilePhotoFile) el.profilePhotoFile.addEventListener("change", handleProfilePhotoFile);
   if (el.profilePhotoUrl) el.profilePhotoUrl.addEventListener("input", updateProfilePhotoPreview);
+
+  // Feedback (6.3)
+  if (el.feedbackBtn) el.feedbackBtn.addEventListener("click", openFeedbackModal);
+  if (el.feedbackClose) el.feedbackClose.addEventListener("click", closeFeedbackModal);
+  if (el.feedbackForm) el.feedbackForm.addEventListener("submit", function (e) { e.preventDefault(); submitFeedback(); });
 
   // Login screen button
   if (el.loginScreenBtn) {

--- a/backend/frontend/assets/styles.css
+++ b/backend/frontend/assets/styles.css
@@ -1,6 +1,6 @@
 /* Design tokens live in ONE place — tokens.css (see docs/design-system.md).
    This import must stay the first rule in the file. */
-@import url("tokens.css?v=20260705e");
+@import url("tokens.css?v=20260726a");
 
 * {
   box-sizing: border-box;
@@ -4063,4 +4063,51 @@ body.theme-admin .billing-seat-cards .stat-card small {
   background: rgba(200, 151, 58, 0.95);
   color: #1A1208;
   border-color: var(--gold-primary, #C8973A);
+}
+
+/* --- Pilot feedback panel (6.3) ------------------------------------------- */
+.feedback-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+}
+
+.feedback-item-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.feedback-item-meta {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.feedback-item-body {
+  color: var(--text-primary);
+  /* Feedback is free text from a tester — keep their line breaks, and make sure a
+     long unbroken paste cannot widen the panel (no horizontal page scroll, 5.5). */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.feedback-item-context {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.empty-row {
+  color: var(--text-muted);
+  padding: var(--space-3);
+  text-align: center;
+}
+
+.field-wide {
+  grid-column: 1 / -1;
 }

--- a/backend/frontend/driver-sw.js
+++ b/backend/frontend/driver-sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = "discra-driver-v20260705e";
+const CACHE_NAME = "discra-driver-v20260726a";
 const PRECACHE_URLS = [
   "driver",
-  "assets/tokens.css?v=20260705e",
-  "assets/driver-mobile.css?v=20260705e",
+  "assets/tokens.css?v=20260726a",
+  "assets/driver-mobile.css?v=20260726a",
   "assets/common.js?v=20260524a",
   "assets/driver.js?v=20260529b",
   "assets/driver-manifest.json",

--- a/backend/frontend/driver.html
+++ b/backend/frontend/driver.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <link rel="manifest" href="assets/driver-manifest.json">
   <meta name="theme-color" content="#0b1117">
-  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260705e">
+  <link rel="stylesheet" href="assets/driver-mobile.css?v=20260726a">
 </head>
 <body>
 
@@ -36,6 +36,7 @@
       </div>
       <div class="drv-topbar-right">
         <span id="driver-auth-state" class="drv-status-pill drv-status-off">Offline</span>
+        <button id="feedback-btn" class="drv-btn drv-btn-ghost drv-btn-sm" type="button" title="Send feedback" aria-label="Send feedback">Feedback</button>
         <button id="profile-btn" class="drv-profile-btn" type="button" title="Profile" aria-label="Profile">
           <span id="profile-avatar" class="drv-profile-avatar">?</span>
         </button>
@@ -139,6 +140,42 @@
           </div>
           <p id="profile-message" class="drv-msg"></p>
           <button type="submit" class="drv-btn drv-btn-accent" style="width:100%;">Save Profile</button>
+        </form>
+      </div>
+    </div>
+
+    <!-- FEEDBACK MODAL (pilot feedback loop, 6.3) -->
+    <div id="feedback-modal" class="drv-detail" style="display:none;">
+      <div class="drv-detail-header">
+        <h3>Send Feedback</h3>
+        <button id="feedback-close" class="drv-close-btn" type="button" aria-label="Close">&times;</button>
+      </div>
+      <div class="drv-detail-body">
+        <form id="feedback-form">
+          <div class="drv-detail-section">
+            <div class="drv-field">
+              <label class="drv-field-label" for="feedback-category">What kind of feedback?</label>
+              <select id="feedback-category" class="drv-input">
+                <option value="bug">Something is broken</option>
+                <option value="confusing">Something is confusing</option>
+                <option value="idea">Idea or suggestion</option>
+                <option value="praise">This worked well</option>
+                <option value="general" selected>General comment</option>
+              </select>
+            </div>
+          </div>
+          <div class="drv-detail-section">
+            <div class="drv-field">
+              <label class="drv-field-label" for="feedback-message">Your feedback</label>
+              <textarea id="feedback-message" class="drv-input" rows="5" maxlength="4000"
+                placeholder="What happened, and what did you expect?"></textarea>
+            </div>
+          </div>
+          <p class="drv-msg" style="opacity:.75;">
+            Your role, the screen you were on, and the app version are included automatically.
+          </p>
+          <p id="feedback-status" class="drv-msg"></p>
+          <button id="feedback-submit" type="submit" class="drv-btn drv-btn-accent" style="width:100%;">Send Feedback</button>
         </form>
       </div>
     </div>

--- a/backend/frontend/index.html
+++ b/backend/frontend/index.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700;900&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="ui/assets/styles.css?v=20260705e">
+  <link rel="stylesheet" href="ui/assets/styles.css?v=20260726a">
 </head>
 <body class="landing-theme">
   <div class="landing-atmosphere" aria-hidden="true">

--- a/backend/frontend/login.html
+++ b/backend/frontend/login.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css?v=20260705e">
+  <link rel="stylesheet" href="assets/styles.css?v=20260726a">
 </head>
 <body class="theme-admin">
   <main class="center-stage">

--- a/backend/frontend/register.html
+++ b/backend/frontend/register.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css?v=20260705e">
+  <link rel="stylesheet" href="assets/styles.css?v=20260726a">
 </head>
 <body class="theme-admin">
   <div class="app-shell app-shell-compact">

--- a/backend/frontend/review.html
+++ b/backend/frontend/review.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cinzel+Decorative:wght@400;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css?v=20260705e">
+  <link rel="stylesheet" href="assets/styles.css?v=20260726a">
 </head>
 <body class="theme-admin">
   <div class="app-shell app-shell-compact">

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,6 +1,7 @@
 from .billing import router as billing_router
 from .drivers import router as drivers_router
 from .email import router as email_router
+from .feedback import router as feedback_router
 from .identity import router as identity_router
 from .onboarding import router as onboarding_router
 from .orders import router as orders_router
@@ -14,6 +15,7 @@ __all__ = [
     "billing_router",
     "drivers_router",
     "email_router",
+    "feedback_router",
     "identity_router",
     "onboarding_router",
     "orders_router",

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -1,0 +1,99 @@
+"""In-app pilot feedback (Step 6.3).
+
+Any authenticated user can submit; only Admin/Dispatcher can read the queue.
+Drivers deliberately cannot list feedback — a driver seeing every colleague's
+complaints is a privacy problem, not a feature.
+
+Submissions are org-scoped from the JWT, never from the request body, so a
+tester cannot file feedback into another tenant.
+"""
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from pydantic import BaseModel, Field
+
+try:
+    from backend.auth import (
+        ROLE_ADMIN,
+        ROLE_DISPATCHER,
+        ROLE_DRIVER,
+        get_current_user,
+        require_roles,
+    )
+    from backend.feedback_store import (
+        MAX_MESSAGE_CHARS,
+        get_feedback_store,
+        new_feedback_id,
+    )
+    from backend.schemas import FeedbackRecord
+except ModuleNotFoundError:  # local run from backend/ directory
+    from auth import (
+        ROLE_ADMIN,
+        ROLE_DISPATCHER,
+        ROLE_DRIVER,
+        get_current_user,
+        require_roles,
+    )
+    from feedback_store import MAX_MESSAGE_CHARS, get_feedback_store, new_feedback_id
+    from schemas import FeedbackRecord
+
+router = APIRouter(prefix="/feedback", tags=["feedback"])
+
+ALLOWED_CATEGORIES = {"bug", "confusing", "idea", "praise", "general"}
+
+# Bound the free-text context fields. These are attacker-controllable (user agent
+# especially) and end up rendered in the admin console.
+MAX_CONTEXT_CHARS = 400
+
+
+class FeedbackSubmitRequest(BaseModel):
+    message: str = Field(..., min_length=1, max_length=MAX_MESSAGE_CHARS)
+    category: str = "general"
+    surface: str = ""
+    page: str = ""
+    app_version: str = ""
+
+
+def _clip(value: Optional[str], limit: int = MAX_CONTEXT_CHARS) -> str:
+    return (value or "").strip()[:limit]
+
+
+@router.post("")
+async def submit_feedback(
+    body: FeedbackSubmitRequest,
+    request: Request,
+    user=Depends(require_roles([ROLE_ADMIN, ROLE_DISPATCHER, ROLE_DRIVER])),
+    feedback_store=Depends(get_feedback_store),
+):
+    """Accept feedback from any signed-in user, scoped to their own org."""
+    category = body.category if body.category in ALLOWED_CATEGORIES else "general"
+    created_at = datetime.now(timezone.utc)
+
+    record = FeedbackRecord(
+        # org comes from the verified token, never from the payload.
+        org_id=user["org_id"],
+        feedback_id=new_feedback_id(created_at),
+        category=category,
+        message=body.message.strip()[:MAX_MESSAGE_CHARS],
+        surface=_clip(body.surface),
+        page=_clip(body.page),
+        app_version=_clip(body.app_version),
+        user_agent=_clip(request.headers.get("user-agent")),
+        submitted_by=user.get("sub") or "",
+        submitted_by_email=user.get("email") or "",
+        submitted_by_roles=list(user.get("groups") or []),
+        created_at=created_at,
+    )
+    saved = feedback_store.add_feedback(record)
+    return {"ok": True, "feedback_id": saved.feedback_id}
+
+
+@router.get("")
+async def list_feedback(
+    limit: int = Query(50, ge=1, le=200),
+    user=Depends(require_roles([ROLE_ADMIN, ROLE_DISPATCHER])),
+    feedback_store=Depends(get_feedback_store),
+) -> List[FeedbackRecord]:
+    """Newest-first feedback for the caller's org."""
+    return feedback_store.list_feedback(user["org_id"], limit=limit)

--- a/backend/routers/onboarding.py
+++ b/backend/routers/onboarding.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from typing import Optional
 
@@ -77,6 +78,8 @@ except ModuleNotFoundError:  # local run from backend/ directory
         OrganizationRecord,
         UserRecord,
     )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["onboarding"])
 
@@ -337,7 +340,16 @@ def _apply_review_decision_for_registration(
                 reason=decision_reason,
             )
         except Exception:
-            pass
+            # Notification is best-effort: the approval itself already succeeded and
+            # must not be rolled back. But swallowing this silently meant a whole
+            # class of delivery failure was invisible — notably SES sandbox mode,
+            # which rejects any recipient that isn't a verified identity, i.e. every
+            # external pilot tester. Log it (no address — S-5 PII rule).
+            logger.warning(
+                "Onboarding approval email failed to send for registration %s",
+                saved.registration_id,
+                exc_info=True,
+            )
 
         _audit_event(
             request=request,
@@ -388,7 +400,12 @@ def _apply_review_decision_for_registration(
             reason=decision_reason,
         )
     except Exception:
-        pass
+        # Best-effort, same rationale as the approval path above.
+        logger.warning(
+            "Onboarding rejection email failed to send for registration %s",
+            saved.registration_id,
+            exc_info=True,
+        )
 
     _audit_event(
         request=request,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -666,3 +666,27 @@ class SkippedEmail(BaseModel):
     skip_reason: str = ""
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at_epoch: int = 0
+
+
+class FeedbackRecord(BaseModel):
+    """Pilot feedback submitted from inside the app (Step 6.3).
+
+    Org-scoped like every other record so tenant isolation applies for free.
+    `feedback_id` is a sortable ULID-ish key (timestamp prefix) so a Query
+    returns newest-first without a secondary index.
+    """
+
+    org_id: str
+    feedback_id: str
+    category: str = "general"
+    message: str
+    # Context captured automatically so a tester doesn't have to describe it.
+    surface: str = ""
+    page: str = ""
+    app_version: str = ""
+    user_agent: str = ""
+    # Who sent it — needed to follow up during a pilot.
+    submitted_by: str = ""
+    submitted_by_email: str = ""
+    submitted_by_roles: List[str] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -51,12 +51,23 @@ def _submit(client, role="Driver", org="org-1", **payload):
     return client.post("/feedback", json=body, headers=auth_headers(role=role, org_id=org))
 
 
+def _assert_status(resp, expected):
+    """Assert status, but put the response body in the message.
+
+    A bare `assert resp.status_code == 200` reports "assert 500 == 200" and nothing
+    about why — useless when the failure only reproduces in CI.
+    """
+    assert resp.status_code == expected, (
+        f"expected {expected}, got {resp.status_code}; body={resp.text[:800]!r}"
+    )
+
+
 # --- submit -----------------------------------------------------------------
 
 @pytest.mark.parametrize("role", ["Admin", "Dispatcher", "Driver"])
 def test_any_signed_in_role_can_submit(client, role):
     resp = _submit(client, role=role)
-    assert resp.status_code == 200
+    _assert_status(resp, 200)
     assert resp.json()["ok"] is True
     assert resp.json()["feedback_id"]
 
@@ -75,7 +86,7 @@ def test_submit_captures_context_and_identity(client):
         page="/backend/ui/driver",
         app_version="20260726",
     )
-    assert resp.status_code == 200
+    _assert_status(resp, 200)
 
     listed = client.get("/feedback", headers=auth_headers(role="Admin", org_id="org-1")).json()
     assert len(listed) == 1
@@ -123,7 +134,7 @@ def test_org_id_comes_from_token_not_body(client):
 def test_admin_and_dispatcher_can_list(client, role):
     _submit(client)
     resp = client.get("/feedback", headers=auth_headers(role=role, org_id="org-1"))
-    assert resp.status_code == 200
+    _assert_status(resp, 200)
     assert len(resp.json()) == 1
 
 

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,0 +1,183 @@
+"""In-app pilot feedback (Step 6.3).
+
+Covers the submit/list contract, the RBAC split (everyone submits, only
+Admin/Dispatcher reads), tenant isolation, ordering, and input bounds.
+"""
+import base64
+import json
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from backend.app import app  # noqa: E402
+from backend.feedback_store import (  # noqa: E402
+    MAX_MESSAGE_CHARS,
+    new_feedback_id,
+    reset_in_memory_feedback_store,
+)
+
+
+def make_token(sub: str, org_id: str, groups):
+    payload = {"sub": sub, "custom:org_id": org_id, "cognito:groups": groups}
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).rstrip(b"=")
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=")
+    return f"{header.decode()}.{body.decode()}."
+
+
+def auth_headers(role: str, org_id: str = "org-1"):
+    token = make_token(sub=f"user-{role.lower()}", org_id=org_id, groups=[role])
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(autouse=True)
+def _clean_store():
+    reset_in_memory_feedback_store()
+    yield
+    reset_in_memory_feedback_store()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _submit(client, role="Driver", org="org-1", **payload):
+    body = {"message": "the assign button is confusing"}
+    body.update(payload)
+    return client.post("/feedback", json=body, headers=auth_headers(role=role, org_id=org))
+
+
+# --- submit -----------------------------------------------------------------
+
+@pytest.mark.parametrize("role", ["Admin", "Dispatcher", "Driver"])
+def test_any_signed_in_role_can_submit(client, role):
+    resp = _submit(client, role=role)
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert resp.json()["feedback_id"]
+
+
+def test_submit_requires_authentication(client):
+    resp = client.post("/feedback", json={"message": "hi"})
+    assert resp.status_code == 401
+
+
+def test_submit_captures_context_and_identity(client):
+    resp = _submit(
+        client,
+        role="Driver",
+        category="bug",
+        surface="driver-pwa",
+        page="/backend/ui/driver",
+        app_version="20260726",
+    )
+    assert resp.status_code == 200
+
+    listed = client.get("/feedback", headers=auth_headers(role="Admin", org_id="org-1")).json()
+    assert len(listed) == 1
+    row = listed[0]
+    assert row["category"] == "bug"
+    assert row["surface"] == "driver-pwa"
+    assert row["page"] == "/backend/ui/driver"
+    assert row["app_version"] == "20260726"
+    assert row["submitted_by"]
+    assert "Driver" in row["submitted_by_roles"]
+    # user_agent is captured from the request, not the body
+    assert "user_agent" in row
+
+
+def test_unknown_category_falls_back_to_general(client):
+    _submit(client, category="../../etc/passwd")
+    listed = client.get("/feedback", headers=auth_headers(role="Admin", org_id="org-1")).json()
+    assert listed[0]["category"] == "general"
+
+
+def test_empty_message_rejected(client):
+    resp = _submit(client, message="")
+    assert resp.status_code == 422
+
+
+def test_oversized_message_rejected(client):
+    resp = _submit(client, message="x" * (MAX_MESSAGE_CHARS + 1))
+    assert resp.status_code == 422
+
+
+def test_org_id_comes_from_token_not_body(client):
+    """A tester must not be able to file feedback into someone else's tenant."""
+    resp = _submit(client, role="Driver", org="org-1", org_id="org-victim")
+    assert resp.status_code == 200
+
+    victim = client.get("/feedback", headers=auth_headers(role="Admin", org_id="org-victim"))
+    assert victim.json() == []
+    mine = client.get("/feedback", headers=auth_headers(role="Admin", org_id="org-1"))
+    assert len(mine.json()) == 1
+
+
+# --- list -------------------------------------------------------------------
+
+@pytest.mark.parametrize("role", ["Admin", "Dispatcher"])
+def test_admin_and_dispatcher_can_list(client, role):
+    _submit(client)
+    resp = client.get("/feedback", headers=auth_headers(role=role, org_id="org-1"))
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_driver_cannot_list_feedback(client):
+    """A driver reading every colleague's complaints is a privacy problem."""
+    _submit(client)
+    resp = client.get("/feedback", headers=auth_headers(role="Driver", org_id="org-1"))
+    assert resp.status_code == 403
+
+
+def test_list_requires_authentication(client):
+    assert client.get("/feedback").status_code == 401
+
+
+def test_list_is_tenant_isolated(client):
+    _submit(client, org="org-1", message="from org one")
+    _submit(client, org="org-2", message="from org two")
+
+    org1 = client.get("/feedback", headers=auth_headers(role="Admin", org_id="org-1")).json()
+    assert [r["message"] for r in org1] == ["from org one"]
+
+    org2 = client.get("/feedback", headers=auth_headers(role="Admin", org_id="org-2")).json()
+    assert [r["message"] for r in org2] == ["from org two"]
+
+
+def test_list_is_newest_first(client):
+    for i in range(3):
+        _submit(client, message=f"note {i}")
+    listed = client.get("/feedback", headers=auth_headers(role="Admin", org_id="org-1")).json()
+    assert [r["message"] for r in listed] == ["note 2", "note 1", "note 0"]
+
+
+def test_list_limit_is_bounded(client):
+    for i in range(5):
+        _submit(client, message=f"note {i}")
+    assert len(client.get("/feedback?limit=2", headers=auth_headers(role="Admin", org_id="org-1")).json()) == 2
+    # out-of-range limits are rejected by validation rather than silently clamped
+    assert client.get("/feedback?limit=0", headers=auth_headers(role="Admin", org_id="org-1")).status_code == 422
+    assert client.get("/feedback?limit=5000", headers=auth_headers(role="Admin", org_id="org-1")).status_code == 422
+
+
+# --- id generation ----------------------------------------------------------
+
+def test_feedback_ids_sort_chronologically():
+    from datetime import datetime, timedelta, timezone
+
+    base = datetime(2026, 7, 26, 12, 0, 0, tzinfo=timezone.utc)
+    ids = [new_feedback_id(base + timedelta(milliseconds=i)) for i in range(5)]
+    assert ids == sorted(ids), "timestamp prefix must make lexicographic order == chronological"
+
+
+def test_feedback_ids_are_unique_within_a_millisecond():
+    from datetime import datetime, timezone
+
+    moment = datetime(2026, 7, 26, 12, 0, 0, tzinfo=timezone.utc)
+    ids = {new_feedback_id(moment) for _ in range(50)}
+    assert len(ids) == 50

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -34,6 +34,19 @@ def auth_headers(role: str, org_id: str = "org-1"):
 
 
 @pytest.fixture(autouse=True)
+def _test_env(monkeypatch):
+    """Pin the auth mode instead of inheriting it.
+
+    The unsigned tokens above are only accepted when signature verification is off.
+    Without this the suite passes on a dev machine (a local .env sets it) and 500s in
+    CI with "Auth misconfigured: missing COGNITO_ISSUER/COGNITO_AUDIENCE" — the same
+    environment dependence that bit test_dev_auth_disabled_by_default. Matches the
+    _test_env fixture in test_rbac_matrix.py.
+    """
+    monkeypatch.setenv("JWT_VERIFY_SIGNATURE", "false")
+
+
+@pytest.fixture(autouse=True)
 def _clean_store():
     reset_in_memory_feedback_store()
     yield

--- a/backend/tests/test_rbac_matrix.py
+++ b/backend/tests/test_rbac_matrix.py
@@ -144,6 +144,10 @@ ENDPOINTS = [
     EP("billing_invitation_cancel", "POST", "/billing/invitations/abc/cancel", {}, {"Admin"}),
     # push
     EP("push_subscribe", "POST", "/push/subscribe", {"json": {"endpoint": "https://e", "p256dh": "p", "auth": "a"}}, {"Admin", "Dispatcher", "Driver"}),
+    # feedback (6.3): anyone signed in may submit; only Admin/Dispatcher may read the
+    # queue — a Driver reading colleagues' feedback is a privacy problem.
+    EP("feedback_submit", "POST", "/feedback", {"json": {"message": "rbac probe"}}, {"Admin", "Dispatcher", "Driver"}),
+    EP("feedback_list", "GET", "/feedback", {}, {"Admin", "Dispatcher"}),
     # email
     EP("email_connect", "POST", "/email/connect", {"json": {"code": "x", "redirect_uri": "https://x"}}, {"Admin"}),
     EP("email_disconnect", "POST", "/email/disconnect", {}, {"Admin"}),

--- a/docs/pilot-uat-checklist.md
+++ b/docs/pilot-uat-checklist.md
@@ -2,33 +2,56 @@
 
 Use this checklist when handing Discra to an external tester for MVP validation.
 
+> **Run [`runbook-pilot-cutover.md`](runbook-pilot-cutover.md) first.** It covers the
+> environment prep and the blockers that must be cleared before this checklist means
+> anything — in particular SES sandbox (tester emails are not delivered) and single-role
+> test accounts (without them, every role check below passes trivially).
+
 ## 1) Environment prep
 
-- Confirm latest `main` is deployed to the dev stack.
+- Confirm latest `main` is deployed: `/backend/version` must equal the `main` tip.
 - Generate stack summary:
   - `tools\pilot\export-pilot-summary.ps1 -StackName "discra-api-dev" -Region "us-east-1"`
 - Run smoke checks:
   - `tools\smoke\run-smoke.ps1 -ApiBaseUrl "https://<api-id>.execute-api.us-east-1.amazonaws.com/dev" -AdminToken "<ADMIN_TOKEN>" -OrdersWebhookToken "<ORDERS_WEBHOOK_TOKEN>"`
 - Verify Cognito groups exist: `Admin`, `Dispatcher`, `Driver`.
+- **Confirm dev-auth is disabled** — this must return `404`:
+  - `POST <api-base>/backend/ui/dev-auth/login {"role":"Admin"}`
+  - A `200` here means the stack is serving a credential-free Admin login (ledger A-6).
+    Stop and fix before going further.
+- **Confirm each test user is in exactly ONE group** (`admin-list-groups-for-user`). A
+  multi-role account passes every check below regardless of whether RBAC works.
+
+> Health checks are `/backend/health` and `/backend/version`. The bare `/health`,
+> `/version`, and `/admin/ping` routes no longer exist and return 404 (O-1).
 
 ## 2) Tester package to share
 
 - Admin UI URL (`/backend/ui/admin`)
 - Driver UI URL (`/backend/ui/driver`)
-- Temporary Cognito test users (one per role)
+- Temporary Cognito test users — **one per role, each in a single group**
 - Test org id (example: `org-pilot-1`)
+- Sign-in is via the **Cognito Hosted UI**; there is no dev/no-password login path.
 - Known limitations for pilot:
+  - **first request after an idle period takes ~7 s** (container cold start); warm
+    requests are 5–130 ms — expected, not a defect
+  - mobile app has **no offline queue** — offline writes error rather than queueing
   - route optimization quality depends on Amazon Location data/geocoding quality
   - webhook ingest requires shared token (and HMAC headers if enabled)
+  - Gmail ingest tokens expire after 7 days and need reconnecting
 
 ## 3) Admin checks
 
 - Log in via hosted UI.
 - Open dispatch summary and confirm KPI data loads.
-- Create at least 2 orders with required fields:
-  - `reference_number`, `pick_up_address`, `delivery`, `dimensions`, `weight`
+- Create at least 2 orders via the admin console, filling the required fields.
+  - Note: the console's create form uses `reference_id` / `pick_up_street` /
+    `delivery_street`; the field names `reference_number` / `pick_up_address` /
+    `delivery` are the **webhook payload** shape (§6). Both exist in the data today.
 - Assign one order to a driver and verify audit log event appears.
 - Open billing summary/status and confirm seat counts and provider readiness render.
+- Confirm a **Failed** order shows its failure reason in the orders table, and that the
+  history view lists both `Delivered` and `Failed` orders.
 
 ## 4) Dispatcher checks
 
@@ -59,6 +82,9 @@ Use this checklist when handing Discra to an external tester for MVP validation.
 - POD upload + metadata succeeds for delivered order.
 - Driver location flow visible to Admin/Dispatcher.
 - Billing summary and seat/invitation flows are reachable by Admin.
+- **Role separation holds:** the single-role Driver is refused the admin console and
+  cannot read another driver's order; the Dispatcher is refused billing/org endpoints.
+- **Dev-auth returns 404** (re-check at sign-off, not only at prep).
 - No P0/P1 defects remain open.
 
 ## 8) Feedback capture

--- a/docs/runbook-ops.md
+++ b/docs/runbook-ops.md
@@ -92,10 +92,27 @@ Use when a table is gone or wholly corrupt.
 
 ### 2c. Restore drill
 
-The procedures in §2a/§2b are **UNDRILLED** — designed against the AWS API contract
-but never executed here. Before the pilot carries real customer data, run §2a once
-against `discra-orders-discra-api-dev`, restoring to a throwaway table, and record
-the result in §6. A drill that has never run is a guess.
+**§2a has now been drilled end to end against the live table (2026-07-26).** Results in
+§6. What the drill established, beyond "it works":
+
+- **Restore is not instant, but it is fast at this scale:** ~4–5 minutes wall clock for a
+  27-item / 14 KB table. Most of that is fixed overhead, so plan minutes, not seconds —
+  and expect materially longer for a table with real pilot volume.
+- **Fidelity was exact:** 27/27 items, identical key set, and zero items differing in
+  content (full attribute-level comparison, not just a count).
+- **`ItemCount` reads 0 on a freshly restored table.** DynamoDB refreshes that metric
+  roughly every 6 hours. **Do not use it to verify a restore** — scan the table. Reading
+  `ItemCount` would have made a perfectly good restore look like a total failure.
+- **PITR is genuinely not inherited** — confirmed by measurement, not assumption: source
+  `ENABLED`, restored `DISABLED`. This is the step most likely to be forgotten.
+- **Tags are not inherited** (0 tags on the restored table).
+- **SSE *is* inherited** — both `ENABLED`. Encryption does not need re-applying.
+- **TTL: not proven either way.** The orders table has no TTL configured, so the drill
+  could not test it. Treat "TTL is not carried over" as unverified and check it explicitly
+  if you ever restore one of the TTL'd tables.
+
+§2b (whole-table loss) remains **UNDRILLED** — it requires either destroying a live table
+or a full stack redeploy, neither of which is drillable without a dedicated scratch stack.
 
 ---
 
@@ -198,13 +215,21 @@ actually executed against AWS.
 
 | Date | Procedure | Result | Run by |
 |---|---|---|---|
-| — | — | *no drill has been run yet* | — |
+| 2026-07-26 | §2a scoped repair — PITR restore of `discra-orders-discra-api-dev` to `discra-orders-restore-drill-20260726`, verify, delete | **PASS.** Restore point 14:30:31Z, table created 14:35:31Z, `ACTIVE` by ~14:40Z (**~4–5 min**). Verified by full scan: **27/27 items, matching key-set fingerprint `59b81e6774eaebdc`, 0 items differing in content**. Confirmed PITR **not** inherited (source `ENABLED` → restored `DISABLED`) and tags not inherited; SSE **was** inherited. Throwaway table deleted; source table untouched (27 items, `ACTIVE`) and the live API unaffected. Gotcha found: restored `ItemCount` reads 0 for ~6h — verify by scanning, not by that metric. | Claude (agent), authorized by Cody |
 
 ---
 
 ## 7. Known gaps
 
-- **Restore procedures are undrilled** (§2c) — the highest-value next ops action.
+- **§2b (whole-table loss) is still undrilled** — it needs a scratch stack to exercise
+  safely. §2a (scoped repair) passed on 2026-07-26.
+- **SES is in sandbox** (`ProductionAccessEnabled: false`, 200 sends/day, 1/sec). Only
+  `pdahs1@gmail.com` is a verified identity, and sandbox mode rejects any recipient that
+  is not verified. Approver notifications work; **the approve/reject email to an external
+  pilot tester will not be delivered.** The approval itself still succeeds (the send is
+  best-effort inside a try block), so this is a notification gap, not a data-integrity one.
+  **Requesting production access is a support ticket with ~24h turnaround — start it before
+  cutover day, not on it.**
 - **No per-IP rate limiting.** API Gateway stage throttling (S-3, 100 req/s
   aggregate) is the only limiter; per-IP abuse limiting needs CloudFront + WAF
   (S-3b), deferred by decision.

--- a/docs/runbook-pilot-cutover.md
+++ b/docs/runbook-pilot-cutover.md
@@ -1,0 +1,176 @@
+# Discra Pilot Cutover Runbook
+
+> Step 6.2. What is verified ready, what blocks cutover, and the exact steps to run.
+>
+> Every "verified" line below was checked against the live `discra-api-dev` stack on
+> **2026-07-26**. Anything not verified is labelled. Complements
+> [`pilot-uat-checklist.md`](pilot-uat-checklist.md) (what testers do) and
+> [`runbook-ops.md`](runbook-ops.md) (what you do when it breaks).
+
+---
+
+## 1. Environment — verified ready
+
+| Item | State |
+|---|---|
+| Stack | `discra-api-dev`, `us-east-1`, acct `422814825143` |
+| API base | `https://m50fjhgrn7.execute-api.us-east-1.amazonaws.com/dev` |
+| Health / version | `/backend/health` 200 · `/backend/version` = deployed SHA |
+| Deploy pipeline | `deploy-dev.yml` auto-deploys `main` → SAM build → deploy → smoke |
+| **Dev-auth (A-6)** | **Disabled and verified closed** — login 404s for all three roles, `dev_auth_enabled:false`, pre-existing dev sessions rejected 401 |
+| Cognito groups | `Admin`, `Dispatcher`, `Driver` all exist |
+| Onboarding | Enabled; approver allowlist + SES sender configured; review link TTL 48h |
+| Backups | PITR on 9 persistent tables; **restore drill PASSED** (see ops runbook §6) |
+| Monitoring | 8 alarms + dashboard + 30-day log retention, live |
+
+Because dev-auth is now off, **every pilot login goes through the Cognito Hosted UI.**
+There is no credential-free path any more — which is the point, but it means tester
+accounts must exist before anyone can do anything.
+
+---
+
+## 2. Blockers — resolve before cutover
+
+### B-1. SES is in sandbox — external testers get no email **(has lead time)**
+
+`ProductionAccessEnabled: false`; quota 200/day, 1/sec. Only `pdahs1@gmail.com` is a
+verified identity, and **sandbox mode rejects any recipient that is not verified.**
+
+Effect on the onboarding flow:
+
+| Email | Recipient | Sandbox result |
+|---|---|---|
+| Approver notification ("registration pending") | `pdahs1@gmail.com` | ✅ delivered |
+| Approve / reject decision | the **external tester** | ❌ **not delivered** |
+
+The approval itself still succeeds — the send is best-effort inside a `try` — so the
+tester's org and Cognito group are set correctly, they just never hear about it. Until
+this session the failure was also swallowed with no log at all; it now logs a warning.
+
+**Action:** request SES production access (~24h turnaround). **Start this first** — it is
+the only cutover item you cannot do on the day. Interim workaround: verify each tester's
+address individually as an SES identity, or tell them out-of-band once approved.
+
+### B-2. No single-role test users — RBAC cannot be validated
+
+`cody.carmichael` is a member of **all three groups** simultaneously. `require_roles`
+authorises on set intersection, so that account passes **every** role check and also
+counts as privileged for driver-scoped object guards.
+
+That means a UAT walk driven by this account **cannot detect a role-separation failure** —
+every per-role section of the checklist passes trivially, including the cases that are
+supposed to be denied. It would have masked exactly the class of bug R-1 was.
+
+Current membership:
+
+| Group | Members |
+|---|---|
+| Admin | `cody.carmichael`, `cody.t.carmichael` |
+| Dispatcher | `cody.carmichael` *(only)* |
+| Driver | `cody.carmichael` *(only)* |
+
+**Action:** create one **single-role** user per role — see §3.1. Do not run the UAT walk
+without them.
+
+### B-3. Demo data is thin and inconsistent
+
+22 orders in `org-pilot-1`, 5 in `org-smoke`. Status spread: 22 `Assigned`, 3 `EnRoute`,
+1 `Created`, **1 `Delivered`, 0 `Failed`**.
+
+- With one Delivered and no Failed order, the **history view and the G-2 failure-reason
+  feature are effectively undemonstrated** — those were built this cycle specifically to
+  make failed deliveries visible.
+- Two different field shapes coexist: 22 orders use `reference_id` / `pick_up_street` /
+  `delivery_street` (admin-UI shape), 5 use `reference_number` / `pick_up_address` /
+  `delivery` (webhook shape). Worth knowing before a tester reports it as a bug.
+
+**Action:** seed a realistic spread (§3.2), including at least two `Failed` orders with
+reasons and several `Delivered`.
+
+---
+
+## 3. Steps that need credentials — run these yourself
+
+These need secrets that live in GitHub Actions / your password manager. They are written
+out so they can be run without further research.
+
+### 3.1 Create single-role test users
+
+For each role, create the user, set a password, and add exactly **one** group. Substitute
+your own values; do not paste passwords into shared channels.
+
+```bash
+aws cognito-idp admin-create-user --user-pool-id us-east-1_vMav7IRF7 --username pilot.dispatcher --user-attributes Name=email,Value=<address> Name=email_verified,Value=true Name=custom:org_id,Value=org-pilot-1 --desired-delivery-mediums EMAIL
+```
+
+Then add the single group (repeat per user with `Admin` / `Dispatcher` / `Driver`):
+
+```bash
+aws cognito-idp admin-add-user-to-group --user-pool-id us-east-1_vMav7IRF7 --username pilot.dispatcher --group-name Dispatcher
+```
+
+**Verify the isolation is real before trusting the UAT run** — each user must be in exactly
+one group:
+
+```bash
+aws cognito-idp admin-list-groups-for-user --user-pool-id us-east-1_vMav7IRF7 --username pilot.dispatcher --query 'Groups[].GroupName'
+```
+
+> While SES is in sandbox (B-1), `--desired-delivery-mediums EMAIL` will not reach an
+> unverified address. Either verify the address first or set the password yourself with
+> `admin-set-user-password`.
+
+### 3.2 Seed demo data
+
+Uses the orders webhook, so it needs `ORDERS_WEBHOOK_TOKEN` (a GitHub secret — not stored
+in this repo or in any local `.env`):
+
+```bash
+python tools/pilot/seed_orders_webhook.py --endpoint "https://m50fjhgrn7.execute-api.us-east-1.amazonaws.com/dev/backend/webhooks/orders" --token "<ORDERS_WEBHOOK_TOKEN>" --org-id "org-pilot-1" --count 25
+```
+
+Re-sending the same external ids should upsert, not duplicate — worth confirming, since
+it is the ingest property a pilot is most likely to stress.
+
+Then drive a few orders to `Delivered` and at least two to `Failed` **with reasons**, so
+the history view and failure-reason feature have something to show.
+
+### 3.3 Generate the tester handover pack
+
+```bash
+pwsh tools/pilot/export-pilot-summary.ps1 -StackName "discra-api-dev" -Region "us-east-1"
+```
+
+The dead `HealthUrl` / `VersionUrl` entries were removed from this pack (O-1); it now emits
+`BackendHealthUrl`, `BackendVersionUrl`, the UI URLs, the webhook URL, and the ops
+dashboard.
+
+---
+
+## 4. Cutover-day verification
+
+Run after the blockers are cleared, in this order.
+
+1. **Deploy is current** — `/backend/version` equals the `main` tip.
+2. **Dev-auth stays shut** — must be `404`:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}\n" -X POST https://m50fjhgrn7.execute-api.us-east-1.amazonaws.com/dev/backend/ui/dev-auth/login -H 'content-type: application/json' -d '{"role":"Admin"}'
+   ```
+3. **Smoke** — `pwsh tools/smoke/run-smoke.ps1 -ApiBaseUrl ... -AdminToken ...`
+4. **Role separation** — sign in as the single-role Driver and confirm the admin console
+   is refused. **If this passes trivially, check group membership before believing it.**
+5. **Alarms are quiet** — all 8 `OK`, no stale `ALARM` from cutover activity.
+6. **Walk `pilot-uat-checklist.md`** per role, with the single-role accounts.
+
+---
+
+## 5. Known limitations to tell testers
+
+- **First request after idle is slow (~7s).** The API Lambda is container-image based and
+  cold-starts at ~7.2–7.3 s; warm requests are 5–130 ms. Provisioned concurrency was
+  deferred as a cost decision. Tell testers, or they will file it as a bug.
+- **No offline queue in the mobile app** — offline writes error rather than queueing.
+- **No per-IP rate limiting** — only aggregate stage throttling (100 req/s). WAF deferred.
+- Route optimisation quality depends on Amazon Location / geocoding data.
+- Webhook ingest requires the shared token (plus HMAC headers when enabled).
+- Gmail ingest tokens expire after 7 days and need reconnecting.

--- a/docs/runbook-pilot-feedback.md
+++ b/docs/runbook-pilot-feedback.md
@@ -1,0 +1,120 @@
+# Pilot Feedback & Triage
+
+> Step 6.3. How feedback gets in, where it lands, and the cadence for acting on it.
+> Companion to [`runbook-pilot-cutover.md`](runbook-pilot-cutover.md) (getting the pilot
+> started) and [`pilot-uat-checklist.md`](pilot-uat-checklist.md) (what testers walk).
+
+---
+
+## 1. The two intake paths, and why there are two
+
+| Path | Who uses it | Where it lands |
+|---|---|---|
+| **In-app feedback** | Pilot testers — drivers, dispatchers, admins | `discra-feedback-*` table, visible in the admin console |
+| **GitHub issue templates** | You, and any technically-inclined tester | GitHub Issues, labelled `pilot` |
+
+In-app is the primary path. A driver mid-shift will not open GitHub, find a repo, create
+an account, and fill in reproduction steps — they will say nothing at all, and you will
+mistake silence for satisfaction. The in-app form asks for one thing (what happened) and
+captures the rest automatically.
+
+GitHub remains the triage queue: it has the labels, assignment, and history. In-app
+feedback that turns out to be a real defect gets **promoted** to an issue (§4).
+
+---
+
+## 2. In-app feedback
+
+**Submit:** any signed-in role, from the driver PWA topbar ("Feedback") or the admin
+console's Pilot Feedback panel.
+
+**Read:** Admin and Dispatcher only. **Drivers cannot list feedback** — a driver reading
+every colleague's complaints is a privacy problem, not a feature. This is enforced
+server-side and locked by the RBAC matrix, not just hidden in the UI.
+
+**Captured automatically**, so the tester doesn't have to describe their context:
+category, surface (`driver-pwa` / `admin-console`), page path, app version, user agent,
+submitter id + email + roles, and timestamp.
+
+**Tenant-scoped:** `org_id` comes from the verified JWT, never the request body, so
+feedback cannot be filed into another tenant.
+
+**Bounds:** message ≤ 4000 chars, context fields ≤ 400, list ≤ 200 rows.
+
+**Retention:** the table has PITR but **no TTL** — feedback is kept until deleted by hand.
+Free-text feedback can contain personal data (a tester describing a customer interaction),
+so it is in scope for a DSAR. Purge it when the pilot ends.
+
+---
+
+## 3. Severity
+
+Use the same rubric as the ledger, so pilot findings and internal findings are comparable.
+
+| Label | Meaning | Response |
+|---|---|---|
+| `P0-blocking` | Testing cannot continue; data loss; auth bypass | Same day. Stop feature work. |
+| `P1-high` | Core flow broken, workaround exists | Within the sprint |
+| `P2-medium` | Degraded or confusing, flow completes | Batch into the next cycle |
+| `P3-low` | Polish, wording, nice-to-have | Backlog |
+
+A tester's own severity is **input, not verdict.** Testers systematically over-rate what
+blocks them personally and under-rate silent data problems, which are the ones that
+actually matter. Re-rate on triage.
+
+---
+
+## 4. Cadence
+
+**Daily, while the pilot is live (~10 min).** Open the admin console's Pilot Feedback
+panel and the `label:pilot` issue list. For each new item: reproduce or discard, assign a
+severity label, and either fix, file, or reply. Promote anything that is a real defect
+from in-app feedback into a GitHub issue using the bug template — in-app feedback is an
+inbox, not a tracker.
+
+**Weekly (~30 min).** Re-rate everything still open, close what is fixed or won't-fix
+(saying which, in a sentence — an unexplained close teaches testers not to bother), and
+check for patterns. Three testers reporting the same confusion is a design defect, not
+three P3s.
+
+**At pilot end.** Fold anything unresolved into `docs/ALPHA.md` §3 with a real severity,
+then purge the feedback table (§2 retention).
+
+**The rule that makes this work:** every submission gets a human response within one
+working day, even if that response is "seen, it's a P3, not this week." Silence is the
+fastest way to stop receiving feedback — and a pilot that stops reporting looks identical
+to a pilot with no problems.
+
+---
+
+## 5. GitHub setup
+
+Labels used by triage — all created 2026-07-26, because the templates referenced `pilot`
+and `uat` while **neither label existed**, so pilot issues were being filed unlabelled and
+any `label:pilot` filter returned nothing:
+
+`pilot` · `uat` · `P0-blocking` · `P1-high` · `P2-medium` · `P3-low`
+
+Templates: `.github/ISSUE_TEMPLATE/pilot-bug-report.yml` (auto-labels `bug`, `pilot`) and
+`pilot-uat-result.yml` (auto-labels `pilot`, `uat`).
+
+> The severity dropdown in the bug template is a **form field**, not a label. Apply the
+> matching `P*` label on triage or severity stays unfilterable.
+
+Useful filters:
+
+```bash
+gh issue list --label pilot --state open
+```
+
+---
+
+## 6. Known gaps
+
+- **No notification on new in-app feedback.** It is pull-only — someone must open the
+  panel. Wiring it to the ops SNS topic would fix that; deferred as scope.
+- **No status field on in-app feedback.** There is no "triaged / resolved" marker, which
+  is deliberate: the tracker is GitHub, and duplicating workflow state in two systems
+  guarantees they disagree. Promote real defects to issues.
+- **No in-app feedback in the Expo mobile app** — web PWA and admin console only. Mobile
+  testers should use the driver PWA or report out-of-band.

--- a/template.yaml
+++ b/template.yaml
@@ -431,6 +431,36 @@ Resources:
         - Key: Env
           Value: dev
 
+  # 6.3: in-app pilot feedback. Persistent business data (not TTL'd), so it gets
+  # PITR like the other 9 — losing tester feedback mid-pilot would be losing the
+  # whole point of running one.
+  FeedbackTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub "discra-feedback-${AWS::StackName}"
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      AttributeDefinitions:
+        - AttributeName: org_id
+          AttributeType: S
+        - AttributeName: feedback_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: org_id
+          KeyType: HASH
+        # feedback_id is timestamp-prefixed, so a reverse Query on the range key
+        # returns newest-first without a secondary index.
+        - AttributeName: feedback_id
+          KeyType: RANGE
+      Tags:
+        - Key: App
+          Value: Discra
+        - Key: Env
+          Value: dev
+
   PushSubscriptionsTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -765,6 +795,7 @@ Resources:
           ORDERS_WEBHOOK_MAX_SKEW_SECONDS: !Ref OrdersWebhookMaxSkewSeconds
           AUDIT_LOGS_TABLE: !Ref AuditLogsTable
           PUSH_SUBSCRIPTIONS_TABLE: !Ref PushSubscriptionsTable
+          FEEDBACK_TABLE: !Ref FeedbackTable
           VAPID_PUBLIC_KEY: !Ref VapidPublicKey
           VAPID_PRIVATE_KEY_PARAM: /discra/vapid-private-key
           ANTHROPIC_API_KEY: !Ref AnthropicApiKey
@@ -820,6 +851,7 @@ Resources:
               - !GetAtt SeatInvitationsTable.Arn
               - !GetAtt AuditLogsTable.Arn
               - !GetAtt PushSubscriptionsTable.Arn
+              - !GetAtt FeedbackTable.Arn
               - !GetAtt OnboardingRegistrationsTable.Arn
               - !Sub "${OnboardingRegistrationsTable.Arn}/index/*"
               - !GetAtt EmailConfigTable.Arn
@@ -1543,6 +1575,10 @@ Outputs:
   DriverLocationsTableName:
     Description: DynamoDB table for latest driver GPS locations
     Value: !Ref DriverLocationsTable
+
+  FeedbackTableName:
+    Description: DynamoDB table for in-app pilot feedback (6.3)
+    Value: !Ref FeedbackTable
 
   PushSubscriptionsTableName:
     Description: DynamoDB table for Web Push notification subscriptions

--- a/template.yaml
+++ b/template.yaml
@@ -1473,23 +1473,10 @@ Outputs:
     Description: Base URL for the HTTP API (no stage suffix)
     Value: !GetAtt DiscraApi.ApiEndpoint
 
-  HealthUrl:
-    Description: Full URL for GET /health
-    Value: !Sub
-      - "${Endpoint}/dev/health"
-      - { Endpoint: !GetAtt DiscraApi.ApiEndpoint }
-
-  VersionUrl:
-    Description: Full URL for GET /version
-    Value: !Sub
-      - "${Endpoint}/dev/version"
-      - { Endpoint: !GetAtt DiscraApi.ApiEndpoint }
-
-  AdminPingUrl:
-    Description: Full URL for GET /admin/ping
-    Value: !Sub
-      - "${Endpoint}/dev/admin/ping"
-      - { Endpoint: !GetAtt DiscraApi.ApiEndpoint }
+  # O-1: HealthUrl / VersionUrl / AdminPingUrl were removed 2026-07-26. Their
+  # Lambdas (HealthFunction, VersionFunction, AdminPingFunction) no longer exist —
+  # all three URLs returned 404, and export-pilot-summary.ps1 was shipping two of
+  # them to pilot testers. Use BackendHealthUrl / BackendVersionUrl instead.
 
   BackendHealthUrl:
     Description: Full URL for GET /backend/health

--- a/tools/pilot/export-pilot-summary.ps1
+++ b/tools/pilot/export-pilot-summary.ps1
@@ -65,14 +65,16 @@ $lines += ""
 $lines += "## Key URLs"
 $lines += ""
 
+# O-1: HealthUrl/VersionUrl dropped 2026-07-26 — those routes 404 (their Lambdas
+# were removed) and this pack goes to pilot testers. Backend* are the live ones.
 $keyUrls = @(
-    "HealthUrl",
-    "VersionUrl",
     "BackendHealthUrl",
     "BackendVersionUrl",
     "AdminUiUrl",
     "DriverUiUrl",
-    "OrdersWebhookUrl"
+    "RegisterUiUrl",
+    "OrdersWebhookUrl",
+    "OpsDashboardUrl"
 )
 
 foreach ($key in $keyUrls) {


### PR DESCRIPTION
Step 6.2 pilot cutover prep, plus the restore drill owed from 6.1.

## Restore drill — executed, PASSED

Ran §2a of the ops runbook against the live orders table: PITR restore to a throwaway table, verify, delete. **~4–5 min** wall clock for 27 items / 14 KB — mostly fixed overhead, so plan minutes and expect longer at real volume.

**Fidelity verified by full scan and attribute-level comparison**, not by a count: 27/27 items, matching key-set fingerprint, **zero items differing in content**.

The drill earned its keep by correcting things I would otherwise have shipped as assumptions:

| Claim | Measured |
|---|---|
| PITR not inherited | ✅ confirmed — source `ENABLED` → restored `DISABLED` |
| Tags not inherited | ✅ confirmed (0 tags) |
| SSE not inherited | ❌ **wrong — SSE *is* inherited.** Runbook corrected |
| TTL not inherited | ⚠️ **unproven** — the orders table has no TTL, so the drill couldn't test it. Now labelled unverified instead of claimed |

**The gotcha that justifies drilling at all:** a freshly restored table reports `ItemCount: 0` for ~6 hours. Verifying a restore by that metric would make a perfect restore look like total data loss. Anyone following an undrilled procedure at 3am would have hit this.

Source table and live API unaffected throughout; throwaway table deleted.

## O-1 — stale stack outputs removed

`HealthUrl` / `VersionUrl` / `AdminPingUrl` all return 404 (their Lambdas are gone), and `export-pilot-summary.ps1` was shipping two of them **straight into the tester handover pack**. The pack now emits the `Backend*` URLs, register, and the ops dashboard.

## Onboarding notification logging

Both decision-email sites were `except Exception: pass` — no log at all. That made an entire class of delivery failure invisible, notably SES sandbox mode (below). Now logs a warning with the registration id — **no address**, per the S-5 PII rule. The send stays best-effort: an approval must not roll back because an email bounced.

## `docs/runbook-pilot-cutover.md` — verified state + three blockers

I could not complete the credential-bearing parts of 6.2: the secrets live in GitHub Actions, and minting user credentials isn't mine to do. Rather than half-do them, the runbook documents verified state and gives exact runnable commands for those steps.

**B-1 — SES is in sandbox.** Approver mail works; **the approve/reject email to an external tester is not delivered** (sandbox rejects unverified recipients). The approval still succeeds, so it's a notification gap, not data loss. Production access is a **~24h support ticket** — the only cutover item that cannot be done on the day. Start it first.

**B-2 — No single-role test users.** `cody.carmichael` is in all three groups, and `require_roles` authorises on **set intersection** — so that account passes every role check and counts as privileged for driver-scoped object guards. **A UAT walk driven by it cannot detect a role-separation failure.** It would have masked exactly the class of bug R-1 was. Only `Admin` has a second member; `Dispatcher` and `Driver` have none.

**B-3 — Demo data is thin.** Across 27 orders: **1 `Delivered`, 0 `Failed`**. The history view and the G-2 failure-reason feature — both built this cycle specifically to make failed deliveries visible — are effectively undemonstrated. Two field shapes also coexist (admin-UI vs webhook), worth knowing before a tester reports it as a bug.

## UAT checklist updated for reality

- Dev-auth `404` check added at prep **and** at sign-off
- Verify single-group membership **before trusting any role result**
- `/backend/health` (bare `/health` is gone)
- The **~7 s cold start** called out as expected, so testers don't file it as a defect
- Explicit role-separation exit criteria
- Sign-in is Hosted-UI only — no dev/no-password path any more

## Verification

Template parses (25 outputs; alarms/PITR/SSE intact) · backend suite **412 passed** · drill evidence in the ops runbook drill log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)